### PR TITLE
Worktree popup cmd fix

### DIFF
--- a/src/app/popup.zig
+++ b/src/app/popup.zig
@@ -465,47 +465,75 @@ pub fn parsePct(s: []const u8, default: u8) u8 {
 }
 
 /// Read captured stdout from the popup's pipe fd.
-/// Returns allocated text (caller owns) with trailing whitespace trimmed,
-/// or null if nothing was captured. Only works when capture_stdout was set.
+/// Returns allocated text (caller owns) with escape sequences stripped
+/// and whitespace trimmed, or null if nothing was captured.
+/// Takes only the last non-empty line to skip shell init noise
+/// (OSC 7 from shell integration, MOTD, etc.).
 pub fn readCapturedStdout(allocator: std.mem.Allocator, fd: posix.fd_t) ?[]u8 {
     if (fd == -1) return null;
-    var result: std.ArrayList(u8) = .{};
+    var raw: std.ArrayList(u8) = .{};
     var buf: [4096]u8 = undefined;
     while (true) {
         const n = posix.read(fd, &buf) catch break;
         if (n == 0) break;
-        result.appendSlice(allocator, buf[0..n]) catch {
-            result.deinit(allocator);
-            return null;
-        };
+        raw.appendSlice(allocator, buf[0..n]) catch { raw.deinit(allocator); return null; };
     }
-    // Trim trailing whitespace/newlines
-    while (result.items.len > 0) {
-        const ch = result.items[result.items.len - 1];
-        if (ch == '\n' or ch == '\r' or ch == ' ' or ch == '\t') {
-            result.items.len -= 1;
-        } else break;
+    defer raw.deinit(allocator);
+    if (raw.items.len == 0) return null;
+
+    // Last non-empty line — skip trailing newlines, then find line start.
+    var end = raw.items.len;
+    while (end > 0 and (raw.items[end - 1] == '\n' or raw.items[end - 1] == '\r')) end -= 1;
+    if (end == 0) return null;
+    var line_start = end;
+    while (line_start > 0 and raw.items[line_start - 1] != '\n' and raw.items[line_start - 1] != '\r') line_start -= 1;
+    const line = raw.items[line_start..end];
+
+    // Strip escape sequences (CSI, OSC, single-char) and control characters.
+    var result: std.ArrayList(u8) = .{};
+    var i: usize = 0;
+    while (i < line.len) {
+        if (line[i] == 0x1B) {
+            i = skipEscape(line, i);
+        } else if (line[i] < 0x20 or line[i] == 0x7F) {
+            i += 1;
+        } else {
+            result.append(allocator, line[i]) catch { result.deinit(allocator); return null; };
+            i += 1;
+        }
     }
-    // Trim leading whitespace
+    // Trim whitespace
+    while (result.items.len > 0 and
+        (result.items[result.items.len - 1] == ' ' or result.items[result.items.len - 1] == '\t'))
+        result.items.len -= 1;
     var start: usize = 0;
-    while (start < result.items.len) {
-        const ch = result.items[start];
-        if (ch == ' ' or ch == '\t') {
-            start += 1;
-        } else break;
-    }
+    while (start < result.items.len and (result.items[start] == ' ' or result.items[start] == '\t'))
+        start += 1;
     if (start > 0) {
         std.mem.copyForwards(u8, result.items[0..result.items.len - start], result.items[start..result.items.len]);
         result.items.len -= start;
     }
-    if (result.items.len == 0) {
-        result.deinit(allocator);
-        return null;
-    }
-    return result.toOwnedSlice(allocator) catch {
-        result.deinit(allocator);
-        return null;
-    };
+    if (result.items.len == 0) { result.deinit(allocator); return null; }
+    return result.toOwnedSlice(allocator) catch { result.deinit(allocator); return null; };
+}
+
+/// Skip an escape sequence starting at data[start] (ESC byte).
+fn skipEscape(data: []const u8, start: usize) usize {
+    var i = start + 1;
+    if (i >= data.len) return i;
+    if (data[i] == '[') { // CSI: ESC [ <params> <final>
+        i += 1;
+        while (i < data.len and data[i] >= 0x20 and data[i] <= 0x3F) : (i += 1) {}
+        if (i < data.len and data[i] >= 0x40 and data[i] <= 0x7E) i += 1;
+    } else if (data[i] == ']') { // OSC: ESC ] ... BEL or ESC ] ... ESC backslash
+        i += 1;
+        while (i < data.len) {
+            if (data[i] == 0x07) { i += 1; break; }
+            if (data[i] == 0x1B and i + 1 < data.len and data[i + 1] == '\\') { i += 2; break; }
+            i += 1;
+        }
+    } else i += 1; // single-char escape
+    return i;
 }
 
 // C functions for detached subprocess execution
@@ -518,8 +546,8 @@ extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int
 extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
 /// Execute `cmd_prefix value` in a detached subprocess (fire-and-forget).
-/// Uses double-fork to avoid zombies. Used when the main terminal is in
-/// alt screen and PTY injection would go to a TUI app instead of a shell.
+/// Uses double-fork to avoid zombies. The command runs invisibly — no PTY
+/// echo, nothing appears in the terminal grid or scrollback.
 pub fn execDetached(allocator: std.mem.Allocator, cmd_prefix: []const u8, value: []const u8) void {
     const full_slice = std.fmt.allocPrint(allocator, "{s} {s}", .{ cmd_prefix, value }) catch return;
     defer allocator.free(full_slice);
@@ -531,11 +559,9 @@ pub fn execDetached(allocator: std.mem.Allocator, cmd_prefix: []const u8, value:
 
     const pid = posix.fork() catch return;
     if (pid == 0) {
-        // First child: double-fork to detach
         const pid2 = posix.fork() catch _exit(1);
         if (pid2 != 0) _exit(0);
 
-        // Grandchild: set up env and exec the command.
         // Detect tmux socket so tools like sesh can switch sessions
         // even when attyx itself wasn't launched from tmux.
         if (getenv("TMUX") == null) {
@@ -559,7 +585,6 @@ pub fn execDetached(allocator: std.mem.Allocator, cmd_prefix: []const u8, value:
         _ = execvp(argv_ptrs[0].?, @ptrCast(&argv_ptrs));
         _exit(127);
     }
-    // Parent: wait for first child (exits immediately)
     _ = waitpid(pid, null, 0);
 }
 

--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -524,3 +524,4 @@ pub fn doReloadConfig(ctx: *PtyThreadCtx) void {
     c.attyx_mark_all_dirty();
     logging.info("config", "reloaded", .{});
 }
+

--- a/src/term/state.zig
+++ b/src/term/state.zig
@@ -92,8 +92,8 @@ pub const TerminalState = struct {
     /// Whether to reflow content on resize (configurable, default true).
     reflow_on_resize: bool = true,
 
-    /// When true, apply() drops all actions until a line-feed arrives.
-    /// Used to suppress the shell echo of injected commands (e.g. popup on_return_cmd).
+    /// When true, apply() drops all actions until a CR or LF arrives.
+    /// Used to suppress the shell echo of injected commands.
     suppress_echo: bool = false,
 
     /// Kitty keyboard protocol flags stack (max 16 entries).
@@ -147,9 +147,9 @@ pub const TerminalState = struct {
 
     /// Apply a single Action to the terminal state.
     pub fn apply(self: *TerminalState, action: Action) void {
-        // Suppress echoed command text until a line-feed signals acceptance.
+        // Suppress echoed command text until a CR or LF signals acceptance.
         if (self.suppress_echo) {
-            if (action == .control and action.control == .lf) {
+            if (action == .control and (action.control == .lf or action.control == .cr)) {
                 self.suppress_echo = false;
             }
             return;


### PR DESCRIPTION
This pull request improves how popup command output is captured and injected, and introduces a mechanism to suppress unwanted shell echoes when sending commands to the terminal. The changes focus on making the output cleaner by stripping escape sequences and only using the last non-empty line, and on preventing the echoed command from appearing in the terminal until it is accepted by the shell.

**Popup output capture improvements:**

* The `readCapturedStdout` function now strips ANSI escape sequences and control characters, trims whitespace, and only returns the last non-empty line of output. This helps avoid shell initialization noise and ensures only relevant command output is processed.
* Added a helper function `skipEscape` to correctly skip over various terminal escape sequences when cleaning up captured output.

**Command injection and echo suppression:**

* When injecting commands into the PTY, the code now constructs the full command in one string (with carriage return), sets a new `suppress_echo` flag in the terminal state, and writes it as a single operation. This prevents partial command echoes and simplifies output handling.
* Introduced the `suppress_echo` field in `TerminalState`, and updated the `apply` method to drop all actions (i.e., suppress output) until a carriage return or line feed is received, at which point echo suppression is lifted. This ensures that shell echoes of injected commands do not pollute the terminal display. [[1]](diffhunk://#diff-7e397821ed1ef38a9981a3ab0a1009a03f96d16461d68126ff2692f8af85695dR95-R98) [[2]](diffhunk://#diff-7e397821ed1ef38a9981a3ab0a1009a03f96d16461d68126ff2692f8af85695dR150-R157)

**Detached subprocess execution clarification:**

* Updated documentation for `execDetached` to clarify that the command runs completely invisibly (no PTY echo, nothing in scrollback), and made minor code cleanups in the double-fork logic. [[1]](diffhunk://#diff-a7b06ab88ed5ac732e329c81438173ff50c1106c9b2534baf0eeb3e514154be4L521-R550) [[2]](diffhunk://#diff-a7b06ab88ed5ac732e329c81438173ff50c1106c9b2534baf0eeb3e514154be4L534-L538) [[3]](diffhunk://#diff-a7b06ab88ed5ac732e329c81438173ff50c1106c9b2534baf0eeb3e514154be4L562)