### PR TITLE
feat: Fuzzy finder session picker

### DIFF
--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -85,8 +85,26 @@ pub const DaemonPane = struct {
     }
 
     /// Write input bytes to PTY master (keystrokes from client).
+    /// Handles short writes and WouldBlock on non-blocking PTY fds
+    /// by retrying with a brief sleep (bounded to avoid stalling the
+    /// daemon event loop for too long).
     pub fn writeInput(self: *DaemonPane, bytes: []const u8) !void {
-        _ = try self.pty.writeToPty(bytes);
+        var offset: usize = 0;
+        var retries: u32 = 0;
+        const max_retries: u32 = 50; // 50ms max stall
+        while (offset < bytes.len) {
+            const n = self.pty.writeToPty(bytes[offset..]) catch |err| {
+                if (err == error.WouldBlock) {
+                    retries += 1;
+                    if (retries >= max_retries) return; // give up, don't stall daemon
+                    posix.nanosleep(0, 1_000_000); // 1ms
+                    continue;
+                }
+                return err;
+            };
+            offset += n;
+            retries = 0;
+        }
     }
 
     /// Resize the PTY.

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -103,20 +103,29 @@ pub const SessionClient = struct {
     }
 
     /// Send input to a specific pane.
+    /// Large payloads are chunked to avoid blocking the main thread or
+    /// truncating data on non-blocking sockets.
     pub fn sendPaneInput(self: *SessionClient, pane_id: u32, bytes: []const u8) !void {
+        // Small input: encode and send in one message (fits in 512-byte buffer).
         if (bytes.len <= 508) {
             var payload_buf: [512]u8 = undefined;
             const payload = try protocol.encodePaneInput(&payload_buf, pane_id, bytes);
             try self.sendMessage(.pane_input, payload);
-        } else {
-            // Large input — send header + payload separately
-            var hdr: [protocol.header_size]u8 = undefined;
-            protocol.encodeHeader(&hdr, .pane_input, @intCast(4 + bytes.len));
-            _ = try posix.write(self.socket_fd, &hdr);
-            var id_buf: [4]u8 = undefined;
-            std.mem.writeInt(u32, &id_buf, pane_id, .little);
-            _ = try posix.write(self.socket_fd, &id_buf);
-            _ = try posix.write(self.socket_fd, bytes);
+            return;
+        }
+
+        // Large input: split into chunks that fit the small path.
+        // Each chunk is a separate pane_input message so the daemon can
+        // process them incrementally without needing a huge contiguous write
+        // to the PTY.
+        const chunk_max: usize = 508;
+        var offset: usize = 0;
+        while (offset < bytes.len) {
+            const end = @min(offset + chunk_max, bytes.len);
+            var payload_buf: [512]u8 = undefined;
+            const payload = try protocol.encodePaneInput(&payload_buf, pane_id, bytes[offset..end]);
+            try self.sendMessage(.pane_input, payload);
+            offset = end;
         }
     }
 
@@ -427,12 +436,31 @@ pub const SessionClient = struct {
         if (payload.len <= 512) {
             const msg = protocol.encodeMessage(&msg_buf, msg_type, payload) catch
                 return error.EncodeFailed;
-            _ = try posix.write(self.socket_fd, msg);
+            try self.writeAll(msg);
         } else {
             var hdr: [protocol.header_size]u8 = undefined;
             protocol.encodeHeader(&hdr, msg_type, @intCast(payload.len));
-            _ = try posix.write(self.socket_fd, &hdr);
-            _ = try posix.write(self.socket_fd, payload);
+            try self.writeAll(&hdr);
+            try self.writeAll(payload);
+        }
+    }
+
+    /// Write all bytes to the socket, handling short writes and WouldBlock.
+    fn writeAll(self: *SessionClient, data: []const u8) !void {
+        var offset: usize = 0;
+        var retries: u32 = 0;
+        while (offset < data.len) {
+            const n = posix.write(self.socket_fd, data[offset..]) catch |err| {
+                if (err == error.WouldBlock) {
+                    retries += 1;
+                    if (retries >= 200) return error.WouldBlock; // 200ms timeout
+                    posix.nanosleep(0, 1_000_000);
+                    continue;
+                }
+                return err;
+            };
+            offset += n;
+            retries = 0;
         }
     }
 

--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -80,6 +80,11 @@ pub const PtyThreadCtx = struct {
     session_icon_new: []const u8 = "+",
     session_icon_active: []const u8 = "(active)",
     session_icon_recent: []const u8 = "",
+    session_icon_folder: []const u8 = "\xe2\x96\xb8",
+    // Session finder config
+    session_finder_root: []const u8 = "~",
+    session_finder_depth: u8 = 4,
+    session_finder_show_hidden: bool = false,
     // Split resize step in cells/rows per keypress
     split_resize_step: u16 = 4,
 };
@@ -626,6 +631,10 @@ pub fn run(
         .session_icon_new = config.session_icon_new,
         .session_icon_active = config.session_icon_active,
         .session_icon_recent = config.session_icon_recent,
+        .session_icon_folder = config.session_icon_folder,
+        .session_finder_root = config.session_finder_root,
+        .session_finder_depth = config.session_finder_depth,
+        .session_finder_show_hidden = config.session_finder_show_hidden,
         .last_focus_panes = initial_focus_panes,
         .last_focus_count = initial_focus_count,
         .split_resize_step = config.split_resize_step,

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -54,6 +54,13 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         search.g_search = null;
     }
 
+    // Configure session finder from config
+    session_picker_ui.setFinderConfig(
+        ctx.session_finder_root,
+        ctx.session_finder_depth,
+        ctx.session_finder_show_hidden,
+    );
+
     // Apply initial grid offsets (statusbar/tab bar) and resize PTY
     publish.updateGridOffsets(ctx);
     publish.generateStatusbar(ctx);
@@ -179,6 +186,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         // Session picker input polling
         if (terminal.g_session_picker_active != 0) {
             _ = session_picker_ui.consumePickerInput(ctx);
+            session_picker_ui.tickFinder(ctx);
         }
 
         // Command palette input polling
@@ -348,7 +356,15 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
             }
         }
 
-        _ = posix.poll(fds[0..nfds], 16) catch break;
+        // Drain any buffered paste data before polling — this interleaves
+        // writing paste input with reading shell output, preventing deadlock
+        // when the kernel PTY buffer fills in both directions.
+        input.drainPasteBuffer();
+
+        // Shorten poll timeout when there's still pending paste data so we
+        // drain it promptly instead of waiting the full 16ms.
+        const poll_timeout: i32 = if (input.hasPendingPaste()) 1 else 16;
+        _ = posix.poll(fds[0..nfds], poll_timeout) catch break;
 
         var got_data = false;
         const active_focused_pane = ctx.tab_mgr.activePane();

--- a/src/app/ui/input.zig
+++ b/src/app/ui/input.zig
@@ -314,6 +314,82 @@ pub fn popupHandleKey(key_raw: u16, mods_raw: u8, event_type_raw: u8, codepoint_
     }
 }
 
+// ---------------------------------------------------------------------------
+// Async paste buffer — large writes are queued here so the main thread
+// doesn't block.  The PTY reader thread drains it via drainPasteBuffer().
+// ---------------------------------------------------------------------------
+
+const paste_buf_cap: usize = 4 * 1024 * 1024; // 4 MB max buffered paste
+var paste_buf: ?[]u8 = null;
+var paste_len: usize = 0;
+var paste_offset: usize = 0;
+var paste_fd: posix.fd_t = -1;
+var paste_mutex: std.Thread.Mutex = .{};
+
+fn pasteAlloc() []u8 {
+    if (paste_buf) |b| return b;
+    paste_buf = std.heap.page_allocator.alloc(u8, paste_buf_cap) catch return &[0]u8{};
+    return paste_buf.?;
+}
+
+/// Enqueue data for async write.  Returns true if buffered successfully.
+fn enqueuePaste(fd: posix.fd_t, data: []const u8) bool {
+    paste_mutex.lock();
+    defer paste_mutex.unlock();
+
+    const buf = pasteAlloc();
+    if (buf.len == 0) return false;
+
+    // If there's already pending data for a different fd, flush concept doesn't
+    // apply — just overwrite (shouldn't happen in practice).
+    if (paste_len > 0 and paste_fd != fd) {
+        paste_len = 0;
+        paste_offset = 0;
+    }
+
+    const avail = buf.len - paste_len;
+    if (data.len > avail) return false;
+
+    @memcpy(buf[paste_len..][0..data.len], data);
+    paste_len += data.len;
+    paste_fd = fd;
+    return true;
+}
+
+/// Called from the PTY reader thread to drain buffered paste data.
+/// Writes as much as the PTY will accept without blocking, then returns.
+pub fn drainPasteBuffer() void {
+    paste_mutex.lock();
+    defer paste_mutex.unlock();
+
+    if (paste_len == 0) return;
+    const buf = paste_buf orelse return;
+    const fd = paste_fd;
+
+    while (paste_offset < paste_len) {
+        const remaining = buf[paste_offset..paste_len];
+        const chunk = remaining[0..@min(remaining.len, 4096)];
+        const n = posix.write(fd, chunk) catch |err| {
+            if (err == error.WouldBlock) return; // try again next tick
+            // Fatal write error — discard remaining paste
+            paste_len = 0;
+            paste_offset = 0;
+            return;
+        };
+        paste_offset += n;
+    }
+
+    // Fully drained
+    paste_len = 0;
+    paste_offset = 0;
+}
+
+pub fn hasPendingPaste() bool {
+    paste_mutex.lock();
+    defer paste_mutex.unlock();
+    return paste_len > 0;
+}
+
 pub fn sendInput(bytes: [*]const u8, len: c_int) void {
     if (len <= 0) return;
     const data = bytes[0..@intCast(@as(c_uint, @bitCast(len)))];
@@ -324,19 +400,47 @@ pub fn sendInput(bytes: [*]const u8, len: c_int) void {
         return;
     }
 
-    if (terminal.g_pty_master < 0) return;
+    const fd = terminal.g_pty_master;
+    if (fd < 0) return;
+
+    // If there's already buffered paste data, append to the buffer to
+    // preserve ordering (e.g. bracketed paste markers must follow data).
+    if (hasPendingPaste()) {
+        if (enqueuePaste(fd, data)) return;
+        // Buffer full — fall through to blocking write
+    }
+
+    // Try to write directly (non-blocking).
     const chunk_size: usize = 4096;
     var offset: usize = 0;
     while (offset < data.len) {
         const end = @min(offset + chunk_size, data.len);
-        const n = posix.write(terminal.g_pty_master, data[offset..end]) catch |err| {
-            if (err == error.WouldBlock) {
-                posix.nanosleep(0, 1_000_000);
-                continue;
-            }
+        const n = posix.write(fd, data[offset..end]) catch |err| {
+            if (err == error.WouldBlock) break;
             return;
         };
         offset += n;
+        // For large writes, only do one direct chunk then switch to async
+        // to avoid blocking the main thread.
+        if (data.len > chunk_size) break;
+    }
+
+    // Buffer whatever remains for the PTY thread to drain
+    if (offset < data.len) {
+        if (!enqueuePaste(fd, data[offset..])) {
+            // Buffer full — fall back to blocking write as last resort.
+            while (offset < data.len) {
+                const end = @min(offset + chunk_size, data.len);
+                const n = posix.write(fd, data[offset..end]) catch |err| {
+                    if (err == error.WouldBlock) {
+                        posix.nanosleep(0, 1_000_000);
+                        continue;
+                    }
+                    return;
+                };
+                offset += n;
+            }
+        }
     }
 }
 

--- a/src/app/ui/session_picker_ui.zig
+++ b/src/app/ui/session_picker_ui.zig
@@ -18,8 +18,13 @@ const attyx = @import("attyx");
 const picker_state_mod = attyx.overlay_session_picker;
 const SessionPickerState = picker_state_mod.SessionPickerState;
 const picker_panel = attyx.overlay_session_picker_panel;
+const FinderState = attyx.finder.FinderState;
 
 var g_picker_state: ?SessionPickerState = null;
+var g_finder_state: ?FinderState = null;
+var g_finder_root: []const u8 = "~";
+var g_finder_depth: u8 = 4;
+var g_finder_show_hidden: bool = false;
 
 pub fn openSessionPicker(ctx: *PtyThreadCtx) void {
     // Close existing popup if any
@@ -68,13 +73,27 @@ pub fn openSessionPicker(ctx: *PtyThreadCtx) void {
     g_picker_state = state;
     @atomicStore(i32, &terminal.g_session_picker_active, 1, .seq_cst);
 
+    // Init finder for filesystem search
+    if (g_finder_state != null) {
+        g_finder_state.?.deinit();
+        g_finder_state = null;
+    }
+    g_finder_state = FinderState.init(ctx.allocator, g_finder_root, g_finder_depth, g_finder_show_hidden) catch null;
+
     renderAndPublish(ctx);
     logging.info("session-picker", "opened overlay picker", .{});
 }
 
+/// Configure finder parameters (called when config is loaded/reloaded).
+pub fn setFinderConfig(root: []const u8, depth: u8, show_hidden: bool) void {
+    g_finder_root = root;
+    g_finder_depth = depth;
+    g_finder_show_hidden = show_hidden;
+}
+
 /// Drain picker input rings and process actions. Returns true if any input consumed.
 pub fn consumePickerInput(ctx: *PtyThreadCtx) bool {
-    var state = &(g_picker_state orelse return false);
+    const state = &(g_picker_state orelse return false);
     var consumed = false;
 
     // Drain char ring
@@ -103,8 +122,79 @@ pub fn consumePickerInput(ctx: *PtyThreadCtx) bool {
         if (processAction(ctx, state, action)) return true;
     }
 
-    if (consumed) renderAndPublish(ctx);
+    if (consumed) {
+        // Update finder with current filter text
+        if (g_finder_state) |*finder| {
+            finder.updateQuery(state.filter_buf[0..state.filter_len]);
+            pushFinderResults(state, finder);
+        }
+        renderAndPublish(ctx);
+    }
     return consumed;
+}
+
+/// Tick the finder — called from the event loop to process directory walking.
+pub fn tickFinder(ctx: *PtyThreadCtx) void {
+    const state = &(g_picker_state orelse return);
+    const finder = &(g_finder_state orelse return);
+
+    if (finder.walking_done) return;
+
+    finder.tick() catch return;
+
+    // If we have an active query, push updated results
+    if (state.filter_len > 0) {
+        const old_count = state.fs_count;
+        pushFinderResults(state, finder);
+        if (state.fs_count != old_count) {
+            renderAndPublish(ctx);
+        }
+    }
+}
+
+fn pushFinderResults(state: *SessionPickerState, finder: *FinderState) void {
+    const query_active = state.filter_len > 0;
+    if (!query_active) {
+        state.fs_count = 0;
+        return;
+    }
+
+    const max_fs = picker_state_mod.max_fs_results;
+    // Fetch more than we need so we can skip dupes and still fill max_fs
+    const fetch_count = max_fs * 3;
+    const result_indices = finder.getResults(0, fetch_count);
+
+    var paths: [max_fs][]const u8 = undefined;
+    var scores: [max_fs]i32 = undefined;
+    var out: usize = 0;
+
+    for (result_indices, 0..) |idx, i| {
+        if (out >= max_fs) break;
+        const path = finder.getPath(idx);
+
+        // Deduplicate: skip if basename matches any existing session name
+        const basename = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep|
+            path[sep + 1 ..]
+        else
+            path;
+
+        if (matchesExistingSession(state, basename)) continue;
+
+        paths[out] = path;
+        scores[out] = finder.getScore(@intCast(i));
+        out += 1;
+    }
+
+    state.updateFsResults(paths[0..out], scores[0..out]);
+}
+
+fn matchesExistingSession(state: *const SessionPickerState, basename: []const u8) bool {
+    if (basename.len == 0) return false;
+    for (0..state.entry_count) |i| {
+        const name = state.entries[i].getName();
+        if (std.mem.eql(u8, name, basename)) return true;
+    }
+    return false;
 }
 
 /// Process a PickerAction returned by the state machine.
@@ -127,6 +217,28 @@ fn processAction(ctx: *PtyThreadCtx, state: *SessionPickerState, action: picker_
             const resolved = actions.resolveFocusedCwd(ctx, &osc7_buf);
             defer if (resolved.owned) if (resolved.cwd) |cwd| ctx.allocator.free(cwd);
             session_actions.doSessionCreate(ctx, resolved.cwd orelse "/tmp");
+            return true;
+        },
+        .create_session_at => |rel_path| {
+            // Build absolute path from finder root + relative path
+            var abs_buf: [512]u8 = undefined;
+            const finder = &(g_finder_state orelse {
+                closeSessionPicker(ctx);
+                return true;
+            });
+            const root = finder.getRootPath();
+            const abs_path = std.fmt.bufPrint(&abs_buf, "{s}/{s}", .{ root, rel_path }) catch {
+                closeSessionPicker(ctx);
+                return true;
+            };
+            // Copy to allocator since closeSessionPicker will deinit finder
+            const path_copy = ctx.allocator.dupe(u8, abs_path) catch {
+                closeSessionPicker(ctx);
+                return true;
+            };
+            closeSessionPicker(ctx);
+            session_actions.doSessionCreate(ctx, path_copy);
+            ctx.allocator.free(path_copy);
             return true;
         },
         .kill_session => |id| {
@@ -178,6 +290,10 @@ fn refreshList(ctx: *PtyThreadCtx, state: *SessionPickerState) void {
 }
 
 pub fn closeSessionPicker(ctx: *PtyThreadCtx) void {
+    if (g_finder_state) |*finder| {
+        finder.deinit();
+        g_finder_state = null;
+    }
     g_picker_state = null;
     @atomicStore(i32, &terminal.g_session_picker_active, 0, .seq_cst);
     if (ctx.overlay_mgr) |mgr| mgr.hide(.session_picker);
@@ -204,6 +320,7 @@ pub fn relayout(ctx: *PtyThreadCtx) void {
         .new = ctx.session_icon_new,
         .active = ctx.session_icon_active,
         .recent = ctx.session_icon_recent,
+        .folder = ctx.session_icon_folder,
     };
 
     const result = picker_panel.renderSessionPicker(
@@ -238,6 +355,7 @@ fn renderAndPublish(ctx: *PtyThreadCtx) void {
         .new = ctx.session_icon_new,
         .active = ctx.session_icon_active,
         .recent = ctx.session_icon_recent,
+        .folder = ctx.session_icon_folder,
     };
 
     const result = picker_panel.renderSessionPicker(

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -171,11 +171,17 @@ pub const AppConfig = struct {
 
     // [sessions]
     sessions_enabled: bool = false,
+    session_finder_root: []const u8 = "~",
+    session_finder_depth: u8 = 4,
+    session_finder_show_hidden: bool = false,
+    _owned_session_finder_root: ?[]const u8 = null,
     session_icon_filter: []const u8 = ">",
     session_icon_session: []const u8 = "",
     session_icon_new: []const u8 = "+",
     session_icon_active: []const u8 = "\xe2\x97\x8f",
     session_icon_recent: []const u8 = "\xe2\x97\x8b",
+    session_icon_folder: []const u8 = "\xe2\x96\xb8",
+    _owned_session_icon_folder: ?[]const u8 = null,
     _owned_session_icon_filter: ?[]const u8 = null,
     _owned_session_icon_session: ?[]const u8 = null,
     _owned_session_icon_new: ?[]const u8 = null,
@@ -217,6 +223,8 @@ pub const AppConfig = struct {
         if (self._owned_log_level) |s| alloc.free(s);
         if (self._owned_log_file)  |s| alloc.free(s);
         if (self._owned_working_directory) |s| alloc.free(s);
+        if (self._owned_session_finder_root) |s| alloc.free(s);
+        if (self._owned_session_icon_folder) |s| alloc.free(s);
         if (self._owned_session_icon_filter) |s| alloc.free(s);
         if (self._owned_session_icon_session) |s| alloc.free(s);
         if (self._owned_session_icon_new) |s| alloc.free(s);

--- a/src/config/config_parse.zig
+++ b/src/config/config_parse.zig
@@ -559,7 +559,39 @@ pub fn applyToml(allocator: std.mem.Allocator, content: []const u8, path: []cons
             return error.ConfigValidationError;
         }
     }
+    if (Lookup.get(root, "sessions", "root")) |v| {
+        if (v == .string) {
+            const dupe = try allocator.dupe(u8, v.string);
+            if (config._owned_session_finder_root) |old| allocator.free(old);
+            config.session_finder_root = dupe;
+            config._owned_session_finder_root = dupe;
+        } else {
+            std.debug.print("error: {s}: sessions.root must be a string\n", .{path});
+            return error.ConfigValidationError;
+        }
+    }
+    if (Lookup.get(root, "sessions", "finder_depth")) |v| {
+        if (v == .int) {
+            if (v.int < 1 or v.int > 8) {
+                std.debug.print("error: {s}: sessions.finder_depth must be between 1 and 8\n", .{path});
+                return error.ConfigValidationError;
+            }
+            config.session_finder_depth = @intCast(v.int);
+        } else {
+            std.debug.print("error: {s}: sessions.finder_depth must be an integer\n", .{path});
+            return error.ConfigValidationError;
+        }
+    }
+    if (Lookup.get(root, "sessions", "finder_show_hidden")) |v| {
+        if (v == .bool) {
+            config.session_finder_show_hidden = v.bool;
+        } else {
+            std.debug.print("error: {s}: sessions.finder_show_hidden must be a boolean\n", .{path});
+            return error.ConfigValidationError;
+        }
+    }
     inline for (.{
+        .{ "icon_folder", &config.session_icon_folder, &config._owned_session_icon_folder },
         .{ "icon_filter", &config.session_icon_filter, &config._owned_session_icon_filter },
         .{ "icon_session", &config.session_icon_session, &config._owned_session_icon_session },
         .{ "icon_new", &config.session_icon_new, &config._owned_session_icon_new },

--- a/src/finder/dir_walker.zig
+++ b/src/finder/dir_walker.zig
@@ -1,0 +1,245 @@
+/// Incremental recursive directory walker. Yields directory paths only (not files).
+/// Processes entries in batches to avoid blocking the event loop.
+const std = @import("std");
+
+pub const PathEntry = struct {
+    path: []const u8, // allocated, relative to root
+};
+
+const max_results: usize = 8192;
+const max_stack_depth: usize = 32;
+
+const skip_dirs = [_][]const u8{
+    ".git",
+    "node_modules",
+    ".cache",
+    "__pycache__",
+    "vendor",
+    ".venv",
+    "venv",
+    ".next",
+    "target",
+    "build",
+    "dist",
+    ".svn",
+    ".hg",
+    "zig-out",
+    "zig-cache",
+    ".zig-cache",
+    ".Trash",
+    "Library",
+};
+
+fn shouldSkip(name: []const u8) bool {
+    for (skip_dirs) |skip| {
+        if (std.mem.eql(u8, name, skip)) return true;
+    }
+    return false;
+}
+
+const StackEntry = struct {
+    dir: std.fs.Dir,
+    iter: std.fs.Dir.Iterator,
+    prefix: []const u8, // allocated path prefix for this level
+};
+
+pub const DirWalker = struct {
+    allocator: std.mem.Allocator,
+    entries: std.ArrayList(PathEntry),
+    stack: [max_stack_depth]?StackEntry,
+    stack_len: u8,
+    max_depth: u8,
+    show_hidden: bool,
+    done: bool,
+    root_path: []const u8, // allocated copy
+
+    pub fn init(allocator: std.mem.Allocator, root: []const u8, max_depth: u8, show_hidden: bool) !DirWalker {
+        // Expand ~ to $HOME
+        const resolved = if (root.len > 0 and root[0] == '~') blk: {
+            const home = std.posix.getenv("HOME") orelse "/";
+            if (root.len == 1) {
+                break :blk try allocator.dupe(u8, home);
+            } else {
+                break :blk try std.fmt.allocPrint(allocator, "{s}{s}", .{ home, root[1..] });
+            }
+        } else try allocator.dupe(u8, root);
+
+        var self = DirWalker{
+            .allocator = allocator,
+            .entries = .{},
+            .stack = .{null} ** max_stack_depth,
+            .stack_len = 0,
+            .max_depth = max_depth,
+            .show_hidden = show_hidden,
+            .done = false,
+            .root_path = resolved,
+        };
+
+        // Open root directory
+        const dir = std.fs.openDirAbsolute(resolved, .{ .iterate = true }) catch {
+            self.done = true;
+            return self;
+        };
+        const prefix = try allocator.dupe(u8, "");
+        self.stack[0] = .{
+            .dir = dir,
+            .iter = dir.iterate(),
+            .prefix = prefix,
+        };
+        self.stack_len = 1;
+
+        return self;
+    }
+
+    pub fn deinit(self: *DirWalker) void {
+        // Close all open dirs and free prefixes
+        for (0..self.stack_len) |i| {
+            if (self.stack[i]) |*entry| {
+                entry.dir.close();
+                self.allocator.free(entry.prefix);
+                self.stack[i] = null;
+            }
+        }
+        // Free all path entries
+        for (self.entries.items) |e| {
+            self.allocator.free(e.path);
+        }
+        self.entries.deinit(self.allocator);
+        self.allocator.free(self.root_path);
+    }
+
+    /// Process up to batch_size directory entries. Returns true if more work remains.
+    pub fn walkBatch(self: *DirWalker, batch_size: u32) !bool {
+        if (self.done) return false;
+
+        var processed: u32 = 0;
+        while (processed < batch_size) {
+            if (self.stack_len == 0) {
+                self.done = true;
+                return false;
+            }
+
+            const top_idx = self.stack_len - 1;
+            var top = &(self.stack[top_idx].?);
+
+            const maybe_entry = top.iter.next() catch {
+                // Permission error or similar — pop this level
+                self.popStack();
+                continue;
+            };
+
+            if (maybe_entry) |entry| {
+                processed += 1;
+
+                // Skip non-directories
+                if (entry.kind != .directory) continue;
+
+                // Skip symlinks
+                if (entry.kind == .sym_link) continue;
+
+                const name = entry.name;
+
+                // Skip hidden dirs unless show_hidden is true
+                if (!self.show_hidden and name.len > 0 and name[0] == '.') continue;
+
+                // Skip known uninteresting dirs
+                if (shouldSkip(name)) continue;
+
+                // Build relative path
+                const rel_path = if (top.prefix.len == 0)
+                    try self.allocator.dupe(u8, name)
+                else
+                    try std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ top.prefix, name });
+
+                // Add to results
+                if (self.entries.items.len < max_results) {
+                    try self.entries.append(self.allocator, .{ .path = rel_path });
+                } else {
+                    self.allocator.free(rel_path);
+                    self.done = true;
+                    return false;
+                }
+
+                // Push subdirectory if within depth limit
+                const current_depth = self.stack_len;
+                if (current_depth < self.max_depth and self.stack_len < max_stack_depth) {
+                    const sub_dir = top.dir.openDir(name, .{ .iterate = true }) catch continue;
+                    const new_prefix = try self.allocator.dupe(u8, rel_path);
+                    self.stack[self.stack_len] = .{
+                        .dir = sub_dir,
+                        .iter = sub_dir.iterate(),
+                        .prefix = new_prefix,
+                    };
+                    self.stack_len += 1;
+                }
+            } else {
+                // Iterator exhausted — pop this level
+                self.popStack();
+            }
+        }
+
+        return self.stack_len > 0;
+    }
+
+    fn popStack(self: *DirWalker) void {
+        if (self.stack_len == 0) return;
+        const idx = self.stack_len - 1;
+        if (self.stack[idx]) |*entry| {
+            entry.dir.close();
+            self.allocator.free(entry.prefix);
+            self.stack[idx] = null;
+        }
+        self.stack_len -= 1;
+    }
+
+    /// Return accumulated results so far.
+    pub fn results(self: *const DirWalker) []const PathEntry {
+        return self.entries.items;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "shouldSkip: known dirs" {
+    try std.testing.expect(shouldSkip(".git"));
+    try std.testing.expect(shouldSkip("node_modules"));
+    try std.testing.expect(shouldSkip("Library"));
+    try std.testing.expect(!shouldSkip("src"));
+    try std.testing.expect(!shouldSkip("my_project"));
+}
+
+test "init and deinit with nonexistent dir" {
+    const allocator = std.testing.allocator;
+    var walker = try DirWalker.init(allocator, "/nonexistent_path_12345", 3, false);
+    defer walker.deinit();
+    try std.testing.expect(walker.done);
+}
+
+test "walk /tmp with depth 1" {
+    const allocator = std.testing.allocator;
+    var walker = try DirWalker.init(allocator, "/tmp", 1, false);
+    defer walker.deinit();
+
+    // Process some entries
+    _ = try walker.walkBatch(100);
+    // Should have found some results (or none, if /tmp is empty)
+    // Just verify it doesn't crash
+    _ = walker.results();
+}
+
+test "batch incremental walking" {
+    const allocator = std.testing.allocator;
+    var walker = try DirWalker.init(allocator, "/tmp", 2, false);
+    defer walker.deinit();
+
+    // Walk in small batches
+    var total_batches: u32 = 0;
+    while (try walker.walkBatch(5)) {
+        total_batches += 1;
+        if (total_batches > 1000) break; // safety
+    }
+    // Just verify we terminate
+    try std.testing.expect(total_batches <= 1000);
+}

--- a/src/finder/finder.zig
+++ b/src/finder/finder.zig
@@ -1,0 +1,207 @@
+/// Top-level finder state machine. Combines directory walker + fuzzy matcher.
+/// Manages incremental walking, scoring, and sorted result presentation.
+const std = @import("std");
+const fuzzy_match = @import("fuzzy_match.zig");
+const dir_walker = @import("dir_walker.zig");
+const DirWalker = dir_walker.DirWalker;
+
+const batch_size: u32 = 200;
+
+pub const FinderState = struct {
+    allocator: std.mem.Allocator,
+    walker: DirWalker,
+    sorted_indices: std.ArrayList(u32),
+    sorted_scores: std.ArrayList(i32),
+    result_count: u32,
+    walking_done: bool,
+    query_buf: [128]u8,
+    query_len: u8,
+    last_scored_count: u32, // how many walker results we've scored so far
+
+    pub fn init(allocator: std.mem.Allocator, root: []const u8, max_depth: u8, show_hidden: bool) !FinderState {
+        return .{
+            .allocator = allocator,
+            .walker = try DirWalker.init(allocator, root, max_depth, show_hidden),
+            .sorted_indices = .{},
+            .sorted_scores = .{},
+            .result_count = 0,
+            .walking_done = false,
+            .query_buf = .{0} ** 128,
+            .query_len = 0,
+            .last_scored_count = 0,
+        };
+    }
+
+    pub fn deinit(self: *FinderState) void {
+        self.sorted_indices.deinit(self.allocator);
+        self.sorted_scores.deinit(self.allocator);
+        self.walker.deinit();
+    }
+
+    /// Process one batch of directory walking, score new entries against current query.
+    pub fn tick(self: *FinderState) !void {
+        if (!self.walking_done) {
+            const more = try self.walker.walkBatch(batch_size);
+            if (!more) self.walking_done = true;
+        }
+
+        // Score any new entries we haven't scored yet
+        const total = @as(u32, @intCast(self.walker.entries.items.len));
+        if (total > self.last_scored_count and self.query_len > 0) {
+            const query = self.query_buf[0..self.query_len];
+            const entries = self.walker.entries.items;
+
+            for (self.last_scored_count..total) |i| {
+                const path = entries[i].path;
+                if (fuzzy_match.matchScore(path, query)) |s| {
+                    try self.sorted_indices.append(self.allocator, @intCast(i));
+                    try self.sorted_scores.append(self.allocator, s);
+                    self.result_count += 1;
+                }
+            }
+            self.last_scored_count = total;
+
+            // Re-sort by score descending
+            self.sortResults();
+        } else if (self.query_len == 0) {
+            self.last_scored_count = total;
+        }
+    }
+
+    /// Rescore ALL entries against a new query, sort by score desc.
+    pub fn updateQuery(self: *FinderState, query: []const u8) void {
+        const len = @min(query.len, self.query_buf.len);
+        @memcpy(self.query_buf[0..len], query[0..len]);
+        self.query_len = @intCast(len);
+
+        // Clear existing results
+        self.sorted_indices.clearRetainingCapacity();
+        self.sorted_scores.clearRetainingCapacity();
+        self.result_count = 0;
+
+        if (len == 0) {
+            self.last_scored_count = @intCast(self.walker.entries.items.len);
+            return;
+        }
+
+        const q = self.query_buf[0..len];
+        const entries = self.walker.entries.items;
+
+        for (entries, 0..) |e, i| {
+            if (fuzzy_match.matchScore(e.path, q)) |s| {
+                self.sorted_indices.append(self.allocator, @intCast(i)) catch continue;
+                self.sorted_scores.append(self.allocator, s) catch continue;
+                self.result_count += 1;
+            }
+        }
+
+        self.last_scored_count = @intCast(entries.len);
+        self.sortResults();
+    }
+
+    /// Get a slice of sorted indices for display.
+    pub fn getResults(self: *const FinderState, offset: u32, count: u32) []const u32 {
+        if (self.result_count == 0) return &.{};
+        const start = @min(offset, self.result_count);
+        const end = @min(start + count, self.result_count);
+        return self.sorted_indices.items[start..end];
+    }
+
+    /// Get the path for a result index (index into walker entries).
+    pub fn getPath(self: *const FinderState, index: u32) []const u8 {
+        if (index >= self.walker.entries.items.len) return "";
+        return self.walker.entries.items[index].path;
+    }
+
+    /// Get score for a sorted position.
+    pub fn getScore(self: *const FinderState, sorted_pos: u32) i32 {
+        if (sorted_pos >= self.sorted_scores.items.len) return 0;
+        return self.sorted_scores.items[sorted_pos];
+    }
+
+    /// Get the root path this finder is walking.
+    pub fn getRootPath(self: *const FinderState) []const u8 {
+        return self.walker.root_path;
+    }
+
+    fn sortResults(self: *FinderState) void {
+        if (self.result_count <= 1) return;
+
+        const indices = self.sorted_indices.items;
+        const scores = self.sorted_scores.items;
+        const n = self.result_count;
+
+        // Insertion sort (good enough for interactive use)
+        var i: usize = 1;
+        while (i < n) : (i += 1) {
+            const tmp_idx = indices[i];
+            const tmp_score = scores[i];
+            var j: usize = i;
+            while (j > 0 and scores[j - 1] < tmp_score) {
+                indices[j] = indices[j - 1];
+                scores[j] = scores[j - 1];
+                j -= 1;
+            }
+            indices[j] = tmp_idx;
+            scores[j] = tmp_score;
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "init and deinit" {
+    const allocator = std.testing.allocator;
+    var finder = try FinderState.init(allocator, "/tmp", 2, false);
+    defer finder.deinit();
+    try std.testing.expect(!finder.walking_done);
+    try std.testing.expectEqual(@as(u32, 0), finder.result_count);
+}
+
+test "tick processes batches" {
+    const allocator = std.testing.allocator;
+    var finder = try FinderState.init(allocator, "/tmp", 1, false);
+    defer finder.deinit();
+
+    // Tick a few times
+    try finder.tick();
+    try finder.tick();
+    // Should terminate without error
+}
+
+test "updateQuery rescores" {
+    const allocator = std.testing.allocator;
+    var finder = try FinderState.init(allocator, "/tmp", 1, false);
+    defer finder.deinit();
+
+    // Walk first
+    try finder.tick();
+
+    // Update query
+    finder.updateQuery("nonexistent_xyz_query_12345");
+    // Very unlikely to match anything
+    try std.testing.expectEqual(@as(u32, 0), finder.result_count);
+
+    // Clear query
+    finder.updateQuery("");
+    try std.testing.expectEqual(@as(u32, 0), finder.result_count);
+}
+
+test "getResults with empty results" {
+    const allocator = std.testing.allocator;
+    var finder = try FinderState.init(allocator, "/tmp", 1, false);
+    defer finder.deinit();
+
+    const results = finder.getResults(0, 10);
+    try std.testing.expectEqual(@as(usize, 0), results.len);
+}
+
+test "getPath out of bounds" {
+    const allocator = std.testing.allocator;
+    var finder = try FinderState.init(allocator, "/tmp", 1, false);
+    defer finder.deinit();
+
+    try std.testing.expectEqualStrings("", finder.getPath(9999));
+}

--- a/src/finder/fuzzy_match.zig
+++ b/src/finder/fuzzy_match.zig
@@ -1,0 +1,181 @@
+/// Fuzzy matching and scoring for path-aware search.
+/// Pure, no allocations, no dependencies beyond std.
+const std = @import("std");
+
+pub const max_positions = 64;
+
+pub const Score = struct {
+    value: i32,
+    matched: bool,
+    positions: [max_positions]u8,
+    match_count: u8,
+};
+
+// Scoring constants (fzf-inspired, path-aware)
+const bonus_sequential: i32 = 16;
+const bonus_separator: i32 = 24;
+const bonus_first_char: i32 = 16;
+const penalty_gap: i32 = -3;
+const penalty_leading: i32 = -1;
+
+fn toLower(ch: u8) u8 {
+    return if (ch >= 'A' and ch <= 'Z') ch + 32 else ch;
+}
+
+fn isSeparator(ch: u8) bool {
+    return ch == '/' or ch == '-' or ch == '_' or ch == '.';
+}
+
+/// Full scoring with match positions.
+pub fn score(candidate: []const u8, query: []const u8) Score {
+    var result = Score{
+        .value = 0,
+        .matched = false,
+        .positions = undefined,
+        .match_count = 0,
+    };
+
+    if (query.len == 0) {
+        result.matched = true;
+        return result;
+    }
+    if (candidate.len == 0 or query.len > candidate.len) return result;
+    if (query.len > max_positions) return result;
+
+    // Try to find the best match using a greedy forward scan
+    var qi: usize = 0;
+    var positions: [max_positions]u8 = undefined;
+
+    for (candidate, 0..) |ch, ci| {
+        if (qi < query.len and toLower(ch) == toLower(query[qi])) {
+            if (ci <= std.math.maxInt(u8)) {
+                positions[qi] = @intCast(ci);
+            }
+            qi += 1;
+        }
+    }
+
+    if (qi < query.len) return result; // Not all query chars matched
+
+    result.matched = true;
+    result.match_count = @intCast(query.len);
+    @memcpy(result.positions[0..query.len], positions[0..query.len]);
+
+    // Calculate score
+    var s: i32 = 0;
+
+    // Leading gap penalty
+    s += @as(i32, @intCast(positions[0])) * penalty_leading;
+
+    for (0..query.len) |i| {
+        const pos = positions[i];
+
+        // First char bonus
+        if (pos == 0) {
+            s += bonus_first_char;
+        }
+
+        // Separator bonus: match right after a separator
+        if (pos > 0 and isSeparator(candidate[pos - 1])) {
+            s += bonus_separator;
+        }
+
+        // Sequential bonus
+        if (i > 0) {
+            const prev_pos = positions[i - 1];
+            if (pos == prev_pos + 1) {
+                s += bonus_sequential;
+            } else {
+                // Gap penalty between matches
+                const gap: i32 = @as(i32, @intCast(pos)) - @as(i32, @intCast(prev_pos)) - 1;
+                s += gap * penalty_gap;
+            }
+        }
+    }
+
+    result.value = s;
+    return result;
+}
+
+/// Simplified scoring: returns just the score or null if no match.
+pub fn matchScore(candidate: []const u8, query: []const u8) ?i32 {
+    const result = score(candidate, query);
+    if (!result.matched) return null;
+    return result.value;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "empty query matches everything" {
+    const result = score("anything", "");
+    try std.testing.expect(result.matched);
+    try std.testing.expectEqual(@as(u8, 0), result.match_count);
+}
+
+test "exact match" {
+    const result = score("hello", "hello");
+    try std.testing.expect(result.matched);
+    try std.testing.expectEqual(@as(u8, 5), result.match_count);
+    try std.testing.expect(result.value > 0);
+}
+
+test "prefix match scores higher than gap match" {
+    const prefix = score("project", "pro");
+    const gap = score("parador", "pro");
+    try std.testing.expect(prefix.matched);
+    try std.testing.expect(gap.matched);
+    try std.testing.expect(prefix.value > gap.value);
+}
+
+test "path boundary bonus" {
+    const boundary = score("src/finder", "finder");
+    const middle = score("pathfinder", "finder");
+    try std.testing.expect(boundary.matched);
+    try std.testing.expect(middle.matched);
+    try std.testing.expect(boundary.value > middle.value);
+}
+
+test "gap penalty" {
+    const tight = score("abc", "abc");
+    const gapped = score("axxbxxc", "abc");
+    try std.testing.expect(tight.matched);
+    try std.testing.expect(gapped.matched);
+    try std.testing.expect(tight.value > gapped.value);
+}
+
+test "no match returns false" {
+    const result = score("hello", "xyz");
+    try std.testing.expect(!result.matched);
+}
+
+test "case insensitive" {
+    const result = score("HelloWorld", "helloworld");
+    try std.testing.expect(result.matched);
+    try std.testing.expectEqual(@as(u8, 10), result.match_count);
+}
+
+test "query longer than candidate" {
+    const result = score("ab", "abc");
+    try std.testing.expect(!result.matched);
+}
+
+test "matchScore convenience" {
+    try std.testing.expect(matchScore("hello", "hel") != null);
+    try std.testing.expect(matchScore("hello", "xyz") == null);
+}
+
+test "separator chars all work" {
+    // All separator types should give bonus
+    const slash = score("a/b", "b");
+    const dash = score("a-b", "b");
+    const under = score("a_b", "b");
+    const dot = score("a.b", "b");
+    const none = score("axb", "b");
+
+    try std.testing.expect(slash.value > none.value);
+    try std.testing.expect(dash.value > none.value);
+    try std.testing.expect(under.value > none.value);
+    try std.testing.expect(dot.value > none.value);
+}

--- a/src/overlay/session_picker.zig
+++ b/src/overlay/session_picker.zig
@@ -19,10 +19,23 @@ pub const SessionEntry = struct {
     }
 };
 
+pub const max_fs_results = 8;
+
+pub const FsEntry = struct {
+    path_buf: [256]u8 = undefined,
+    path_len: u16 = 0,
+    score: i32 = 0,
+
+    pub fn getPath(self: *const FsEntry) []const u8 {
+        return self.path_buf[0..self.path_len];
+    }
+};
+
 pub const PickerAction = union(enum) {
     none,
     switch_session: u32,
     create_session: void,
+    create_session_at: []const u8,
     kill_session: u32,
     rename_session: struct { id: u32, name: []const u8 },
     close: void,
@@ -44,6 +57,10 @@ pub const SessionPickerState = struct {
     // Rename
     rename_buf: [64]u8 = .{0} ** 64,
     rename_len: u8 = 0,
+
+    // Filesystem results
+    fs_results: [max_fs_results]FsEntry = undefined,
+    fs_count: u8 = 0,
 
     // Context
     current_session_id: ?u32 = null,
@@ -173,14 +190,15 @@ pub const SessionPickerState = struct {
             },
             7 => return .close, // Escape
             8 => { // Enter
-                const total = self.totalCount();
-                if (self.selected == self.filtered_count) {
-                    return .create_session;
-                } else if (self.filtered_count > 0 and self.selected < self.filtered_count) {
+                if (self.selected < self.filtered_count) {
                     const e = &self.entries[self.filtered_indices[self.selected]];
                     return .{ .switch_session = e.id };
+                } else if (self.selected < self.filtered_count +| self.fs_count) {
+                    const fs_idx = self.selected - self.filtered_count;
+                    return .{ .create_session_at = self.fs_results[fs_idx].getPath() };
+                } else {
+                    return .create_session;
                 }
-                _ = total;
             },
             9 => self.moveUp(), // Up
             10 => self.moveDown(), // Down
@@ -228,9 +246,21 @@ pub const SessionPickerState = struct {
         }
     }
 
-    /// Total items = filtered sessions + 1 ("New session" entry).
+    /// Total items = filtered sessions + fs results + 1 ("New session" entry).
     pub fn totalCount(self: *const SessionPickerState) u8 {
-        return self.filtered_count +| 1;
+        return self.filtered_count +| self.fs_count +| 1;
+    }
+
+    /// Update filesystem results from the finder.
+    pub fn updateFsResults(self: *SessionPickerState, paths: []const []const u8, scores: []const i32) void {
+        const n: u8 = @intCast(@min(paths.len, max_fs_results));
+        for (0..n) |i| {
+            const plen = @min(paths[i].len, @as(usize, 256));
+            @memcpy(self.fs_results[i].path_buf[0..plen], paths[i][0..plen]);
+            self.fs_results[i].path_len = @intCast(plen);
+            self.fs_results[i].score = if (i < scores.len) scores[i] else 0;
+        }
+        self.fs_count = n;
     }
 
     pub fn applyFilter(self: *SessionPickerState) void {

--- a/src/overlay/session_picker_panel.zig
+++ b/src/overlay/session_picker_panel.zig
@@ -20,6 +20,7 @@ pub const Icons = struct {
     new: []const u8 = "+",
     active: []const u8 = "(active)",
     recent: []const u8 = "",
+    folder: []const u8 = "\xe2\x96\xb8",
 };
 
 pub fn renderSessionPicker(
@@ -35,7 +36,8 @@ pub fn renderSessionPicker(
     const tmp = arena.allocator();
 
     // Build menu items from state
-    var menu_items: [picker_state.max_entries + 1]Element.MenuItem = undefined;
+    const max_menu = picker_state.max_entries + picker_state.max_fs_results + 1;
+    var menu_items: [max_menu]Element.MenuItem = undefined;
     var menu_count: u16 = 0;
 
     const vis_start = state.scroll_offset;
@@ -75,6 +77,30 @@ pub fn renderSessionPicker(
             menu_items[menu_count] = .{
                 .label = label_copy,
                 .enabled = e.alive,
+            };
+        } else if (i < state.filtered_count +| state.fs_count) {
+            // Filesystem result entry
+            const fs_idx = i - state.filtered_count;
+            const fs_entry = &state.fs_results[fs_idx];
+            const fs_path = fs_entry.getPath();
+
+            var fs_buf: [280]u8 = undefined;
+            var fs_len: usize = 0;
+            if (icons.folder.len > 0) {
+                @memcpy(fs_buf[fs_len..][0..icons.folder.len], icons.folder);
+                fs_len += icons.folder.len;
+                fs_buf[fs_len] = ' ';
+                fs_len += 1;
+            }
+
+            const copy_len = @min(fs_path.len, fs_buf.len - fs_len);
+            @memcpy(fs_buf[fs_len..][0..copy_len], fs_path[0..copy_len]);
+            fs_len += copy_len;
+
+            const fs_copy = tmp.dupe(u8, fs_buf[0..fs_len]) catch "";
+            menu_items[menu_count] = .{
+                .label = fs_copy,
+                .enabled = true,
             };
         } else {
             // "New session" entry

--- a/src/root.zig
+++ b/src/root.zig
@@ -53,6 +53,10 @@ pub const overlay_session_picker_panel = @import("overlay/session_picker_panel.z
 pub const overlay_command_palette = @import("overlay/command_palette.zig");
 pub const overlay_command_palette_panel = @import("overlay/command_palette_panel.zig");
 
+pub const finder = @import("finder/finder.zig");
+pub const finder_match = @import("finder/fuzzy_match.zig");
+pub const finder_walker = @import("finder/dir_walker.zig");
+
 pub const version = @import("build_options").version;
 pub const env = @import("build_options").env;
 
@@ -132,4 +136,7 @@ test {
     _ = @import("overlay/session_picker_panel.zig");
     _ = @import("overlay/command_palette.zig");
     _ = @import("overlay/command_palette_panel.zig");
+    _ = @import("finder/fuzzy_match.zig");
+    _ = @import("finder/dir_walker.zig");
+    _ = @import("finder/finder.zig");
 }


### PR DESCRIPTION
## Fuzzy finder session picker

Adds a fuzzy-match directory finder to the session picker, so you can type a few characters and instantly jump to a project directory as a new session — no more `cd`-ing around.

### What's new

- **Fuzzy directory finder** — the session picker now walks directories under a configurable root (default `~`, depth 4) and matches your query with a fuzzy scoring algorithm (consecutive bonus, camelCase-aware, separator bonus). Results update as you type.
- **New config options** under `[sessions]`:
  - `finder_root` — root path to scan (default `~`)
  - `finder_depth` — max directory depth (default 4)
  - `finder_show_hidden` — include dotfiles/dotdirs (default false)
  - `icon_folder` — icon for folder results (default `▸`)
- **Incremental walker** — directory scanning happens in batches so the UI stays responsive even on large directory trees. Skips known noise dirs (`node_modules`, `.git`, `target`, `build`, etc).

### Paste fix (bonus)

Fixed a hang when pasting large text — the terminal would freeze because the main thread was blocked in a write-retry loop waiting for the PTY buffer to drain.

- **Local PTY path**: large pastes are now buffered and drained incrementally by the PTY reader thread instead of spin-waiting on the main thread
- **Daemon/session path**: large `pane_input` messages are chunked into 508-byte protocol messages; the daemon's PTY write now handles short writes and `WouldBlock` properly instead of silently truncating; socket writes handle short writes via `writeAll`

### Files changed

- `src/finder/` — new module: `dir_walker.zig`, `finder.zig`, `fuzzy_match.zig`
- `src/overlay/session_picker.zig`, `session_picker_panel.zig` — folder results in picker UI
- `src/app/ui/session_picker_ui.zig` — finder integration + input routing
- `src/app/ui/input.zig` — async paste buffer (local PTY path)
- `src/app/ui/event_loop.zig` — drain paste buffer from PTY thread
- `src/app/session_client.zig` — chunked `sendPaneInput`, `writeAll` for socket
- `src/app/daemon/pane.zig` — proper short-write handling in `writeInput`
- `src/config/` — new session finder config fields