### PR TITLE
Support drag-and-drop

### DIFF
--- a/src/app/linux_input.c
+++ b/src/app/linux_input.c
@@ -1021,6 +1021,53 @@ static void errorCallback(int error, const char* description) {
 }
 
 // ---------------------------------------------------------------------------
+// Drag and Drop — file path insertion
+// ---------------------------------------------------------------------------
+
+static void dropCallback(GLFWwindow* w, int count, const char** paths) {
+    (void)w;
+    if (count <= 0 || !paths) return;
+
+    // Compute buffer size: each char could be ' (becomes 4 chars), plus quotes and spaces
+    int totalMax = 0;
+    for (int i = 0; i < count; i++)
+        totalMax += (int)strlen(paths[i]) * 4 + 3; // worst case + surrounding quotes + space
+
+    char* buf = (char*)malloc(totalMax);
+    if (!buf) return;
+    int pos = 0;
+
+    for (int i = 0; i < count; i++) {
+        if (i > 0) buf[pos++] = ' ';
+        // Shell-escape: wrap in single quotes, replace ' with '\''
+        buf[pos++] = '\'';
+        for (const char* p = paths[i]; *p; p++) {
+            if (*p == '\'') {
+                buf[pos++] = '\'';
+                buf[pos++] = '\\';
+                buf[pos++] = '\'';
+                buf[pos++] = '\'';
+            } else {
+                buf[pos++] = *p;
+            }
+        }
+        buf[pos++] = '\'';
+    }
+    buf[pos] = '\0';
+
+    void (*send_fn)(const uint8_t*, int) =
+        g_popup_active ? attyx_popup_send_input : attyx_send_input;
+    if (g_bracketed_paste) {
+        send_fn((const uint8_t*)"\x1b[200~", 6);
+        send_fn((const uint8_t*)buf, pos);
+        send_fn((const uint8_t*)"\x1b[201~", 6);
+    } else {
+        send_fn((const uint8_t*)buf, pos);
+    }
+    free(buf);
+}
+
+// ---------------------------------------------------------------------------
 // Callback registration — called from attyx_run in platform_linux.c
 // ---------------------------------------------------------------------------
 
@@ -1037,4 +1084,5 @@ void linux_register_callbacks(GLFWwindow* win) {
     glfwSetMouseButtonCallback(win, mouseButtonCallback);
     glfwSetCursorPosCallback(win, cursorPosCallback);
     glfwSetScrollCallback(win, scrollCallback);
+    glfwSetDropCallback(win, dropCallback);
 }

--- a/src/app/macos_input.m
+++ b/src/app/macos_input.m
@@ -191,6 +191,7 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
         _markedText = [[NSMutableString alloc] init];
         _markedRange = NSMakeRange(NSNotFound, 0);
         _selectedRange = NSMakeRange(0, 0);
+        [self registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
     }
     return self;
 }

--- a/src/app/macos_input_ime.m
+++ b/src/app/macos_input_ime.m
@@ -242,6 +242,46 @@
     }
 }
 
+// ---------------------------------------------------------------------------
+// Drag and Drop — file path insertion
+// ---------------------------------------------------------------------------
+
+- (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender {
+    (void)sender;
+    return NSDragOperationCopy;
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender {
+    NSPasteboard* pb = [sender draggingPasteboard];
+    NSArray<NSURL*>* urls = [pb readObjectsForClasses:@[[NSURL class]]
+                                              options:@{NSPasteboardURLReadingFileURLsOnlyKey: @YES}];
+    if (!urls || urls.count == 0) return NO;
+
+    NSMutableString* result = [NSMutableString string];
+    for (NSUInteger i = 0; i < urls.count; i++) {
+        if (i > 0) [result appendString:@" "];
+        // Shell-escape: wrap in single quotes, replace ' with '\''
+        NSString* escaped = [urls[i].path stringByReplacingOccurrencesOfString:@"'"
+                                                                   withString:@"'\\''"];
+        [result appendFormat:@"'%@'", escaped];
+    }
+
+    const char* utf8 = [result UTF8String];
+    if (!utf8) return NO;
+    int len = (int)strlen(utf8);
+
+    void (*send_fn)(const uint8_t*, int) =
+        g_popup_active ? attyx_popup_send_input : attyx_send_input;
+    if (g_bracketed_paste) {
+        send_fn((const uint8_t*)"\x1b[200~", 6);
+        send_fn((const uint8_t*)utf8, len);
+        send_fn((const uint8_t*)"\x1b[201~", 6);
+    } else {
+        send_fn((const uint8_t*)utf8, len);
+    }
+    return YES;
+}
+
 @end
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds drag-and-drop support for inserting file paths into the application on both Linux and macOS platforms. The implementation ensures that dropped file paths are shell-escaped and inserted as input, with support for bracketed paste if enabled.

**Drag and Drop Support for File Path Insertion:**

* **Linux platform:**
  - Added a `dropCallback` function in `linux_input.c` to handle file drops, shell-escape file paths, and send them as input, with bracketed paste support.
  - Registered the new drop callback with GLFW in `linux_input.c`.

* **macOS platform:**
  - Registered the view to accept file URL drag-and-drop types in `macos_input.m`.
  - Implemented `draggingEntered:` and `performDragOperation:` methods in `macos_input_ime.m` to handle file drops, shell-escape file paths, and send them as input, with bracketed paste support.