### PR TITLE
Fix text copying

### DIFF
--- a/src/app/bridge.h
+++ b/src/app/bridge.h
@@ -83,6 +83,10 @@ extern volatile int g_sel_start_row, g_sel_start_col;
 extern volatile int g_sel_end_row, g_sel_end_col;
 extern volatile int g_sel_active;
 
+// Per-row soft-wrap flag (viewport-relative, updated inside seqlock).
+// 1 = row was soft-wrapped (auto-wrap at right edge), 0 = hard newline.
+extern volatile uint8_t g_row_wrapped[ATTYX_MAX_ROWS];
+
 // Kitty keyboard protocol flags (written by PTY thread, read by main thread).
 extern volatile int g_kitty_kbd_flags;
 

--- a/src/app/linux_input.c
+++ b/src/app/linux_input.c
@@ -794,7 +794,7 @@ void doCopy(void) {
                 }
             }
         }
-        if (row < er) buf[pos++] = '\n';
+        if (row < er && !g_row_wrapped[row]) buf[pos++] = '\n';
     }
 
     buf[pos] = '\0';

--- a/src/app/linux_internal.h
+++ b/src/app/linux_internal.h
@@ -30,6 +30,7 @@ extern AttyxCell* g_cells;
 extern int g_cols;
 extern int g_rows;
 extern volatile uint64_t g_cell_gen;
+extern volatile uint8_t g_row_wrapped[ATTYX_MAX_ROWS];
 extern volatile int g_cursor_row;
 extern volatile int g_cursor_col;
 extern volatile int g_should_quit;

--- a/src/app/macos_input_ime.m
+++ b/src/app/macos_input_ime.m
@@ -202,7 +202,7 @@
             }
         }
 
-        if (row < er) [result appendString:@"\n"];
+        if (row < er && !g_row_wrapped[row]) [result appendString:@"\n"];
     }
 
     if (result.length > 0) {

--- a/src/app/macos_internal.h
+++ b/src/app/macos_internal.h
@@ -16,6 +16,7 @@ extern AttyxCell* g_cells;
 extern int g_cols;
 extern int g_rows;
 extern volatile uint64_t g_cell_gen;
+extern volatile uint8_t g_row_wrapped[ATTYX_MAX_ROWS];
 extern volatile int g_cursor_row;
 extern volatile int g_cursor_col;
 extern volatile int g_should_quit;

--- a/src/app/platform_linux.c
+++ b/src/app/platform_linux.c
@@ -33,6 +33,8 @@ volatile int g_sel_start_row = -1, g_sel_start_col = -1;
 volatile int g_sel_end_row = -1, g_sel_end_col = -1;
 volatile int g_sel_active = 0;
 
+volatile uint8_t g_row_wrapped[ATTYX_MAX_ROWS] = {0};
+
 volatile int g_cursor_shape   = 0;
 volatile int g_cursor_visible = 1;
 volatile int g_cursor_trail   = 0;

--- a/src/app/platform_macos.m
+++ b/src/app/platform_macos.m
@@ -39,6 +39,8 @@ volatile int g_sel_start_row = -1, g_sel_start_col = -1;
 volatile int g_sel_end_row = -1, g_sel_end_col = -1;
 volatile int g_sel_active = 0;
 
+volatile uint8_t g_row_wrapped[ATTYX_MAX_ROWS] = {0};
+
 volatile int g_cursor_shape   = 0;
 volatile int g_cursor_visible = 1;
 volatile int g_cursor_trail   = 0;

--- a/src/app/ui2.zig
+++ b/src/app/ui2.zig
@@ -1304,11 +1304,15 @@ fn fillCells(cells: []c.AttyxCell, eng: *Engine, _: usize, theme: *const Theme) 
     const cols = eng.state.grid.cols;
     const rows = eng.state.grid.rows;
     const sb = &eng.state.scrollback;
+    const wrapped: *volatile [c.ATTYX_MAX_ROWS]u8 = @ptrCast(&c.g_row_wrapped);
 
     if (vp == 0) {
         const total = rows * cols;
         for (0..total) |i| {
             cells[i] = cellToAttyxCell(eng.state.grid.cells[i], theme);
+        }
+        for (0..rows) |row| {
+            wrapped[row] = @intFromBool(eng.state.grid.row_wrapped[row]);
         }
         return;
     }
@@ -1321,11 +1325,13 @@ fn fillCells(cells: []c.AttyxCell, eng: *Engine, _: usize, theme: *const Theme) 
             for (0..cols) |col| {
                 cells[row * cols + col] = cellToAttyxCell(sb_cells[col], theme);
             }
+            wrapped[row] = @intFromBool(sb.getLineWrapped(sb_line_idx));
         } else {
             const grid_row = row - effective_vp;
             for (0..cols) |col| {
                 cells[row * cols + col] = cellToAttyxCell(eng.state.grid.cells[grid_row * cols + col], theme);
             }
+            wrapped[row] = @intFromBool(eng.state.grid.row_wrapped[grid_row]);
         }
     }
 }

--- a/src/headless/tests/scrollback.zig
+++ b/src/headless/tests/scrollback.zig
@@ -13,7 +13,7 @@ test "scrollback: push and get single line" {
         .{ .char = 'B' },
         .{ .char = 'C' },
     };
-    sb.pushLine(&line);
+    sb.pushLine(&line, false);
 
     try std.testing.expectEqual(@as(usize, 1), sb.count);
     const got = sb.getLine(0);
@@ -32,7 +32,7 @@ test "scrollback: ring wrap-around" {
     for (0..5) |i| {
         line[0] = .{ .char = @intCast('a' + i) };
         line[1] = .{ .char = @intCast('A' + i) };
-        sb.pushLine(&line);
+        sb.pushLine(&line, false);
     }
 
     try std.testing.expectEqual(@as(usize, 3), sb.count);
@@ -48,8 +48,8 @@ test "scrollback: clear resets count" {
     defer sb.deinit();
 
     var line = [2]Cell{ .{ .char = 'X' }, .{ .char = 'Y' } };
-    sb.pushLine(&line);
-    sb.pushLine(&line);
+    sb.pushLine(&line, false);
+    sb.pushLine(&line, false);
     try std.testing.expectEqual(@as(usize, 2), sb.count);
 
     sb.clear();
@@ -222,7 +222,7 @@ test "scrollback: removeRecent drops most recent lines" {
     for (0..5) |i| {
         line[0] = .{ .char = @intCast('A' + i) };
         line[1] = .{ .char = ' ' };
-        sb.pushLine(&line);
+        sb.pushLine(&line, false);
     }
     try std.testing.expectEqual(@as(usize, 5), sb.count);
 

--- a/src/term/grid.zig
+++ b/src/term/grid.zig
@@ -204,7 +204,7 @@ pub const Grid = struct {
     /// of the call — the callee must copy if it needs to keep the data).
     pub const DropHandler = struct {
         ctx: *anyopaque,
-        save: *const fn (ctx: *anyopaque, row_cells: []const Cell) void,
+        save: *const fn (ctx: *anyopaque, row_cells: []const Cell, wrapped: bool) void,
     };
 
     /// Resize with reflow: re-wraps logical lines at the new column width.
@@ -303,7 +303,7 @@ pub const Grid = struct {
                                     sr[c] = self.cells[old_r * self.cols + old_c];
                                 }
                             }
-                            handler.save(handler.ctx, sr);
+                            handler.save(handler.ctx, sr, pr < rows_needed - 1);
                         }
                     }
                     continue;

--- a/src/term/scrollback.zig
+++ b/src/term/scrollback.zig
@@ -11,6 +11,7 @@ pub const Cell = grid_mod.Cell;
 /// are stored (up to `max_lines`).
 pub const Scrollback = struct {
     cells: []Cell,
+    line_wrapped: []bool,
     cols: usize,
     max_lines: usize,
     head: usize = 0,
@@ -23,8 +24,11 @@ pub const Scrollback = struct {
         std.debug.assert(max_lines > 0 and cols > 0);
         const cells = try allocator.alloc(Cell, max_lines * cols);
         @memset(cells, Cell{});
+        const line_wrapped = try allocator.alloc(bool, max_lines);
+        @memset(line_wrapped, false);
         return .{
             .cells = cells,
+            .line_wrapped = line_wrapped,
             .cols = cols,
             .max_lines = max_lines,
             .allocator = allocator,
@@ -33,17 +37,20 @@ pub const Scrollback = struct {
 
     pub fn deinit(self: *Scrollback) void {
         self.allocator.free(self.cells);
+        self.allocator.free(self.line_wrapped);
     }
 
     /// Append a row of cells to the ring.  Accepts any line length:
     /// truncates if longer than `self.cols`, pads with blank cells if shorter.
-    pub fn pushLine(self: *Scrollback, line: []const Cell) void {
+    /// `wrapped` indicates whether this row was soft-wrapped (auto-wrap at right edge).
+    pub fn pushLine(self: *Scrollback, line: []const Cell, wrapped: bool) void {
         const offset = self.head * self.cols;
         const copy_len = @min(line.len, self.cols);
         @memcpy(self.cells[offset .. offset + copy_len], line[0..copy_len]);
         if (copy_len < self.cols) {
             @memset(self.cells[offset + copy_len .. offset + self.cols], Cell{});
         }
+        self.line_wrapped[self.head] = wrapped;
         self.head = (self.head + 1) % self.max_lines;
         if (self.count < self.max_lines) self.count += 1;
     }
@@ -58,6 +65,16 @@ pub const Scrollback = struct {
             (self.head + index) % self.max_lines;
         const offset = ring_pos * self.cols;
         return self.cells[offset .. offset + self.cols];
+    }
+
+    /// Returns whether the scrollback line at `index` was soft-wrapped.
+    pub fn getLineWrapped(self: *const Scrollback, index: usize) bool {
+        std.debug.assert(index < self.count);
+        const ring_pos = if (self.count < self.max_lines)
+            index
+        else
+            (self.head + index) % self.max_lines;
+        return self.line_wrapped[ring_pos];
     }
 
     /// Drop the N most recently pushed lines from the ring.
@@ -87,6 +104,8 @@ pub const Scrollback = struct {
 
         const new_cells = try self.allocator.alloc(Cell, new_max_lines * self.cols);
         errdefer self.allocator.free(new_cells);
+        const new_wrapped = try self.allocator.alloc(bool, new_max_lines);
+        errdefer self.allocator.free(new_wrapped);
 
         const lines_to_copy = @min(self.count, new_max_lines);
         const oldest = if (self.count < self.max_lines) 0 else self.head;
@@ -96,15 +115,19 @@ pub const Scrollback = struct {
                 new_cells[i * self.cols .. (i + 1) * self.cols],
                 self.cells[src_idx * self.cols .. src_idx * self.cols + self.cols],
             );
+            new_wrapped[i] = self.line_wrapped[src_idx];
         }
         if (lines_to_copy < new_max_lines) {
             @memset(new_cells[lines_to_copy * self.cols ..], Cell{});
+            @memset(new_wrapped[lines_to_copy..], false);
         }
 
         self.allocator.free(self.cells);
-        self.cells     = new_cells;
-        self.max_lines = new_max_lines;
-        self.count     = lines_to_copy;
-        self.head      = lines_to_copy % new_max_lines;
+        self.allocator.free(self.line_wrapped);
+        self.cells        = new_cells;
+        self.line_wrapped = new_wrapped;
+        self.max_lines    = new_max_lines;
+        self.count        = lines_to_copy;
+        self.head         = lines_to_copy % new_max_lines;
     }
 };

--- a/src/term/search.zig
+++ b/src/term/search.zig
@@ -326,7 +326,7 @@ test "search: scrollback matches" {
     @memset(&line, Cell{});
     const err_text = "error";
     for (err_text, 0..) |ch, i| line[i] = .{ .char = ch };
-    sb.pushLine(&line);
+    sb.pushLine(&line, false);
 
     s.update("error", &sb, &g);
     try testing.expectEqual(@as(usize, 1), s.matchCount());

--- a/src/term/state.zig
+++ b/src/term/state.zig
@@ -334,7 +334,7 @@ pub const TerminalState = struct {
         if (self.alt_active) return;
         if (self.scroll_top != 0) return;
         const row_cells = self.grid.cells[0..self.grid.cols];
-        self.scrollback.pushLine(row_cells);
+        self.scrollback.pushLine(row_cells, self.grid.row_wrapped[0]);
         if (self.viewport_offset > 0) self.viewport_offset += 1;
     }
 

--- a/src/term/state_erase.zig
+++ b/src/term/state_erase.zig
@@ -48,7 +48,7 @@ pub fn eraseInDisplay(self: *TerminalState, mode: actions_mod.EraseMode) void {
                 if (has_content) {
                     for (0..last_content_row + 1) |r| {
                         const start = r * cols;
-                        self.scrollback.pushLine(self.grid.cells[start .. start + cols]);
+                        self.scrollback.pushLine(self.grid.cells[start .. start + cols], self.grid.row_wrapped[r]);
                     }
                 }
             }

--- a/src/term/state_resize.zig
+++ b/src/term/state_resize.zig
@@ -5,9 +5,9 @@ const scrollback_mod = @import("scrollback.zig");
 const TerminalState = @import("state.zig").TerminalState;
 
 /// Grid.DropHandler callback: pushes a dropped reflow row into scrollback.
-fn onDropRow(ctx_raw: *anyopaque, row_cells: []const grid_mod.Cell) void {
+fn onDropRow(ctx_raw: *anyopaque, row_cells: []const grid_mod.Cell, wrapped: bool) void {
     const self: *TerminalState = @ptrCast(@alignCast(ctx_raw));
-    self.scrollback.pushLine(row_cells);
+    self.scrollback.pushLine(row_cells, wrapped);
 }
 
 fn clampState(self: *TerminalState, rows: usize, cols: usize) void {
@@ -104,7 +104,7 @@ pub fn resize(self: *TerminalState, new_rows: usize, new_cols: usize) !void {
         );
         for (0..self.scrollback.count) |i| {
             const old_line = self.scrollback.getLine(i);
-            new_sb.pushLine(old_line);
+            new_sb.pushLine(old_line, self.scrollback.getLineWrapped(i));
         }
         self.scrollback.deinit();
         self.scrollback = new_sb;


### PR DESCRIPTION
This pull request introduces tracking of soft-wrapped lines (lines that wrapped at the right edge rather than ending with a hard newline) throughout the terminal grid, scrollback, and clipboard/copy logic. This enables more accurate reproduction of the original line structure when copying text and when managing scrollback, especially after resizing or erasing content.

**Soft-wrap tracking and propagation:**

* Added a per-row soft-wrap flag array `g_row_wrapped` to track whether each visible row is soft-wrapped or ends with a hard newline, with definitions and initializations in both Linux and macOS platform code (`bridge.h`, `linux_internal.h`, `macos_internal.h`, `platform_linux.c`, `platform_macos.m`). [[1]](diffhunk://#diff-2222ab60b36a294228020986c8911890f8430c4c8221836304faebfb439d9ae3R86-R89) [[2]](diffhunk://#diff-4d38e31c8eefc3f87b662c267b38697240bc2553b3e2294e7964ae4d5937deeeR33) [[3]](diffhunk://#diff-c06cf8cf54d95bbfb8014c197d317cecd52694f54314fdc0e44f50177dd182b3R19) [[4]](diffhunk://#diff-e8bb18b2b2fd7472bea1b15f8096a19b1e4698473a99d8fad482776aadd90309R36-R37) [[5]](diffhunk://#diff-236b43c5dd0e41597db97d5576cba1221e4afa8a0393eda7c83e5c8e4a646525R42-R43)
* Updated the Zig UI layer to propagate the `row_wrapped` state from the grid and scrollback into the C-visible `g_row_wrapped` array, ensuring the UI and clipboard logic have access to accurate wrap information (`ui2.zig`). [[1]](diffhunk://#diff-a337a285a013648b4036a73ce21703f6242c8964cd4fac9772578086b3c2b8a3R1307-R1316) [[2]](diffhunk://#diff-a337a285a013648b4036a73ce21703f6242c8964cd4fac9772578086b3c2b8a3R1328-R1334)

**Clipboard/copy logic improvements:**

* Modified both Linux and macOS copy routines to only insert newlines between rows if the row was not soft-wrapped, resulting in more natural copied text that matches what the user sees (`linux_input.c`, `macos_input_ime.m`). [[1]](diffhunk://#diff-00c0fd68c8e642c93f5037c1af5bc043c3e11f9b263a8d21fa8a40d31585811dL797-R797) [[2]](diffhunk://#diff-84b1d71b3595c0eab33676d522583dba6ffd97868e0fe360f92856d70f7c4051L205-R205)

**Scrollback and grid enhancements:**

* Extended the scrollback ring buffer to store a `line_wrapped` array, tracking the wrap status for each line, and updated all push, resize, and accessors to handle this new state (`scrollback.zig`). [[1]](diffhunk://#diff-dcf8aed5ee8e754c0284737148da8206df0b401e4f2921e48b57fe282bd17facR14) [[2]](diffhunk://#diff-dcf8aed5ee8e754c0284737148da8206df0b401e4f2921e48b57fe282bd17facR27-R31) [[3]](diffhunk://#diff-dcf8aed5ee8e754c0284737148da8206df0b401e4f2921e48b57fe282bd17facR40-R53) [[4]](diffhunk://#diff-dcf8aed5ee8e754c0284737148da8206df0b401e4f2921e48b57fe282bd17facR70-R79) [[5]](diffhunk://#diff-dcf8aed5ee8e754c0284737148da8206df0b401e4f2921e48b57fe282bd17facR107-R108) [[6]](diffhunk://#diff-dcf8aed5ee8e754c0284737148da8206df0b401e4f2921e48b57fe282bd17facR118-R128)
* Updated the grid and scrollback interfaces, as well as all related call sites and tests, to pass and propagate the `wrapped` flag, ensuring that reflow, erasing, and scrollback restoration preserve line wrap status (`grid.zig`, `state.zig`, `state_erase.zig`, `state_resize.zig`, `scrollback.zig`, `search.zig`, and tests). [[1]](diffhunk://#diff-67e4955105a29dfbce2fff46da75fda33f1e42de6002a3931b369f6a9a134a06L207-R207) [[2]](diffhunk://#diff-67e4955105a29dfbce2fff46da75fda33f1e42de6002a3931b369f6a9a134a06L306-R306) [[3]](diffhunk://#diff-7e397821ed1ef38a9981a3ab0a1009a03f96d16461d68126ff2692f8af85695dL337-R337) [[4]](diffhunk://#diff-970c5a0f3ba379fa267ad5b4f8486f7a57297e804b8125ac4bb47e2b6b1961f1L51-R51) [[5]](diffhunk://#diff-8daa6a91c0b64a9bfc5fc76b5d921a316f4e8f135fd832fd473445f30319dc91L8-R10) [[6]](diffhunk://#diff-8daa6a91c0b64a9bfc5fc76b5d921a316f4e8f135fd832fd473445f30319dc91L107-R107) [[7]](diffhunk://#diff-faeefb40dc2d79cc7ce290b5778d3f42a0356c2e6e68e91ba9ae058f719a6ec1L16-R16) [[8]](diffhunk://#diff-faeefb40dc2d79cc7ce290b5778d3f42a0356c2e6e68e91ba9ae058f719a6ec1L35-R35) [[9]](diffhunk://#diff-faeefb40dc2d79cc7ce290b5778d3f42a0356c2e6e68e91ba9ae058f719a6ec1L51-R52) [[10]](diffhunk://#diff-faeefb40dc2d79cc7ce290b5778d3f42a0356c2e6e68e91ba9ae058f719a6ec1L225-R225) [[11]](diffhunk://#diff-8666b61352a8fe4cc2f58f68d8ef7fc4ca579ee9108d1c736f4d3ee82aa02f6bL329-R329)

These changes ensure that soft-wrapped lines are consistently tracked and handled across all terminal features, improving the fidelity of text selection, copy-paste, and scrollback behaviors.