### PR TITLE
Merge standalone CLI into main binary

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -87,34 +87,12 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("themes/themes.zig"),
     });
 
-    // -----------------------------------------------------------------------
-    // CLI binary — built here so we can embed it in the main executable below
-    // -----------------------------------------------------------------------
-    const ai_auth_mod = b.createModule(.{
-        .root_source_file = b.path("src/overlay/ai_auth.zig"),
+    const cli_commands_mod = b.createModule(.{
+        .root_source_file = b.path("src/cli/main.zig"),
+        .imports = &.{
+            .{ .name = "attyx", .module = mod },
+        },
     });
-
-    const cli = b.addExecutable(.{
-        .name = "attyx-cli",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/cli/main.zig"),
-            .target = target,
-            .optimize = .ReleaseSmall,
-            .imports = &.{
-                .{ .name = "build_options", .module = build_options.createModule() },
-                .{ .name = "ai_auth", .module = ai_auth_mod },
-            },
-        }),
-    });
-    cli.root_module.linkSystemLibrary("c", .{});
-
-    // Embed the compiled CLI binary so the main app can extract it at startup
-    const cli_embed_wf = b.addWriteFiles();
-    _ = cli_embed_wf.addCopyFile(cli.getEmittedBin(), "attyx-cli-bin");
-    const cli_embed_src = cli_embed_wf.add("cli_embed.zig",
-        \\pub const data: []const u8 = @embedFile("attyx-cli-bin");
-    );
-    const cli_embed_mod = b.createModule(.{ .root_source_file = cli_embed_src });
 
     const exe = b.addExecutable(.{
         .name = "attyx",
@@ -127,7 +105,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "toml", .module = toml_mod },
                 .{ .name = "app_icon", .module = icon_mod },
                 .{ .name = "builtin_themes", .module = themes_mod },
-                .{ .name = "cli_binary", .module = cli_embed_mod },
+                .{ .name = "cli_commands", .module = cli_commands_mod },
             },
         }),
     });
@@ -198,20 +176,6 @@ pub fn build(b: *std.Build) void {
     // step). By default the install prefix is `zig-out/` but can be overridden
     // by passing `--prefix` or `-p`.
     b.installArtifact(exe);
-
-    b.installArtifact(cli);
-
-    // `zig build install-cli` — copies the CLI binary to ~/.attyx/bin/attyx
-    const install_cli_step = b.step("install-cli", "Install the attyx CLI to ~/.attyx/bin/attyx");
-    const copy_cli = b.addInstallFile(cli.getEmittedBin(), "../attyx-cli-tmp");
-    const install_cli_cmd = b.addSystemCommand(&.{
-        "/bin/sh", "-c",
-        "mkdir -p \"$HOME/.attyx/bin\" && cp \"$1\" \"$HOME/.attyx/bin/attyx\"",
-        "--",
-    });
-    install_cli_cmd.addFileArg(cli.getEmittedBin());
-    install_cli_cmd.step.dependOn(&copy_cli.step);
-    install_cli_step.dependOn(&install_cli_cmd.step);
 
     // This creates a top level step. Top level steps have a name and can be
     // invoked by name when running `zig build` (e.g. `zig build run`).

--- a/src/app/platform_macos.m
+++ b/src/app/platform_macos.m
@@ -130,6 +130,7 @@ void attyx_set_cursor(int row, int col) {
 }
 
 void attyx_request_quit(void) {
+    g_should_quit = 1;  // Signal PTY thread immediately to prevent use-after-close race
     dispatch_async(dispatch_get_main_queue(), ^{
         [NSApp terminate:nil];
     });

--- a/src/app/pty.zig
+++ b/src/app/pty.zig
@@ -27,6 +27,8 @@ extern "c" fn chdir(path: [*:0]const u8) c_int;
 extern "c" fn waitpid(pid: c_int, status: ?*c_int, options: c_int) c_int;
 extern "c" fn getuid() c_uint;
 extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
+extern "c" fn readlink(path: [*:0]const u8, buf: [*]u8, bufsiz: usize) isize;
+extern "c" fn _NSGetExecutablePath(buf: [*]u8, bufsize: *u32) c_int;
 
 pub const Pty = struct {
     master: posix.fd_t,
@@ -97,16 +99,13 @@ pub const Pty = struct {
             _ = setenv("TERM", "xterm-256color", 1);
             _ = setenv("TERM_PROGRAM", "attyx", 1);
             _ = setenv("ATTYX", "1", 1);
-            // Inject ~/.attyx/bin into PATH so the `attyx` CLI is available
-            // inside the terminal session.
-            if (getenv("HOME")) |home| {
-                const existing_path = getenv("PATH") orelse "/usr/bin:/bin";
-                var path_buf: [4096]u8 = undefined;
-                const written = std.fmt.bufPrintZ(&path_buf, "{s}/.attyx/bin:{s}", .{ home, existing_path }) catch null;
-                if (written) |new_path| {
-                    _ = setenv("PATH", new_path, 1);
-                }
-            }
+
+            // Shell integration: inject attyx binary dir into PATH via
+            // ZDOTDIR override. Setting PATH directly doesn't survive
+            // shell init scripts (.zshenv, nix, path_helper) that rebuild
+            // PATH from scratch. The ZDOTDIR approach runs our .zshenv
+            // first, which appends the binary dir before anything else.
+            setupShellIntegration();
 
             // Prevent main shell children from thinking they're inside tmux.
             // When Attyx is launched from a tmux session, TMUX is inherited
@@ -231,5 +230,142 @@ pub const Pty = struct {
         }
         // Killed by signal — treat as non-zero exit
         return 1;
+    }
+
+    /// Set up shell integration to inject the attyx binary dir into PATH.
+    ///
+    /// For zsh: override ZDOTDIR to point to our integration .zshenv which
+    /// appends the binary dir to PATH before chaining to the real .zshenv.
+    /// This survives shell init scripts that rebuild PATH from scratch.
+    ///
+    /// For other shells: fall back to direct PATH append (best-effort).
+    fn setupShellIntegration() void {
+        var exe_buf: [1024]u8 = undefined;
+        const exe_dir = getExeDir(&exe_buf) orelse return;
+
+        // Set __ATTYX_BIN_DIR for the integration script
+        var dir_buf: [1024]u8 = undefined;
+        const dir_z = std.fmt.bufPrintZ(&dir_buf, "{s}", .{exe_dir}) catch return;
+        _ = setenv("__ATTYX_BIN_DIR", dir_z, 1);
+
+        // Detect shell
+        const shell = std.mem.sliceTo(getenv("SHELL") orelse "/bin/sh", 0);
+        const is_zsh = std.mem.endsWith(u8, shell, "/zsh") or
+            std.mem.eql(u8, shell, "zsh");
+
+        if (is_zsh) {
+            // Write integration .zshenv to a known location
+            const home = std.mem.sliceTo(getenv("HOME") orelse return, 0);
+            var integ_dir_buf: [512]u8 = undefined;
+            const integ_dir = std.fmt.bufPrintZ(&integ_dir_buf,
+                "{s}/.config/attyx/shell-integration/zsh", .{home}) catch return;
+
+            // Ensure directory exists (ignore errors — may already exist)
+            mkdirp(integ_dir);
+
+            // Write the .zshenv integration script
+            var zshenv_buf: [600]u8 = undefined;
+            const zshenv_path = std.fmt.bufPrintZ(&zshenv_buf,
+                "{s}/.zshenv", .{integ_dir}) catch return;
+            writeIntegrationScript(zshenv_path);
+
+            // Save original ZDOTDIR so our script can restore it
+            const orig_zdotdir = getenv("ZDOTDIR");
+            if (orig_zdotdir) |zd| {
+                _ = setenv("__ATTYX_ORIGINAL_ZDOTDIR", zd, 1);
+            } else {
+                _ = setenv("__ATTYX_ORIGINAL_ZDOTDIR", "", 1);
+            }
+
+            // Point zsh to our integration directory
+            _ = setenv("ZDOTDIR", integ_dir, 1);
+        } else {
+            // Non-zsh: best-effort direct PATH append
+            appendExeDirToPath(exe_dir);
+        }
+    }
+
+    fn appendExeDirToPath(exe_dir: []const u8) void {
+        const existing = std.mem.sliceTo(getenv("PATH") orelse "/usr/bin:/bin", 0);
+        if (std.mem.indexOf(u8, existing, exe_dir) != null) return;
+        var path_buf: [4096]u8 = undefined;
+        const new_path = std.fmt.bufPrintZ(&path_buf, "{s}:{s}", .{
+            existing, exe_dir,
+        }) catch return;
+        _ = setenv("PATH", new_path, 1);
+    }
+
+    fn writeIntegrationScript(path: [*:0]const u8) void {
+        const content =
+            \\#!/bin/zsh
+            \\# Attyx shell integration
+            \\if [[ -n "$__ATTYX_ORIGINAL_ZDOTDIR" ]]; then
+            \\  ZDOTDIR="$__ATTYX_ORIGINAL_ZDOTDIR"
+            \\elif [[ -z "$__ATTYX_ORIGINAL_ZDOTDIR" ]]; then
+            \\  ZDOTDIR="$HOME"
+            \\fi
+            \\unset __ATTYX_ORIGINAL_ZDOTDIR
+            \\if [[ -n "$__ATTYX_BIN_DIR" ]] && [[ ":$PATH:" != *":$__ATTYX_BIN_DIR:"* ]]; then
+            \\  export PATH="$PATH:$__ATTYX_BIN_DIR"
+            \\fi
+            \\unset __ATTYX_BIN_DIR
+            \\[[ -f "$ZDOTDIR/.zshenv" ]] && source "$ZDOTDIR/.zshenv"
+            \\
+        ;
+        // Use raw C open/write since we're in a fork child
+        const fd = std.posix.openatZ(std.posix.AT.FDCWD, path, .{
+            .ACCMODE = .WRONLY,
+            .CREAT = true,
+            .TRUNC = true,
+        }, 0o644) catch return;
+        defer std.posix.close(fd);
+        _ = std.posix.write(fd, content) catch {};
+    }
+
+    /// Recursively create directories (like mkdir -p). Best-effort.
+    fn mkdirp(path_z: [*:0]const u8) void {
+        const path = std.mem.sliceTo(path_z, 0);
+        // Walk through the path, creating each component
+        var i: usize = 1; // skip leading /
+        while (i < path.len) : (i += 1) {
+            if (path[i] == '/') {
+                var component_buf: [512]u8 = undefined;
+                if (i >= component_buf.len) return;
+                @memcpy(component_buf[0..i], path[0..i]);
+                component_buf[i] = 0;
+                _ = std.posix.mkdiratZ(
+                    std.posix.AT.FDCWD,
+                    @ptrCast(&component_buf),
+                    0o755,
+                ) catch {};
+            }
+        }
+        // Create the final directory
+        _ = std.posix.mkdiratZ(std.posix.AT.FDCWD, path_z, 0o755) catch {};
+    }
+
+    fn getExeDir(buf: *[1024]u8) ?[]const u8 {
+        const exe_path = getExePath(buf) orelse return null;
+        var last_slash: usize = 0;
+        for (exe_path, 0..) |ch, i| {
+            if (ch == '/') last_slash = i;
+        }
+        if (last_slash == 0) return null;
+        return exe_path[0..last_slash];
+    }
+
+    fn getExePath(buf: *[1024]u8) ?[]const u8 {
+        if (comptime @import("builtin").os.tag == .macos) {
+            var size: u32 = buf.len;
+            if (_NSGetExecutablePath(buf, &size) == 0) {
+                return std.mem.sliceTo(@as([*:0]const u8, @ptrCast(buf)), 0);
+            }
+        } else {
+            const n = readlink("/proc/self/exe", buf, buf.len);
+            if (n > 0) {
+                return buf[0..@intCast(n)];
+            }
+        }
+        return null;
     }
 };

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1,70 +1,12 @@
 const std = @import("std");
-const build_options = @import("build_options");
-const ai_auth = @import("ai_auth");
+const ai_auth = @import("attyx").overlay_ai_auth;
 
-const base_url: []const u8 = if (std.mem.eql(u8, build_options.env, "production"))
-    "https://app.semos.sh"
-else
-    "http://localhost:8085";
-
-const usage =
-    \\Usage: attyx <command>
-    \\
-    \\Commands:
-    \\  login       Authenticate with Attyx AI services
-    \\  device      Show device and account info
-    \\  uninstall   Remove config, auth tokens, and desktop entry
-    \\
-    \\Options:
-    \\  --help, -h  Show this help message
-    \\
-;
-
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    var iter = std.process.args();
-    _ = iter.next(); // skip argv[0]
-
-    const subcommand = iter.next();
-
-    if (subcommand) |cmd| {
-        if (std.mem.eql(u8, cmd, "login")) {
-            doLogin(allocator) catch |err| {
-                var buf: [256]u8 = undefined;
-                const msg = std.fmt.bufPrint(&buf, "error: login failed: {s}\n", .{@errorName(err)}) catch "error: login failed\n";
-                std.fs.File.stderr().writeAll(msg) catch {};
-                std.process.exit(1);
-            };
-        } else if (std.mem.eql(u8, cmd, "device")) {
-            doDevice(allocator) catch |err| {
-                var buf: [256]u8 = undefined;
-                const msg = std.fmt.bufPrint(&buf, "error: {s}\n", .{@errorName(err)}) catch "error: failed to get device info\n";
-                std.fs.File.stderr().writeAll(msg) catch {};
-                std.process.exit(1);
-            };
-        } else if (std.mem.eql(u8, cmd, "uninstall")) {
-            doUninstall();
-        } else if (std.mem.eql(u8, cmd, "--help") or std.mem.eql(u8, cmd, "-h")) {
-            std.fs.File.stdout().writeAll(usage) catch {};
-        } else {
-            var buf: [256]u8 = undefined;
-            const msg = std.fmt.bufPrint(&buf, "attyx: unknown command '{s}'\n\n", .{cmd}) catch "attyx: unknown command\n\n";
-            std.fs.File.stderr().writeAll(msg) catch {};
-            std.fs.File.stdout().writeAll(usage) catch {};
-            std.process.exit(1);
-        }
-    } else {
-        std.fs.File.stdout().writeAll(usage) catch {};
-    }
-}
-
-fn doLogin(allocator: std.mem.Allocator) !void {
+pub fn doLogin(allocator: std.mem.Allocator, base_url: []const u8) !void {
     const stdout = std.fs.File.stdout();
 
-    stdout.writeAll("Connecting to " ++ base_url ++ "...\n") catch {};
+    stdout.writeAll("Connecting to ") catch {};
+    stdout.writeAll(base_url) catch {};
+    stdout.writeAll("...\n") catch {};
 
     // Load existing tokens for refresh
     var store = ai_auth.TokenStore.load(allocator) catch ai_auth.TokenStore.init(allocator);
@@ -133,7 +75,7 @@ fn doLogin(allocator: std.mem.Allocator) !void {
     return error.DeviceExpired;
 }
 
-fn doDevice(allocator: std.mem.Allocator) !void {
+pub fn doDevice(allocator: std.mem.Allocator, base_url: []const u8) !void {
     const stdout = std.fs.File.stdout();
 
     // Load tokens
@@ -219,7 +161,7 @@ fn doDevice(allocator: std.mem.Allocator) !void {
     stdout.writeAll("\n") catch {};
 }
 
-fn doUninstall() void {
+pub fn doUninstall() void {
     const stdout = std.fs.File.stdout();
     const home = std.posix.getenv("HOME") orelse {
         stdout.writeAll("error: HOME not set\n") catch {};
@@ -228,7 +170,6 @@ fn doUninstall() void {
 
     const targets = [_]struct { dir: []const u8, file: []const u8 }{
         .{ .dir = ".config/attyx", .file = "" },                                    // config + auth tokens
-        .{ .dir = ".attyx", .file = "" },                                            // embedded CLI
         .{ .dir = ".local/share/applications", .file = "attyx.desktop" },            // desktop entry
         .{ .dir = ".local/share/icons/hicolor/256x256/apps", .file = "attyx.png" },  // icon
     };
@@ -241,8 +182,8 @@ fn doUninstall() void {
             std.fs.cwd().deleteTree(path) catch |err| {
                 if (err != error.FileNotFound) {
                     var err_buf: [512]u8 = undefined;
-                    const msg = std.fmt.bufPrint(&err_buf, "  warning: could not remove {s}: {s}\n", .{ path, @errorName(err) }) catch continue;
-                    stdout.writeAll(msg) catch {};
+                    const err_msg = std.fmt.bufPrint(&err_buf, "  warning: could not remove {s}: {s}\n", .{ path, @errorName(err) }) catch continue;
+                    stdout.writeAll(err_msg) catch {};
                 }
                 continue;
             };
@@ -255,8 +196,8 @@ fn doUninstall() void {
             std.fs.cwd().deleteFile(path) catch |err| {
                 if (err != error.FileNotFound) {
                     var err_buf: [512]u8 = undefined;
-                    const msg = std.fmt.bufPrint(&err_buf, "  warning: could not remove {s}: {s}\n", .{ path, @errorName(err) }) catch continue;
-                    stdout.writeAll(msg) catch {};
+                    const err_msg = std.fmt.bufPrint(&err_buf, "  warning: could not remove {s}: {s}\n", .{ path, @errorName(err) }) catch continue;
+                    stdout.writeAll(err_msg) catch {};
                 }
                 continue;
             };
@@ -269,14 +210,14 @@ fn doUninstall() void {
     stdout.writeAll("\nAttyx data cleaned up. You can now run `brew uninstall attyx`.\n") catch {};
 }
 
-fn printField(stdout: std.fs.File, label: []const u8, value: []const u8) void {
+pub fn printField(stdout: std.fs.File, label: []const u8, value: []const u8) void {
     var buf: [512]u8 = undefined;
     const line = std.fmt.bufPrint(&buf, "{s}: {s}\n", .{ label, value }) catch return;
     stdout.writeAll(line) catch {};
 }
 
 /// Find the JSON object substring containing "is_current":true
-fn findCurrentSession(json: []const u8) ?[]const u8 {
+pub fn findCurrentSession(json: []const u8) ?[]const u8 {
     // Find "is_current":true and work backwards to the enclosing {
     const marker = "\"is_current\":true";
     const alt_marker = "\"is_current\": true";

--- a/src/config/cli.zig
+++ b/src/config/cli.zig
@@ -16,6 +16,9 @@ pub const Action = enum {
     run,
     print_config,
     show_help,
+    login,
+    device,
+    uninstall,
 };
 
 fn fatal(msg: []const u8) noreturn {
@@ -37,6 +40,20 @@ pub fn parse(args: []const [:0]const u8) CliResult {
         .config = AppConfig{},
         .action = .run,
     };
+    // Detect bare subcommand as first arg (before any flags)
+    if (args.len > 1) {
+        const first = args[1];
+        if (std.mem.eql(u8, first, "login")) {
+            result.action = .login;
+            return result;
+        } else if (std.mem.eql(u8, first, "device")) {
+            result.action = .device;
+            return result;
+        } else if (std.mem.eql(u8, first, "uninstall")) {
+            result.action = .uninstall;
+            return result;
+        }
+    }
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         const arg = args[i];
@@ -294,6 +311,12 @@ pub fn printUsage() void {
         \\
         \\Usage:
         \\  attyx [options]            Launch terminal (GPU-accelerated)
+        \\  attyx <command>            Run a subcommand
+        \\
+        \\Commands:
+        \\  login                      Authenticate with Attyx AI services
+        \\  device                     Show device and account info
+        \\  uninstall                  Remove config, auth tokens, and desktop entry
         \\
         \\Options:
         \\  --rows N                   Terminal rows (default: 24)

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,9 +1,15 @@
 const std = @import("std");
+const attyx = @import("attyx");
 const cli = @import("config/cli.zig");
 const config_mod = @import("config/config.zig");
 const ui2 = @import("app/ui2.zig");
 const logging = @import("logging/log.zig");
-const cli_binary = @import("cli_binary");
+const cli_commands = @import("cli_commands");
+
+const base_url: []const u8 = if (std.mem.eql(u8, attyx.env, "production"))
+    "https://app.semos.sh"
+else
+    "http://localhost:8085";
 
 pub const std_options: std.Options = .{
     .logFn = logging.stdLogFn,
@@ -22,6 +28,28 @@ pub fn main() !void {
     switch (result.action) {
         .show_help => {
             cli.printUsage();
+            return;
+        },
+        .login => {
+            cli_commands.doLogin(allocator, base_url) catch |err| {
+                var buf: [256]u8 = undefined;
+                const msg = std.fmt.bufPrint(&buf, "error: login failed: {s}\n", .{@errorName(err)}) catch "error: login failed\n";
+                std.fs.File.stderr().writeAll(msg) catch {};
+                std.process.exit(1);
+            };
+            return;
+        },
+        .device => {
+            cli_commands.doDevice(allocator, base_url) catch |err| {
+                var buf: [256]u8 = undefined;
+                const msg = std.fmt.bufPrint(&buf, "error: {s}\n", .{@errorName(err)}) catch "error: failed to get device info\n";
+                std.fs.File.stderr().writeAll(msg) catch {};
+                std.process.exit(1);
+            };
+            return;
+        },
+        .uninstall => {
+            cli_commands.doUninstall();
             return;
         },
         .print_config => {
@@ -49,8 +77,6 @@ pub fn main() !void {
         logging.Level.info;
     logging.init(log_level, merged.log_file);
     defer logging.deinit();
-
-    installCli(allocator);
 
     try ui2.run(merged, result.no_config, result.config_path, args);
 }
@@ -85,58 +111,6 @@ fn loadMergedConfig(
 fn fatal(msg: []const u8) noreturn {
     std.debug.print("error: {s}\n", .{msg});
     std.process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Embedded CLI auto-install
-// ---------------------------------------------------------------------------
-
-fn installCli(allocator: std.mem.Allocator) void {
-    installCliInner(allocator) catch |err| {
-        logging.warn("cli", "failed to install CLI binary: {}", .{err});
-    };
-}
-
-fn installCliInner(allocator: std.mem.Allocator) !void {
-    const home = std.posix.getenv("HOME") orelse return;
-    const bin_dir = try std.fmt.allocPrint(allocator, "{s}/.attyx/bin", .{home});
-    defer allocator.free(bin_dir);
-    const hash_path = try std.fmt.allocPrint(allocator, "{s}/.cli-hash", .{bin_dir});
-    defer allocator.free(hash_path);
-    const bin_path = try std.fmt.allocPrint(allocator, "{s}/attyx", .{bin_dir});
-    defer allocator.free(bin_path);
-
-    // Compute hash of embedded binary at runtime (one-time, fast)
-    var hash_buf: [16]u8 = undefined;
-    const h = std.hash.Fnv1a_64.hash(cli_binary.data);
-    _ = std.fmt.bufPrint(&hash_buf, "{x:0>16}", .{h}) catch unreachable;
-
-    // Check if the currently installed binary is already up-to-date
-    if (hashMatches(hash_path, &hash_buf)) return;
-
-    // Ensure directory exists
-    std.fs.cwd().makePath(bin_dir) catch {};
-
-    // Write the binary
-    const file = try std.fs.cwd().createFile(bin_path, .{ .mode = 0o755 });
-    defer file.close();
-    try file.writeAll(cli_binary.data);
-
-    // Write the hash file
-    const hf = try std.fs.cwd().createFile(hash_path, .{});
-    defer hf.close();
-    try hf.writeAll(&hash_buf);
-
-    logging.info("cli", "installed attyx CLI to {s}", .{bin_path});
-}
-
-fn hashMatches(hash_path: []const u8, expected: *const [16]u8) bool {
-    const file = std.fs.cwd().openFile(hash_path, .{}) catch return false;
-    defer file.close();
-    var buf: [16]u8 = undefined;
-    const n = file.readAll(&buf) catch return false;
-    if (n != 16) return false;
-    return std.mem.eql(u8, &buf, expected);
 }
 
 test {

--- a/src/root.zig
+++ b/src/root.zig
@@ -42,6 +42,7 @@ pub const overlay_ai_error = @import("overlay/ai_error.zig");
 pub const overlay_update_check = @import("overlay/update_check.zig");
 
 pub const version = @import("build_options").version;
+pub const env = @import("build_options").env;
 
 pub const Action = actions.Action;
 pub const ControlCode = actions.ControlCode;


### PR DESCRIPTION
## Summary

- Replace the separate `attyx-cli` binary (embedded at build, extracted to `~/.attyx/bin/`, PATH-injected in PTY child) with `login`, `device`, `uninstall` subcommands on the main `attyx` binary
- Remove CLI embedding from `build.zig` (attyx-cli exe, `cli_embed_wf`, `install-cli` step)
- Add ZDOTDIR-based shell integration so `attyx` is in PATH inside the terminal, surviving shell init scripts (nix `.zshenv`, `path_helper`) that rebuild PATH from scratch