### PR TITLE
Fix "Invalid free" on linux

### DIFF
--- a/src/app/linux_glyph.c
+++ b/src/app/linux_glyph.c
@@ -25,6 +25,7 @@ char* findFontPath(const char* family) {
         FcPatternDestroy(match);
     }
     FcPatternDestroy(pat);
+    FcConfigDestroy(config);
     return path;
 }
 
@@ -108,6 +109,7 @@ static char* findFontPathAny(const char* family) {
         FcPatternDestroy(match);
     }
     FcPatternDestroy(pat);
+    FcConfigDestroy(config);
     return path;
 }
 

--- a/src/app/ui2.zig
+++ b/src/app/ui2.zig
@@ -332,7 +332,7 @@ pub fn run(
     else
         null;
     defer if (program_argv) |pa| {
-        for (pa) |s| allocator.free(@as([]const u8, s));
+        for (pa) |s| allocator.free(s);
         allocator.free(pa);
     };
 

--- a/src/theme/registry.zig
+++ b/src/theme/registry.zig
@@ -32,6 +32,9 @@ pub const ThemeRegistry = struct {
             result.value_ptr.* = theme;
         } else {
             // Own a copy of the key — the source slice may be temporary.
+            // If dupe fails, remove the stale entry so deinit() doesn't
+            // try to free the non-owned original slice.
+            errdefer self.themes.removeByPtr(result.key_ptr);
             result.key_ptr.* = try self.allocator.dupe(u8, name);
             result.value_ptr.* = theme;
         }


### PR DESCRIPTION
Addresses the following issue: https://github.com/semos-labs/attyx/issues/2

- Fix "Invalid free" crash on Linux caused by `dupeZ`/`free` size mismatch in program argv cleanup — freeing `[:0]const u8` as `[]const u8` drops the sentinel byte, causing GPA bucket mismatch when string length is a power of 2
- Fix fontconfig resource leak in `findFontPath()` and `findFontPathAny()` — missing `FcConfigDestroy()` leaked an `FcConfig*` on every call
- Fix latent bug in `ThemeRegistry.register()` — add `errdefer` to remove stale hash map entry if key duplication fails, preventing `deinit()` from freeing a non-owned slice
