### PR TITLE
Tabs refinement

### DIFF
--- a/src/app/bridge.h
+++ b/src/app/bridge.h
@@ -405,6 +405,8 @@ extern volatile int        g_popup_image_placement_count;
 #define ATTYX_ACTION_PANE_RESIZE_DOWN  61
 #define ATTYX_ACTION_PANE_RESIZE_LEFT  62
 #define ATTYX_ACTION_PANE_RESIZE_RIGHT 63
+#define ATTYX_ACTION_TAB_SELECT_1     64
+#define ATTYX_ACTION_TAB_SELECT_9     72
 
 // Returns action ID (0 = no match). For ATTYX_ACTION_SEND_SEQUENCE,
 // g_keybind_matched_seq/len are set before returning.

--- a/src/app/linux_input.c
+++ b/src/app/linux_input.c
@@ -135,6 +135,10 @@ static int dispatchAction(uint8_t act) {
         attyx_tab_action(act);
         return 1;
     }
+    if (act >= ATTYX_ACTION_TAB_SELECT_1 && act <= ATTYX_ACTION_TAB_SELECT_9) {
+        attyx_tab_action(act);
+        return 1;
+    }
     if (act >= ATTYX_ACTION_SPLIT_VERTICAL && act <= ATTYX_ACTION_PANE_CLOSE) {
         attyx_split_action(act);
         return 1;
@@ -234,6 +238,9 @@ static void glfwToKeyCombo(int key, int mods, uint16_t* outKey, uint32_t* outCp)
         uint32_t cp = 'a' + (key - GLFW_KEY_A);
         if (mods & GLFW_MOD_SHIFT) cp -= 32;
         *outCp = cp;
+    } else if (key >= GLFW_KEY_0 && key <= GLFW_KEY_9) {
+        *outKey = KC_CODEPOINT;
+        *outCp = '0' + (key - GLFW_KEY_0);
     } else {
         *outKey = KC_CODEPOINT;
         *outCp = 0;

--- a/src/app/macos_input_keyboard.m
+++ b/src/app/macos_input_keyboard.m
@@ -91,6 +91,10 @@ static int dispatchAction(uint8_t action) {
         attyx_tab_action(action);
         return 1;
     }
+    if (action >= ATTYX_ACTION_TAB_SELECT_1 && action <= ATTYX_ACTION_TAB_SELECT_9) {
+        attyx_tab_action(action);
+        return 1;
+    }
     if (action >= ATTYX_ACTION_SPLIT_VERTICAL && action <= ATTYX_ACTION_PANE_CLOSE) {
         attyx_split_action(action);
         return 1;

--- a/src/app/tab_bar.zig
+++ b/src/app/tab_bar.zig
@@ -1,18 +1,20 @@
 // Attyx — Tab bar overlay generator
 //
 // Produces a single row of OverlayCells representing the tab bar.
-// Each tab shows " title " with separators. Active tab gets distinct colors.
+// Each tab shows " title  N " with the active tab's number highlighted.
 
 const std = @import("std");
 const attyx = @import("attyx");
 const OverlayCell = attyx.overlay_mod.OverlayCell;
 const Rgb = attyx.overlay_mod.Rgb;
+const tab_manager = @import("tab_manager.zig");
+pub const max_tabs = tab_manager.max_tabs;
 
 pub const Style = struct {
-    bg: Rgb = .{ .r = 30, .g = 30, .b = 40 },
-    active_bg: Rgb = .{ .r = 60, .g = 60, .b = 90 },
+    tab_bg: Rgb = .{ .r = 50, .g = 50, .b = 58 },
     fg: Rgb = .{ .r = 140, .g = 140, .b = 160 },
-    active_fg: Rgb = .{ .r = 230, .g = 230, .b = 240 },
+    num_highlight_bg: Rgb = .{ .r = 90, .g = 90, .b = 100 },
+    num_highlight_fg: Rgb = .{ .r = 230, .g = 230, .b = 240 },
     bg_alpha: u8 = 230,
 };
 
@@ -22,72 +24,155 @@ pub const Result = struct {
     height: u16, // always 1
 };
 
+/// Per-tab title, resolved by the caller (OSC title or process name).
+pub const TabTitles = [max_tabs]?[]const u8;
+
+/// Cached per-tab widths written by generate(), read by tabIndexAtCol().
+var cached_widths: [max_tabs]u16 = .{0} ** max_tabs;
+var cached_count: u8 = 0;
+
+/// Decode the next UTF-8 codepoint from `s[i..*]`, advancing `i`.
+/// Skips invalid bytes gracefully, returning 0xFFFD (replacement char).
+fn nextCodepoint(s: []const u8, i: *usize) ?u21 {
+    if (i.* >= s.len) return null;
+    const len = std.unicode.utf8ByteSequenceLength(s[i.*]) catch {
+        i.* += 1;
+        return 0xFFFD;
+    };
+    if (i.* + len > s.len) {
+        i.* = s.len;
+        return 0xFFFD;
+    }
+    const cp = std.unicode.utf8Decode(s[i.*..][0..len]) catch {
+        i.* += 1;
+        return 0xFFFD;
+    };
+    i.* += len;
+    return cp;
+}
+
+/// Count display columns for a UTF-8 string (1 column per codepoint).
+fn displayWidth(s: []const u8) u16 {
+    var i: usize = 0;
+    var count: u16 = 0;
+    while (nextCodepoint(s, &i) != null) count += 1;
+    return count;
+}
+
+/// Number of digits in a 1-indexed tab number.
+fn numLen(n: u8) u16 {
+    return if (n >= 10) 2 else 1;
+}
+
+/// Compute the natural width for a tab: " title " + " N " = (1+title+1) + (1+numlen+1).
+fn tabWidth(title_len: u16, tab_number: u8) u16 {
+    return 1 + title_len + 1 + 1 + numLen(tab_number) + 1;
+}
+
+/// Resolve the title for tab `i`, writing fallback into `fallback_buf`.
+fn resolveTitle(titles: *const TabTitles, i: usize, fallback_buf: *[20]u8) []const u8 {
+    return titles[i] orelse
+        (std.fmt.bufPrint(fallback_buf, "Tab {d}", .{i + 1}) catch "Tab ?");
+}
+
 /// Generate tab bar overlay cells into a caller-provided buffer.
 /// Returns the number of cells written, or null if buffer is too small.
+/// `titles` provides per-tab display names; falls back to "Tab N" when null.
 pub fn generate(
     buf: []OverlayCell,
     tab_count: u8,
     active: u8,
     grid_cols: u16,
     style: Style,
+    titles: *const TabTitles,
 ) ?Result {
     if (grid_cols == 0 or tab_count == 0) return null;
     const width: u16 = grid_cols;
     if (buf.len < width) return null;
 
-    // Fill entire row with bar background
+    // Fill entire row with transparent background
     for (buf[0..width]) |*cell| {
         cell.* = .{
             .char = ' ',
             .fg = style.fg,
-            .bg = style.bg,
-            .bg_alpha = style.bg_alpha,
+            .bg = .{ .r = 0, .g = 0, .b = 0 },
+            .bg_alpha = 0,
         };
     }
 
-    // Compute tab width: divide evenly, cap at a reasonable max
-    const max_tab_width: u16 = 24;
-    const available: u16 = width;
-    var tab_width: u16 = if (tab_count > 0) available / @as(u16, tab_count) else available;
-    if (tab_width > max_tab_width) tab_width = max_tab_width;
-    if (tab_width < 5) tab_width = 5; // minimum: " T1 |"
+    // Compute content-based widths and cache them for tabIndexAtCol().
+    var fallback_bufs: [max_tabs][20]u8 = undefined;
+    var resolved: [max_tabs][]const u8 = undefined;
+    var widths: [max_tabs]u16 = undefined;
+    for (0..tab_count) |i| {
+        resolved[i] = resolveTitle(titles, i, &fallback_bufs[i]);
+        widths[i] = tabWidth(displayWidth(resolved[i]), @intCast(i + 1));
+    }
+    @memcpy(cached_widths[0..tab_count], widths[0..tab_count]);
+    cached_count = tab_count;
+
+    // Format each tab number (1-indexed) into a small buffer.
+    var num_bufs: [max_tabs][3]u8 = undefined;
+    var num_slices: [max_tabs][]const u8 = undefined;
+    for (0..tab_count) |i| {
+        num_slices[i] = std.fmt.bufPrint(&num_bufs[i], "{d}", .{i + 1}) catch "?";
+    }
 
     var col: u16 = 0;
     for (0..tab_count) |i| {
         if (col >= width) break;
         const is_active = (i == active);
-        const fg = if (is_active) style.active_fg else style.fg;
-        const bg = if (is_active) style.active_bg else style.bg;
+        const natural_width = widths[i];
+        const content_width = if (col + natural_width <= width) natural_width else width - col;
 
-        // Format title: "Tab N" (1-indexed)
-        var title_buf: [20]u8 = undefined;
-        const title = std.fmt.bufPrint(&title_buf, "Tab {d}", .{i + 1}) catch "Tab ?";
+        const title = resolved[i];
+        const num = num_slices[i];
 
-        // Write " title " padded to tab_width, then separator
-        const content_width = if (col + tab_width <= width) tab_width else width - col;
+        // Number area: double-space + digits + trailing space — all use num bg for active
+        const n_fg = if (is_active) style.num_highlight_fg else style.fg;
+        const n_bg = if (is_active) style.num_highlight_bg else style.tab_bg;
 
-        // Leading space
         var pos: u16 = 0;
+
+        // Title area: " title " — tab_bg
         if (pos < content_width) {
-            buf[col + pos] = .{ .char = ' ', .fg = fg, .bg = bg, .bg_alpha = style.bg_alpha };
+            buf[col + pos] = .{ .char = ' ', .fg = style.fg, .bg = style.tab_bg, .bg_alpha = style.bg_alpha };
+            pos += 1;
+        }
+        {
+            var ti: usize = 0;
+            while (nextCodepoint(title, &ti)) |cp| {
+                if (pos >= content_width) break;
+                buf[col + pos] = .{ .char = cp, .fg = style.fg, .bg = style.tab_bg, .bg_alpha = style.bg_alpha };
+                pos += 1;
+            }
+        }
+        if (pos < content_width) {
+            buf[col + pos] = .{ .char = ' ', .fg = style.fg, .bg = style.tab_bg, .bg_alpha = style.bg_alpha };
             pos += 1;
         }
 
-        // Title characters
-        for (title) |ch| {
+        // Number area: " N " — leading space + digits + trailing space
+        if (pos < content_width) {
+            buf[col + pos] = .{ .char = ' ', .fg = n_fg, .bg = n_bg, .bg_alpha = style.bg_alpha };
+            pos += 1;
+        }
+        for (num) |ch| {
             if (pos >= content_width) break;
-            buf[col + pos] = .{ .char = ch, .fg = fg, .bg = bg, .bg_alpha = style.bg_alpha };
+            buf[col + pos] = .{ .char = ch, .fg = n_fg, .bg = n_bg, .bg_alpha = style.bg_alpha };
             pos += 1;
         }
-
-        // Remaining padding
         while (pos < content_width) : (pos += 1) {
-            const ch: u21 = if (pos == content_width - 1 and i + 1 < tab_count) '|' else ' ';
-            const sep_fg = if (ch == '|') style.fg else fg;
-            buf[col + pos] = .{ .char = ch, .fg = sep_fg, .bg = bg, .bg_alpha = style.bg_alpha };
+            buf[col + pos] = .{ .char = ' ', .fg = n_fg, .bg = n_bg, .bg_alpha = style.bg_alpha };
         }
 
         col += content_width;
+
+        // 1-cell gap between tabs (bar background, not part of any tab)
+        if (i + 1 < tab_count and col < width) {
+            buf[col] = .{ .char = ' ', .fg = style.fg, .bg = .{ .r = 0, .g = 0, .b = 0 }, .bg_alpha = 0 };
+            col += 1;
+        }
     }
 
     return .{
@@ -97,104 +182,158 @@ pub fn generate(
     };
 }
 
-/// Given a column position, return the tab index at that column (or null if outside tabs).
+/// Given a column position, return the tab index at that column (or null if outside tabs
+/// or on a gap between tabs).
 pub fn tabIndexAtCol(col: u16, tab_count: u8, grid_cols: u16) ?u8 {
     if (grid_cols == 0 or tab_count == 0) return null;
 
-    const max_tab_width: u16 = 24;
-    var tab_width: u16 = grid_cols / @as(u16, tab_count);
-    if (tab_width > max_tab_width) tab_width = max_tab_width;
-    if (tab_width < 5) tab_width = 5;
-
-    const total_tabs_width = tab_width * @as(u16, tab_count);
-    if (col >= total_tabs_width) return null;
-
-    const idx: u8 = @intCast(col / tab_width);
-    return if (idx < tab_count) idx else null;
+    const count = @min(tab_count, cached_count);
+    var offset: u16 = 0;
+    for (0..count) |i| {
+        const w = cached_widths[i];
+        if (col >= offset and col < offset + w) return @intCast(i);
+        offset += w;
+        // Skip the 1-cell gap between tabs
+        if (i + 1 < count) offset += 1;
+        if (offset >= grid_cols) break;
+    }
+    return null;
 }
 
 // ===========================================================================
 // Tests
 // ===========================================================================
 
+const no_titles: TabTitles = .{null} ** max_tabs;
+
 test "generate: null on 0 cols" {
     var buf: [100]OverlayCell = undefined;
-    try std.testing.expect(generate(&buf, 2, 0, 0, .{}) == null);
+    try std.testing.expect(generate(&buf, 2, 0, 0, .{}, &no_titles) == null);
 }
 
 test "generate: null on 0 tabs" {
     var buf: [100]OverlayCell = undefined;
-    try std.testing.expect(generate(&buf, 0, 0, 40, .{}) == null);
+    try std.testing.expect(generate(&buf, 0, 0, 40, .{}, &no_titles) == null);
 }
 
 test "generate: null on small buffer" {
     var buf: [5]OverlayCell = undefined;
-    try std.testing.expect(generate(&buf, 1, 0, 10, .{}) == null);
+    try std.testing.expect(generate(&buf, 1, 0, 10, .{}, &no_titles) == null);
 }
 
-test "generate: single tab fills width" {
-    var buf: [20]OverlayCell = undefined;
-    const result = generate(&buf, 1, 0, 20, .{}) orelse return error.TestUnexpectedResult;
-    try std.testing.expectEqual(@as(u16, 20), result.width);
-    try std.testing.expectEqual(@as(u16, 1), result.height);
-    // First cell should be a space (leading padding)
+test "generate: tab layout is ' title ' + ' N '" {
+    var buf: [80]OverlayCell = undefined;
+    const style = Style{};
+    var titles: TabTitles = .{null} ** max_tabs;
+    titles[0] = "vim";
+    // " vim " + " 1 " = (1+3+1) + (1+1+1) = 5 + 3 = 8
+    const result = generate(&buf, 1, 0, 80, style, &titles) orelse return error.TestUnexpectedResult;
+    // Title area: " vim " — tab_bg
     try std.testing.expectEqual(@as(u21, ' '), result.cells[0].char);
+    try std.testing.expectEqual(style.tab_bg, result.cells[0].bg);
+    try std.testing.expectEqual(@as(u21, 'v'), result.cells[1].char);
+    try std.testing.expectEqual(@as(u21, 'i'), result.cells[2].char);
+    try std.testing.expectEqual(@as(u21, 'm'), result.cells[3].char);
+    try std.testing.expectEqual(@as(u21, ' '), result.cells[4].char); // trailing space
+    try std.testing.expectEqual(style.tab_bg, result.cells[4].bg);
+    // Number area: " 1 " — num_highlight_bg (active)
+    try std.testing.expectEqual(@as(u21, ' '), result.cells[5].char);
+    try std.testing.expectEqual(style.num_highlight_bg, result.cells[5].bg);
+    try std.testing.expectEqual(@as(u21, '1'), result.cells[6].char);
+    try std.testing.expectEqual(style.num_highlight_bg, result.cells[6].bg);
+    try std.testing.expectEqual(@as(u21, ' '), result.cells[7].char);
+    try std.testing.expectEqual(style.num_highlight_bg, result.cells[7].bg);
 }
 
-test "generate: separator pipes between tabs" {
+test "generate: inactive number area uses tab_bg, active uses num_highlight_bg" {
     var buf: [80]OverlayCell = undefined;
     const style = Style{};
-    const result = generate(&buf, 3, 0, 60, style) orelse return error.TestUnexpectedResult;
+    var titles: TabTitles = .{null} ** max_tabs;
+    titles[0] = "zsh";
+    titles[1] = "vim";
+    // Each tab: " xxx " + " N " = 5 + 3 = 8, gap at 8, tab 1 starts at 9
+    const result = generate(&buf, 2, 1, 80, style, &titles) orelse return error.TestUnexpectedResult;
 
-    // Tab width = 60/3 = 20 (capped at 24). Last cell of first tab should be '|'
-    const tab_width: u16 = 20;
-    try std.testing.expectEqual(@as(u21, '|'), result.cells[tab_width - 1].char);
+    // Tab 0 (inactive) — title area tab_bg
+    try std.testing.expectEqual(style.tab_bg, result.cells[0].bg);
+    // Tab 0 number area (cols 5-7) — inactive, tab_bg
+    try std.testing.expectEqual(style.tab_bg, result.cells[5].bg);
+    try std.testing.expectEqual(style.tab_bg, result.cells[6].bg);
+    try std.testing.expectEqual(style.fg, result.cells[6].fg);
+
+    // Gap at col 8 — transparent
+    try std.testing.expectEqual(@as(u8, 0), result.cells[8].bg_alpha);
+
+    // Tab 1 (active) — title area tab_bg
+    try std.testing.expectEqual(style.tab_bg, result.cells[9].bg);
+    // Tab 1 number area (cols 14-16) — active, highlighted
+    try std.testing.expectEqual(style.num_highlight_bg, result.cells[14].bg);
+    try std.testing.expectEqual(style.num_highlight_bg, result.cells[15].bg);
+    try std.testing.expectEqual(style.num_highlight_fg, result.cells[15].fg);
+    try std.testing.expectEqual(style.num_highlight_bg, result.cells[16].bg);
 }
 
-test "generate: active tab uses highlight colors" {
+test "generate: two-digit tab numbers" {
+    // tabWidth: 1 + title + 1 + 1 + numlen + 1
+    // tab 10 (2 digits), title=1: 1+1+1+1+2+1 = 7
+    try std.testing.expectEqual(@as(u16, 7), tabWidth(1, 10));
+    // tab 1 (1 digit), title=1: 1+1+1+1+1+1 = 6
+    try std.testing.expectEqual(@as(u16, 6), tabWidth(1, 1));
+}
+
+test "generate: gap between tabs is transparent" {
     var buf: [80]OverlayCell = undefined;
     const style = Style{};
-    const result = generate(&buf, 2, 1, 40, style) orelse return error.TestUnexpectedResult;
+    var titles: TabTitles = .{null} ** max_tabs;
+    titles[0] = "a";
+    titles[1] = "b";
+    // Tab 0: " a " + " 1 " = 3+3 = 6, gap at 6, Tab 1 starts at 7
+    _ = generate(&buf, 2, 0, 80, style, &titles) orelse return error.TestUnexpectedResult;
 
-    // Tab 0 (inactive) should use default bg
-    try std.testing.expectEqual(style.bg, result.cells[0].bg);
-    // Tab 1 (active) — first cell of second tab should use active_bg
-    const tab_width: u16 = 20;
-    try std.testing.expectEqual(style.active_bg, result.cells[tab_width].bg);
+    try std.testing.expectEqual(@as(u8, 0), buf[6].bg_alpha);
+    try std.testing.expectEqual(style.tab_bg, buf[7].bg);
 }
 
-test "tabIndexAtCol: correct index per column" {
-    // 3 tabs, 60 cols → tab_width = 20
-    try std.testing.expectEqual(@as(?u8, 0), tabIndexAtCol(0, 3, 60));
-    try std.testing.expectEqual(@as(?u8, 0), tabIndexAtCol(19, 3, 60));
-    try std.testing.expectEqual(@as(?u8, 1), tabIndexAtCol(20, 3, 60));
-    try std.testing.expectEqual(@as(?u8, 2), tabIndexAtCol(40, 3, 60));
+test "tabIndexAtCol: variable width tabs with gaps" {
+    var buf: [80]OverlayCell = undefined;
+    var titles: TabTitles = .{null} ** max_tabs;
+    titles[0] = "vim"; // " vim " + " 1 " = 5+3 = 8
+    titles[1] = "long-process"; // " long-process " + " 2 " = 14+3 = 17
+    titles[2] = "zsh"; // " zsh " + " 3 " = 5+3 = 8
+    _ = generate(&buf, 3, 0, 80, .{}, &titles) orelse return error.TestUnexpectedResult;
+
+    // Tab 0: cols 0..7
+    try std.testing.expectEqual(@as(?u8, 0), tabIndexAtCol(0, 3, 80));
+    try std.testing.expectEqual(@as(?u8, 0), tabIndexAtCol(7, 3, 80));
+    // Gap at col 8
+    try std.testing.expectEqual(@as(?u8, null), tabIndexAtCol(8, 3, 80));
+    // Tab 1: cols 9..25
+    try std.testing.expectEqual(@as(?u8, 1), tabIndexAtCol(9, 3, 80));
+    try std.testing.expectEqual(@as(?u8, 1), tabIndexAtCol(25, 3, 80));
+    // Gap at col 26
+    try std.testing.expectEqual(@as(?u8, null), tabIndexAtCol(26, 3, 80));
+    // Tab 2: cols 27..34
+    try std.testing.expectEqual(@as(?u8, 2), tabIndexAtCol(27, 3, 80));
+    try std.testing.expectEqual(@as(?u8, 2), tabIndexAtCol(34, 3, 80));
+    // Beyond all tabs
+    try std.testing.expectEqual(@as(?u8, null), tabIndexAtCol(35, 3, 80));
 }
 
-test "tabIndexAtCol: null beyond tabs" {
-    // 2 tabs, 60 cols → tab_width = 24 (capped), total = 48
-    try std.testing.expectEqual(@as(?u8, null), tabIndexAtCol(48, 2, 60));
+test "generate: utf-8 title renders codepoints not bytes" {
+    var buf: [80]OverlayCell = undefined;
+    var titles: TabTitles = .{null} ** max_tabs;
+    // "café" = 4 codepoints (5 bytes: c a f 0xC3 0xA9)
+    titles[0] = "caf\xc3\xa9";
+    // displayWidth = 4, tab = " café " + " 1 " = 6 + 3 = 9
+    const result = generate(&buf, 1, 0, 80, .{}, &titles) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(u21, 'c'), result.cells[1].char);
+    try std.testing.expectEqual(@as(u21, 'a'), result.cells[2].char);
+    try std.testing.expectEqual(@as(u21, 'f'), result.cells[3].char);
+    try std.testing.expectEqual(@as(u21, 0xe9), result.cells[4].char); // é as single codepoint
+    try std.testing.expectEqual(@as(u21, ' '), result.cells[5].char); // trailing space of title
 }
 
 test "tabIndexAtCol: null on 0 cols or 0 tabs" {
     try std.testing.expectEqual(@as(?u8, null), tabIndexAtCol(0, 0, 40));
     try std.testing.expectEqual(@as(?u8, null), tabIndexAtCol(0, 2, 0));
-}
-
-test "tab width capping: max 24" {
-    // 1 tab, 100 cols → tab_width capped at 24
-    var buf: [100]OverlayCell = undefined;
-    const default_style = Style{};
-    const result = generate(&buf, 1, 0, 100, default_style) orelse return error.TestUnexpectedResult;
-
-    // Active tab content should only span first 24 cells with tab content
-    // (the rest is bar background). Check that cell 24 has bar bg, not active bg.
-    try std.testing.expectEqual(default_style.bg, result.cells[24].bg);
-}
-
-test "tab width capping: min 5" {
-    // 10 tabs, 20 cols → 20/10 = 2 < 5, so tab_width = 5
-    try std.testing.expectEqual(@as(?u8, 0), tabIndexAtCol(0, 10, 20));
-    try std.testing.expectEqual(@as(?u8, 0), tabIndexAtCol(4, 10, 20));
-    try std.testing.expectEqual(@as(?u8, 1), tabIndexAtCol(5, 10, 20));
 }

--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -68,6 +68,17 @@ pub fn processTabActions(ctx: *PtyThreadCtx) void {
             switchActiveTab(ctx);
             logging.info("tabs", "switched to tab {d}", .{ctx.tab_mgr.active + 1});
         },
+        .tab_select_1, .tab_select_2, .tab_select_3,
+        .tab_select_4, .tab_select_5, .tab_select_6,
+        .tab_select_7, .tab_select_8, .tab_select_9,
+        => {
+            const idx = @intFromEnum(action) - @intFromEnum(Action.tab_select_1);
+            if (idx < ctx.tab_mgr.count and idx != ctx.tab_mgr.active) {
+                ctx.tab_mgr.switchTo(idx);
+                switchActiveTab(ctx);
+                logging.info("tabs", "switched to tab {d}", .{idx + 1});
+            }
+        },
         else => {},
     }
 }

--- a/src/app/ui/publish.zig
+++ b/src/app/ui/publish.zig
@@ -535,6 +535,22 @@ pub fn generateTabBar(ctx: *PtyThreadCtx) void {
         return;
     }
 
+    // Resolve a display title for each tab: prefer OSC title, fall back to
+    // the foreground process name (e.g. "zsh", "vim").
+    var titles: tab_bar_mod.TabTitles = .{null} ** tab_bar_mod.max_tabs;
+    var name_bufs: [tab_bar_mod.max_tabs][256]u8 = undefined;
+    for (0..ctx.tab_mgr.count) |i| {
+        const layout = &(ctx.tab_mgr.tabs[i] orelse continue);
+        const pane = layout.focusedPane();
+        if (pane.engine.state.title) |t| {
+            titles[i] = t;
+        } else {
+            if (platform.getForegroundProcessName(pane.pty.master, &name_bufs[i])) |name| {
+                titles[i] = name;
+            }
+        }
+    }
+
     var tab_cells: [512]overlay_mod.OverlayCell = undefined;
     const result = tab_bar_mod.generate(
         &tab_cells,
@@ -542,6 +558,7 @@ pub fn generateTabBar(ctx: *PtyThreadCtx) void {
         ctx.tab_mgr.active,
         ctx.grid_cols,
         .{},
+        &titles,
     ) orelse return;
 
     mgr.setContent(.tab_bar, 0, 0, result.width, result.height, result.cells) catch return;

--- a/src/config/keybinds.zig
+++ b/src/config/keybinds.zig
@@ -92,6 +92,15 @@ pub const Action = enum(u8) {
     pane_resize_down = 61,
     pane_resize_left = 62,
     pane_resize_right = 63,
+    tab_select_1 = 64,
+    tab_select_2 = 65,
+    tab_select_3 = 66,
+    tab_select_4 = 67,
+    tab_select_5 = 68,
+    tab_select_6 = 69,
+    tab_select_7 = 70,
+    tab_select_8 = 71,
+    tab_select_9 = 72,
     _,
 
     /// Return the popup index if this is a popup_toggle action.
@@ -283,6 +292,15 @@ pub fn actionFromString(s: []const u8) ?Action {
         .{ "pane_resize_down", Action.pane_resize_down },
         .{ "pane_resize_left", Action.pane_resize_left },
         .{ "pane_resize_right", Action.pane_resize_right },
+        .{ "tab_select_1", Action.tab_select_1 },
+        .{ "tab_select_2", Action.tab_select_2 },
+        .{ "tab_select_3", Action.tab_select_3 },
+        .{ "tab_select_4", Action.tab_select_4 },
+        .{ "tab_select_5", Action.tab_select_5 },
+        .{ "tab_select_6", Action.tab_select_6 },
+        .{ "tab_select_7", Action.tab_select_7 },
+        .{ "tab_select_8", Action.tab_select_8 },
+        .{ "tab_select_9", Action.tab_select_9 },
     };
     inline for (map) |entry| {
         if (eql(s, entry[0])) return entry[1];
@@ -314,6 +332,21 @@ fn defaultKeybinds() []const Keybind {
             kb(.{ .key = KC_TAB, .mods = MOD_CTRL, .codepoint = 0 }, .tab_next),
             kb(.{ .key = KC_TAB, .mods = MOD_CTRL | MOD_SHIFT, .codepoint = 0 }, .tab_prev),
         };
+        // Tab select by number: Cmd+1..9 on macOS, Alt+1..9 on Linux
+        {
+            const tab_mod = if (is_macos) MOD_SUPER else MOD_ALT;
+            list = list ++ &[_]Keybind{
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '1' }, .tab_select_1),
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '2' }, .tab_select_2),
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '3' }, .tab_select_3),
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '4' }, .tab_select_4),
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '5' }, .tab_select_5),
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '6' }, .tab_select_6),
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '7' }, .tab_select_7),
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '8' }, .tab_select_8),
+                kb(.{ .key = KC_CODEPOINT, .mods = tab_mod, .codepoint = '9' }, .tab_select_9),
+            };
+        }
         // Split pane navigation (cross-platform, only active when splits exist)
         list = list ++ &[_]Keybind{
             kb(.{ .key = KC_CODEPOINT, .mods = MOD_CTRL, .codepoint = 'h' }, .pane_focus_left),


### PR DESCRIPTION
### UI
- Tab bar now has no background
- Tabs now wrap their content instead of being fixed width
- Tabs now have an index next to the content

### UX
- Tab title now displays currently running process
- Users can jump to a specific tab by pressing Cmd-[0-9] on macOS and Alt-[1-9] on Linux

### Configuration
Tab hotkeys can be customized via `attyx.toml`:

```toml
[keybindings]
tab_select_1 = "ctrl+1"
tab_select_2 = "ctrl+shift+2"
tab_select_3 = "none" # disable hotkey
``` 