### PR TITLE
Fix theme passthrough for TUI apps

### DIFF
--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -48,14 +48,18 @@ pub const DaemonClient = struct {
     pub fn nextMessage(self: *DaemonClient) ?Message {
         if (self.read_len < protocol.header_size) return null;
 
+        // Read payload length from header (first 4 bytes) before decoding
+        // the message type, so we can skip unknown messages cleanly.
+        const payload_len = std.mem.readInt(u32, self.read_buf[0..4], .little);
+        const total = protocol.header_size + payload_len;
+        if (self.read_len < total) return null;
+
         const header = protocol.decodeHeader(self.read_buf[0..protocol.header_size]) catch {
-            // Invalid header — skip one byte and try again
-            self.consumeBytes(1);
+            // Unknown message type — skip the entire message (header + payload)
+            // to keep the stream in sync.
+            self.consumeBytes(total);
             return null;
         };
-
-        const total = protocol.header_size + header.payload_len;
-        if (self.read_len < total) return null;
 
         const payload = self.read_buf[protocol.header_size..total];
         // Copy payload to stable msg_buf before consuming,

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -42,6 +42,7 @@ pub fn handleMessage(
         .pane_input => handlePaneInput(cl, msg.payload, sessions),
         .pane_resize => handlePaneResize(cl, msg.payload, sessions),
         .save_layout => handleSaveLayout(cl, msg.payload, sessions, clients),
+        .set_theme_colors => handleSetThemeColors(cl, msg.payload, sessions),
 
         // Ignore server→client messages
         else => {},
@@ -297,6 +298,24 @@ fn handleFocusPanes(
                 cl.sendPaneReplay(pane);
                 cl.sendReplayEnd(new_id);
             }
+        }
+    }
+}
+
+fn handleSetThemeColors(
+    cl: *DaemonClient,
+    payload: []const u8,
+    sessions: *[max_sessions]?DaemonSession,
+) void {
+    const msg = protocol.decodeThemeColors(payload) catch return;
+    const session = getAttachedSession(cl, sessions) orelse return;
+    // Apply to all panes in the session
+    for (&session.panes) |*slot| {
+        if (slot.*) |*pane| {
+            pane.theme_fg = msg.fg;
+            pane.theme_bg = msg.bg;
+            pane.theme_cursor = msg.cursor;
+            pane.theme_cursor_set = msg.cursor_set;
         }
     }
 }

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -28,6 +28,13 @@ pub const DaemonPane = struct {
     osc7337_path: [2048]u8 = .{0} ** 2048,
     osc7337_path_len: u16 = 0,
 
+    /// Theme colors for OSC 10/11/12/4 query responses.
+    /// Defaults match Theme.default(). Updated by the client via protocol.
+    theme_fg: [3]u8 = .{ 220, 220, 220 },
+    theme_bg: [3]u8 = .{ 30, 30, 36 },
+    theme_cursor: [3]u8 = .{ 220, 220, 220 },
+    theme_cursor_set: bool = false,
+
     /// Restore a pane from deserialized state (inherited PTY fd across exec).
     pub fn fromRestored(
         allocator: std.mem.Allocator,
@@ -332,6 +339,65 @@ pub const DaemonPane = struct {
                 }
             }
 
+            // OSC sequences: ESC ] <num> ; ? <terminator>
+            if (data[i + 1] == ']') {
+                var j = i + 2;
+                // Parse OSC number
+                var osc_num: u16 = 0;
+                var has_osc_digits = false;
+                while (j < data.len and data[j] >= '0' and data[j] <= '9') : (j += 1) {
+                    osc_num = osc_num *% 10 +% @as(u16, data[j] - '0');
+                    has_osc_digits = true;
+                }
+                if (has_osc_digits and j < data.len and data[j] == ';') {
+                    j += 1; // skip ';'
+                    // Find terminator to get the rest payload
+                    const payload_start = j;
+                    var term_end: usize = j;
+                    var found_term = false;
+                    while (term_end < data.len) : (term_end += 1) {
+                        if (data[term_end] == 0x07) {
+                            found_term = true;
+                            break;
+                        }
+                        if (data[term_end] == '\x1b' and term_end + 1 < data.len and data[term_end + 1] == '\\') {
+                            found_term = true;
+                            break;
+                        }
+                    }
+                    if (found_term) {
+                        const rest = data[payload_start..term_end];
+                        const advanced = if (data[term_end] == 0x07) term_end + 1 else term_end + 2;
+                        switch (osc_num) {
+                            10 => if (std.mem.eql(u8, rest, "?")) {
+                                self.respondOscColor(10, self.theme_fg);
+                                i = advanced;
+                                continue;
+                            },
+                            11 => if (std.mem.eql(u8, rest, "?")) {
+                                self.respondOscColor(11, self.theme_bg);
+                                i = advanced;
+                                continue;
+                            },
+                            12 => if (std.mem.eql(u8, rest, "?")) {
+                                const c = if (self.theme_cursor_set) self.theme_cursor else self.theme_fg;
+                                self.respondOscColor(12, c);
+                                i = advanced;
+                                continue;
+                            },
+                            4 => {
+                                // OSC 4;N;? — palette query
+                                if (self.parseAndRespondPaletteQuery(rest)) {
+                                    i = advanced;
+                                    continue;
+                                }
+                            },
+                            else => {},
+                        }
+                    }
+                }
+            }
+
             i += 1;
         }
     }
@@ -347,6 +413,72 @@ pub const DaemonPane = struct {
         const resp = std.fmt.bufPrint(&buf, "\x1b[?{d};{d}$y", .{ mode, pm }) catch return;
         _ = self.pty.writeToPty(resp) catch {};
     }
+
+    /// Format and write an OSC color response: ESC ] <num> ; rgb:RRRR/GGGG/BBBB BEL.
+    /// Uses BEL (0x07) terminator for maximum compatibility — some libraries
+    /// (e.g. termbg, terminal-colorsaurus) only parse BEL-terminated responses.
+    fn respondOscColor(self: *DaemonPane, osc_num: u8, rgb: [3]u8) void {
+        var buf: [64]u8 = undefined;
+        const resp = std.fmt.bufPrint(&buf, "\x1b]{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}\x07", .{
+            osc_num,
+            rgb[0], rgb[0],
+            rgb[1], rgb[1],
+            rgb[2], rgb[2],
+        }) catch return;
+        _ = self.pty.writeToPty(resp) catch {};
+    }
+
+    /// Parse "N;?" from an OSC 4 payload and respond with the palette color.
+    fn parseAndRespondPaletteQuery(self: *DaemonPane, rest: []const u8) bool {
+        const semi = std.mem.indexOfScalar(u8, rest, ';') orelse return false;
+        if (!std.mem.eql(u8, rest[semi + 1 ..], "?")) return false;
+        const idx = std.fmt.parseInt(u8, rest[0..semi], 10) catch return false;
+        const rgb = paletteRgb(idx);
+        var buf: [64]u8 = undefined;
+        const resp = std.fmt.bufPrint(&buf, "\x1b]4;{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}\x07", .{
+            idx,
+            rgb[0], rgb[0],
+            rgb[1], rgb[1],
+            rgb[2], rgb[2],
+        }) catch return false;
+        _ = self.pty.writeToPty(resp) catch return false;
+        return true;
+    }
+
+    /// Standard 256-color palette lookup.
+    fn paletteRgb(n: u8) [3]u8 {
+        if (n < 16) return ansi16[n];
+        if (n < 232) {
+            const idx = n - 16;
+            return .{ cubeComp(idx / 36), cubeComp((idx / 6) % 6), cubeComp(idx % 6) };
+        }
+        const g: u8 = @intCast(@as(u16, 8) + @as(u16, n - 232) * 10);
+        return .{ g, g, g };
+    }
+
+    fn cubeComp(idx: u8) u8 {
+        if (idx == 0) return 0;
+        return @intCast(@as(u16, 55) + @as(u16, idx) * 40);
+    }
+
+    const ansi16 = [16][3]u8{
+        .{ 0, 0, 0 },
+        .{ 170, 0, 0 },
+        .{ 0, 170, 0 },
+        .{ 170, 85, 0 },
+        .{ 0, 0, 170 },
+        .{ 170, 0, 170 },
+        .{ 0, 170, 170 },
+        .{ 170, 170, 170 },
+        .{ 85, 85, 85 },
+        .{ 255, 85, 85 },
+        .{ 85, 255, 85 },
+        .{ 255, 255, 85 },
+        .{ 85, 85, 255 },
+        .{ 255, 85, 255 },
+        .{ 85, 255, 255 },
+        .{ 255, 255, 255 },
+    };
 
     pub fn deinit(self: *DaemonPane) void {
         self.pty.deinit();

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -20,6 +20,7 @@ pub const MessageType = enum(u8) {
     save_layout = 0x0D,
     rename = 0x0E,
     hello = 0x0F,
+    set_theme_colors = 0x10,
 
     // Daemon → Client
     created = 0x81,
@@ -500,6 +501,35 @@ pub fn decodeHello(payload: []const u8) ![]const u8 {
     const vlen = payload[0];
     if (payload.len < 1 + @as(usize, vlen)) return error.PayloadTooShort;
     return payload[1 .. 1 + vlen];
+}
+
+// ── Theme colors ──
+
+/// Encode SetThemeColors payload: fg[3], bg[3], cursor_set:u8, cursor[3] = 10 bytes
+pub fn encodeThemeColors(buf: []u8, fg: [3]u8, bg: [3]u8, cursor_set: bool, cursor: [3]u8) ![]u8 {
+    if (buf.len < 10) return error.BufferTooSmall;
+    @memcpy(buf[0..3], &fg);
+    @memcpy(buf[3..6], &bg);
+    buf[6] = if (cursor_set) 1 else 0;
+    @memcpy(buf[7..10], &cursor);
+    return buf[0..10];
+}
+
+pub const ThemeColorsMsg = struct {
+    fg: [3]u8,
+    bg: [3]u8,
+    cursor_set: bool,
+    cursor: [3]u8,
+};
+
+pub fn decodeThemeColors(payload: []const u8) !ThemeColorsMsg {
+    if (payload.len < 10) return error.PayloadTooShort;
+    return .{
+        .fg = payload[0..3].*,
+        .bg = payload[3..6].*,
+        .cursor_set = payload[6] != 0,
+        .cursor = payload[7..10].*,
+    };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/popup.zig
+++ b/src/app/popup.zig
@@ -399,6 +399,12 @@ fn resolveWithTheme(color: anytype, is_bg: bool, theme: *const Theme) color_mod.
             if (theme.palette[n]) |p| return .{ .r = p.r, .g = p.g, .b = p.b };
             return color_mod.resolve(color, is_bg);
         },
+        .palette => |n| {
+            if (n < 16) {
+                if (theme.palette[n]) |p| return .{ .r = p.r, .g = p.g, .b = p.b };
+            }
+            return color_mod.resolve(color, is_bg);
+        },
         else => return color_mod.resolve(color, is_bg),
     }
 }

--- a/src/app/pty.zig
+++ b/src/app/pty.zig
@@ -111,6 +111,7 @@ pub const Pty = struct {
                 _ = chdir(home);
 
             _ = setenv("TERM", "xterm-256color", 1);
+            _ = setenv("COLORTERM", "truecolor", 1);
             _ = setenv("TERM_PROGRAM", "attyx", 1);
             _ = setenv("ATTYX", "1", 1);
 

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -189,6 +189,13 @@ pub const SessionClient = struct {
     /// Send input to a specific pane.
     /// Large payloads are chunked to avoid blocking the main thread or
     /// truncating data on non-blocking sockets.
+    /// Push theme colors to the daemon so it can respond to OSC 10/11/12/4 queries.
+    pub fn sendThemeColors(self: *SessionClient, fg: [3]u8, bg: [3]u8, cursor_set: bool, cursor: [3]u8) !void {
+        var payload_buf: [16]u8 = undefined;
+        const payload = try protocol.encodeThemeColors(&payload_buf, fg, bg, cursor_set, cursor);
+        try self.sendMessage(.set_theme_colors, payload);
+    }
+
     pub fn sendPaneInput(self: *SessionClient, pane_id: u32, bytes: []const u8) !void {
         // Small input: encode and send in one message (fits in 512-byte buffer).
         if (bytes.len <= 508) {

--- a/src/app/split_render.zig
+++ b/src/app/split_render.zig
@@ -296,6 +296,12 @@ fn resolveWithTheme(color: anytype, is_bg: bool, theme: *const Theme) color_mod.
             if (theme.palette[n]) |p| return .{ .r = p.r, .g = p.g, .b = p.b };
             return color_mod.resolve(color, is_bg);
         },
+        .palette => |n| {
+            if (n < 16) {
+                if (theme.palette[n]) |p| return .{ .r = p.r, .g = p.g, .b = p.b };
+            }
+            return color_mod.resolve(color, is_bg);
+        },
         else => return color_mod.resolve(color, is_bg),
     }
 }

--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -432,6 +432,7 @@ pub fn run(
     initial_pane.* = try Pane.spawn(allocator, initial_pty_rows, config.cols, spawn_argv, null, config.scrollback_lines);
     initial_pane.engine.state.cursor_shape = publish.cursorShapeFromConfig(config.cursor_shape, config.cursor_blink);
     initial_pane.engine.state.reflow_on_resize = config.reflow_enabled;
+    initial_pane.engine.state.theme_colors = publish.themeToEngineColors(&initial_theme);
 
     // Transfer SessionClient to heap — shared by all panes via ctx.
     // Assign daemon_pane_id to the initial pane and send focus_panes.
@@ -643,6 +644,11 @@ pub fn run(
         .last_focus_count = initial_focus_count,
         .split_resize_step = config.split_resize_step,
     };
+
+    // Push theme colors to all pane engines (covers reconstructed daemon tabs too).
+    publish.publishThemeToEngines(&ctx);
+    // Push theme colors to daemon for direct OSC 10/11/12/4 response.
+    publish.publishThemeToDaemon(&ctx);
 
     const thread = try std.Thread.spawn(.{}, event_loop.ptyReaderThread, .{&ctx});
     defer thread.join();

--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -72,6 +72,7 @@ pub fn processTabActions(ctx: *PtyThreadCtx) void {
                 };
             }
             publish.updateGridTopOffset(ctx);
+            ctx.tab_mgr.activePane().engine.state.theme_colors = publish.themeToEngineColors(&ctx.active_theme);
             switchActiveTab(ctx);
             saveSessionLayout(ctx);
             logging.info("tabs", "new tab {d}/{d}", .{ ctx.tab_mgr.active + 1, ctx.tab_mgr.count });
@@ -467,6 +468,7 @@ pub fn processPopupToggle(ctx: *PtyThreadCtx) void {
                 ctx.allocator.destroy(ps);
                 return;
             };
+            ps.pane.engine.state.theme_colors = publish.themeToEngineColors(&ctx.active_theme);
             ps.config_index = @intCast(i);
             ctx.popup_state = ps;
             terminal.g_popup_pty_master = ps.pane.pty.master;
@@ -619,6 +621,8 @@ pub fn doReloadConfig(ctx: *PtyThreadCtx) void {
     ctx.active_theme = ctx.theme_registry.resolve(new_cfg.theme_name);
     if (new_cfg.theme_background) |bg| ctx.active_theme.background = bg;
     publish.publishTheme(&ctx.active_theme);
+    publish.publishThemeToEngines(ctx);
+    publish.publishThemeToDaemon(ctx);
 
     // Window properties
     {

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -405,6 +405,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                                             ) catch continue;
                                             result.pane.engine.deinit();
                                             result.pane.engine = new_engine;
+                                            result.pane.engine.state.theme_colors = publish.themeToEngineColors(&ctx.active_theme);
                                             result.pane.needs_engine_reinit = false;
                                         }
                                         if (result.pane == active_focused_pane) {
@@ -414,9 +415,9 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                                         if (result.tab_idx == ctx.tab_mgr.active) got_data = true;
                                         result.pane.engine.feed(out.data);
                                         // Discard engine responses — the daemon intercepts
-                                        // common queries (DA1, DECRPM, kitty keyboard, etc.)
-                                        // and responds directly to avoid round-trip latency
-                                        // that causes shells to echo stale responses as text.
+                                        // all queries (DA1, DECRPM, kitty keyboard, OSC
+                                        // color queries, etc.) and responds directly to
+                                        // avoid round-trip latency and duplicate responses.
                                         _ = result.pane.engine.state.drainResponse();
                                     }
                                 },

--- a/src/app/ui/publish.zig
+++ b/src/app/ui/publish.zig
@@ -409,6 +409,58 @@ pub fn publishTheme(theme: *const Theme) void {
     c.g_theme_bg_b = @intCast(theme.background.b);
 }
 
+/// Convert a Theme to ThemeColors for OSC 10/11/12/4 query responses.
+pub fn themeToEngineColors(theme: *const Theme) attyx.ThemeColors {
+    var tc: attyx.ThemeColors = .{
+        .fg = .{ .r = theme.foreground.r, .g = theme.foreground.g, .b = theme.foreground.b },
+        .bg = .{ .r = theme.background.r, .g = theme.background.g, .b = theme.background.b },
+    };
+    if (theme.cursor) |cur| {
+        tc.cursor = .{ .r = cur.r, .g = cur.g, .b = cur.b };
+    }
+    for (theme.palette, 0..) |opt, i| {
+        if (opt) |p| {
+            tc.palette[i] = .{ .r = p.r, .g = p.g, .b = p.b };
+        }
+    }
+    return tc;
+}
+
+/// Push theme colors to the daemon so it can respond to OSC 10/11/12 queries directly.
+pub fn publishThemeToDaemon(ctx: *PtyThreadCtx) void {
+    const sc = ctx.session_client orelse return;
+    if (sc.legacy_daemon) return;
+    const theme = &ctx.active_theme;
+    const cursor_set = theme.cursor != null;
+    const cursor_rgb = if (theme.cursor) |cur| [3]u8{ cur.r, cur.g, cur.b } else [3]u8{ 0, 0, 0 };
+    sc.sendThemeColors(
+        .{ theme.foreground.r, theme.foreground.g, theme.foreground.b },
+        .{ theme.background.r, theme.background.g, theme.background.b },
+        cursor_set,
+        cursor_rgb,
+    ) catch {};
+}
+
+/// Push theme colors to all pane engines across all tabs (+ popup).
+pub fn publishThemeToEngines(ctx: *PtyThreadCtx) void {
+    const tc = themeToEngineColors(&ctx.active_theme);
+    const tab_mgr = ctx.tab_mgr;
+    for (&tab_mgr.tabs) |*slot| {
+        if (slot.*) |*layout| {
+            for (&layout.pool) |*node| {
+                if (node.tag == .leaf) {
+                    if (node.pane) |pane| {
+                        pane.engine.state.theme_colors = tc;
+                    }
+                }
+            }
+        }
+    }
+    if (ctx.popup_state) |ps| {
+        ps.pane.engine.state.theme_colors = tc;
+    }
+}
+
 /// Resolve a cell color using the active theme for default fg/bg and ANSI palette.
 fn resolveWithTheme(color: anytype, is_bg: bool, theme: *const Theme) color_mod.Rgb {
     switch (color) {
@@ -418,6 +470,15 @@ fn resolveWithTheme(color: anytype, is_bg: bool, theme: *const Theme) color_mod.
         },
         .ansi => |n| {
             if (theme.palette[n]) |p| return .{ .r = p.r, .g = p.g, .b = p.b };
+            return color_mod.resolve(color, is_bg);
+        },
+        .palette => |n| {
+            // SGR 38;5;N for indices 0-15 should also use theme palette.
+            // Many TUI frameworks (crossterm/ratatui) emit 38;5;N even for
+            // basic ANSI colors, producing .palette instead of .ansi.
+            if (n < 16) {
+                if (theme.palette[n]) |p| return .{ .r = p.r, .g = p.g, .b = p.b };
+            }
             return color_mod.resolve(color, is_bg);
         },
         else => return color_mod.resolve(color, is_bg),

--- a/src/app/ui/session_actions.zig
+++ b/src/app/ui/session_actions.zig
@@ -174,6 +174,7 @@ pub fn spawnSessionPicker(ctx: *PtyThreadCtx) void {
         ctx.allocator.destroy(ps);
         return;
     };
+    ps.pane.engine.state.theme_colors = publish.themeToEngineColors(&ctx.active_theme);
     ps.config_index = 0;
     ctx.popup_state = ps;
     ctx.session_picker_active = true;

--- a/src/app/ui/split_actions.zig
+++ b/src/app/ui/split_actions.zig
@@ -73,6 +73,13 @@ pub fn doSplit(ctx: *PtyThreadCtx, layout: *SplitLayout, dir: split_layout_mod.D
         layout.splitPaneResolved(dir, ctx.allocator, resolved.cwd, ctx.applied_scrollback_lines) catch return;
     }
 
+    // Set theme colors on the newly created pane's engine.
+    if (layout.focused != 0xFF) {
+        if (layout.pool[layout.focused].pane) |pane| {
+            pane.engine.state.theme_colors = publish.themeToEngineColors(&ctx.active_theme);
+        }
+    }
+
     const pty_rows: u16 = @intCast(@max(1, @as(i32, ctx.grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
     layout.layout(pty_rows, ctx.grid_cols);
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -76,6 +76,7 @@ pub const Style = grid.Style;
 pub const Parser = parser.Parser;
 pub const TerminalState = state.TerminalState;
 pub const Cursor = state.Cursor;
+pub const ThemeColors = state.ThemeColors;
 pub const Engine = engine.Engine;
 pub const MouseEvent = input.MouseEvent;
 pub const MouseButton = input.MouseButton;

--- a/src/term/actions.zig
+++ b/src/term/actions.zig
@@ -186,4 +186,16 @@ pub const Action = union(enum) {
     set_keypad_app_mode,
     /// ESC > — DECKPNM: switch keypad to normal (numeric) mode.
     reset_keypad_app_mode,
+
+    /// OSC 10/11/12 — query default foreground, background, or cursor color.
+    query_color: ColorQueryType,
+    /// OSC 4;N;? — query palette color at index N.
+    query_palette_color: u8,
+};
+
+/// Which color is being queried by an OSC 10/11/12 sequence.
+pub const ColorQueryType = enum {
+    foreground, // OSC 10
+    background, // OSC 11
+    cursor, // OSC 12
 };

--- a/src/term/parser.zig
+++ b/src/term/parser.zig
@@ -495,6 +495,15 @@ pub const Parser = struct {
         return .nop;
     }
 
+    /// Parse OSC 4;N;? — palette color query.
+    fn parseOscPaletteQuery(rest: []const u8) Action {
+        // Format: "N;?" where N is palette index 0–255
+        const semi = std.mem.indexOfScalar(u8, rest, ';') orelse return .nop;
+        if (!std.mem.eql(u8, rest[semi + 1 ..], "?")) return .nop;
+        const idx = std.fmt.parseInt(u8, rest[0..semi], 10) catch return .nop;
+        return .{ .query_palette_color = idx };
+    }
+
     fn dispatchOsc(self: *Parser) Action {
         if (self.osc_overflow) return .nop;
         const payload = self.osc_buf[0..self.osc_len];
@@ -515,8 +524,12 @@ pub const Parser = struct {
 
         return switch (num) {
             0, 1, 2 => .{ .set_title = rest },
+            4 => parseOscPaletteQuery(rest),
             7 => .{ .set_cwd = rest },
             8 => csi.makeOscHyperlink(rest),
+            10 => if (std.mem.eql(u8, rest, "?")) .{ .query_color = .foreground } else .nop,
+            11 => if (std.mem.eql(u8, rest, "?")) .{ .query_color = .background } else .nop,
+            12 => if (std.mem.eql(u8, rest, "?")) .{ .query_color = .cursor } else .nop,
             7337 => dispatchOsc7337(rest),
             else => .nop,
         };

--- a/src/term/state.zig
+++ b/src/term/state.zig
@@ -14,6 +14,16 @@ pub const Style = grid_mod.Style;
 pub const Action = actions_mod.Action;
 pub const ControlCode = actions_mod.ControlCode;
 
+/// Colors the terminal reports in response to OSC 10/11/12/4 queries.
+/// Set by the app layer from the active theme; defaults match the
+/// built-in renderer palette.
+pub const ThemeColors = struct {
+    fg: grid_mod.Color.Rgb = .{ .r = 220, .g = 220, .b = 220 },
+    bg: grid_mod.Color.Rgb = .{ .r = 30, .g = 30, .b = 36 },
+    cursor: ?grid_mod.Color.Rgb = null,
+    palette: [16]?grid_mod.Color.Rgb = .{null} ** 16,
+};
+
 pub const Cursor = struct {
     row: usize = 0,
     col: usize = 0,
@@ -93,6 +103,9 @@ pub const TerminalState = struct {
     /// Whether to reflow content on resize (configurable, default true).
     reflow_on_resize: bool = true,
 
+    /// Colors reported by OSC 10/11/12/4 queries (set from active theme).
+    theme_colors: ThemeColors = .{},
+
     /// When true, apply() drops all actions until a CR or LF arrives.
     /// Used to suppress the shell echo of injected commands.
     suppress_echo: bool = false,
@@ -159,7 +172,7 @@ pub const TerminalState = struct {
 
         // Clear wrap_next for cursor-moving actions.
         switch (action) {
-            .print, .nop, .sgr, .hyperlink_start, .hyperlink_end, .set_title, .set_cwd, .set_shell_path, .dec_private_mode, .device_status, .cursor_position_report, .device_attributes, .secondary_device_attributes, .set_cursor_shape, .query_dec_private_mode, .graphics_command, .kitty_push_flags, .kitty_pop_flags, .kitty_query_flags, .inject_into_main, .dcs_passthrough, .set_keypad_app_mode, .reset_keypad_app_mode => {},
+            .print, .nop, .sgr, .hyperlink_start, .hyperlink_end, .set_title, .set_cwd, .set_shell_path, .dec_private_mode, .device_status, .cursor_position_report, .device_attributes, .secondary_device_attributes, .set_cursor_shape, .query_dec_private_mode, .graphics_command, .kitty_push_flags, .kitty_pop_flags, .kitty_query_flags, .inject_into_main, .dcs_passthrough, .set_keypad_app_mode, .reset_keypad_app_mode, .query_color, .query_palette_color => {},
             else => {
                 self.wrap_next = false;
             },
@@ -269,6 +282,8 @@ pub const TerminalState = struct {
             .dcs_passthrough => {}, // handled by engine, never reaches here
             .set_keypad_app_mode => self.keypad_app_mode = true,
             .reset_keypad_app_mode => self.keypad_app_mode = false,
+            .query_color => |target| self.respondColorQuery(target),
+            .query_palette_color => |idx| self.respondPaletteColorQuery(idx),
         }
 
         // Mark old + new cursor rows dirty for cursor overlay movement.
@@ -542,6 +557,8 @@ pub const TerminalState = struct {
     pub const respondSecondaryDeviceAttributes = @import("state_report.zig").respondSecondaryDeviceAttributes;
     pub const respondDecRequestMode = @import("state_report.zig").respondDecRequestMode;
     pub const respondKittyFlags = @import("state_report.zig").respondKittyFlags;
+    pub const respondColorQuery = @import("state_report.zig").respondColorQuery;
+    pub const respondPaletteColorQuery = @import("state_report.zig").respondPaletteColorQuery;
 
     /// Drain the response buffer. Returns the pending response bytes and
     /// resets the buffer. Caller must write these to the PTY.

--- a/src/term/state_report.zig
+++ b/src/term/state_report.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
-const TerminalState = @import("state.zig").TerminalState;
+const state_mod = @import("state.zig");
+const TerminalState = state_mod.TerminalState;
+const actions_mod = @import("actions.zig");
+const grid_mod = @import("grid.zig");
 
 pub fn appendResponse(self: *TerminalState, data: []const u8) void {
     const avail = self.response_buf.len - self.response_len;
@@ -34,6 +37,169 @@ pub fn respondKittyFlags(self: *TerminalState) void {
     var buf: [32]u8 = undefined;
     const resp = std.fmt.bufPrint(&buf, "\x1b[?{d}u", .{flags}) catch return;
     self.appendResponse(resp);
+}
+
+/// Format an 8-bit color component as a 4-digit hex value (scaled to 16-bit).
+/// E.g. 0xFF → "ffff", 0x1e → "1e1e".
+fn fmtColorComponent(buf: *[4]u8, val: u8) []const u8 {
+    return std.fmt.bufPrint(buf, "{x:0>2}{x:0>2}", .{ val, val }) catch buf;
+}
+
+/// Respond to OSC 10 (fg), 11 (bg), or 12 (cursor) color query.
+pub fn respondColorQuery(self: *TerminalState, target: actions_mod.ColorQueryType) void {
+    const rgb: grid_mod.Color.Rgb = switch (target) {
+        .foreground => self.theme_colors.fg,
+        .background => self.theme_colors.bg,
+        .cursor => self.theme_colors.cursor orelse self.theme_colors.fg,
+    };
+    const osc_num: u8 = switch (target) {
+        .foreground => 10,
+        .background => 11,
+        .cursor => 12,
+    };
+    var rb: [4]u8 = undefined;
+    var gb: [4]u8 = undefined;
+    var bb: [4]u8 = undefined;
+    var buf: [64]u8 = undefined;
+    const resp = std.fmt.bufPrint(&buf, "\x1b]{d};rgb:{s}/{s}/{s}\x07", .{
+        osc_num,
+        fmtColorComponent(&rb, rgb.r),
+        fmtColorComponent(&gb, rgb.g),
+        fmtColorComponent(&bb, rgb.b),
+    }) catch return;
+    self.appendResponse(resp);
+}
+
+/// Respond to OSC 4;N;? palette color query.
+pub fn respondPaletteColorQuery(self: *TerminalState, idx: u8) void {
+    const rgb = resolvePaletteColor(self, idx);
+    var rb: [4]u8 = undefined;
+    var gb: [4]u8 = undefined;
+    var bb: [4]u8 = undefined;
+    var buf: [64]u8 = undefined;
+    const resp = std.fmt.bufPrint(&buf, "\x1b]4;{d};rgb:{s}/{s}/{s}\x07", .{
+        idx,
+        fmtColorComponent(&rb, rgb.r),
+        fmtColorComponent(&gb, rgb.g),
+        fmtColorComponent(&bb, rgb.b),
+    }) catch return;
+    self.appendResponse(resp);
+}
+
+/// Resolve a 256-color palette index to RGB, using theme overrides for 0-15.
+fn resolvePaletteColor(self: *TerminalState, idx: u8) grid_mod.Color.Rgb {
+    // Theme palette overrides for ANSI 0-15
+    if (idx < 16) {
+        if (self.theme_colors.palette[idx]) |p| return p;
+    }
+    // Fall back to standard 256-color palette
+    return resolve256(idx);
+}
+
+const ansi16 = [16]grid_mod.Color.Rgb{
+    .{ .r = 0, .g = 0, .b = 0 },
+    .{ .r = 170, .g = 0, .b = 0 },
+    .{ .r = 0, .g = 170, .b = 0 },
+    .{ .r = 170, .g = 85, .b = 0 },
+    .{ .r = 0, .g = 0, .b = 170 },
+    .{ .r = 170, .g = 0, .b = 170 },
+    .{ .r = 0, .g = 170, .b = 170 },
+    .{ .r = 170, .g = 170, .b = 170 },
+    .{ .r = 85, .g = 85, .b = 85 },
+    .{ .r = 255, .g = 85, .b = 85 },
+    .{ .r = 85, .g = 255, .b = 85 },
+    .{ .r = 255, .g = 255, .b = 85 },
+    .{ .r = 85, .g = 85, .b = 255 },
+    .{ .r = 255, .g = 85, .b = 255 },
+    .{ .r = 85, .g = 255, .b = 255 },
+    .{ .r = 255, .g = 255, .b = 255 },
+};
+
+fn cubeComponent(idx: u8) u8 {
+    if (idx == 0) return 0;
+    return @intCast(@as(u16, 55) + @as(u16, idx) * 40);
+}
+
+fn resolve256(n: u8) grid_mod.Color.Rgb {
+    if (n < 16) return ansi16[n];
+    if (n < 232) {
+        const i = n - 16;
+        return .{
+            .r = cubeComponent(i / 36),
+            .g = cubeComponent((i / 6) % 6),
+            .b = cubeComponent(i % 6),
+        };
+    }
+    const g: u8 = @intCast(@as(u16, 8) + @as(u16, n - 232) * 10);
+    return .{ .r = g, .g = g, .b = g };
+}
+
+test "respondColorQuery foreground" {
+    const t = std.testing;
+    var s = try TerminalState.init(t.allocator, 24, 80, 1);
+    defer s.deinit();
+    s.theme_colors.fg = .{ .r = 0xdc, .g = 0xdc, .b = 0xdc };
+    s.respondColorQuery(.foreground);
+    const resp = s.drainResponse().?;
+    try t.expectEqualStrings("\x1b]10;rgb:dcdc/dcdc/dcdc\x07", resp);
+}
+
+test "respondColorQuery background" {
+    const t = std.testing;
+    var s = try TerminalState.init(t.allocator, 24, 80, 1);
+    defer s.deinit();
+    s.theme_colors.bg = .{ .r = 0x1e, .g = 0x1e, .b = 0x24 };
+    s.respondColorQuery(.background);
+    const resp = s.drainResponse().?;
+    try t.expectEqualStrings("\x1b]11;rgb:1e1e/1e1e/2424\x07", resp);
+}
+
+test "respondColorQuery cursor fallback to fg" {
+    const t = std.testing;
+    var s = try TerminalState.init(t.allocator, 24, 80, 1);
+    defer s.deinit();
+    s.theme_colors.fg = .{ .r = 0xff, .g = 0x00, .b = 0xaa };
+    s.theme_colors.cursor = null;
+    s.respondColorQuery(.cursor);
+    const resp = s.drainResponse().?;
+    try t.expectEqualStrings("\x1b]12;rgb:ffff/0000/aaaa\x07", resp);
+}
+
+test "respondPaletteColorQuery with theme override" {
+    const t = std.testing;
+    var s = try TerminalState.init(t.allocator, 24, 80, 1);
+    defer s.deinit();
+    s.theme_colors.palette[1] = .{ .r = 0xcc, .g = 0x00, .b = 0x33 };
+    s.respondPaletteColorQuery(1);
+    const resp = s.drainResponse().?;
+    try t.expectEqualStrings("\x1b]4;1;rgb:cccc/0000/3333\x07", resp);
+}
+
+test "respondPaletteColorQuery standard fallback" {
+    const t = std.testing;
+    var s = try TerminalState.init(t.allocator, 24, 80, 1);
+    defer s.deinit();
+    // Index 0 with no theme override = standard black
+    s.respondPaletteColorQuery(0);
+    const resp = s.drainResponse().?;
+    try t.expectEqualStrings("\x1b]4;0;rgb:0000/0000/0000\x07", resp);
+}
+
+test "OSC 10 query via parser round-trip" {
+    const t = std.testing;
+    var s = try TerminalState.init(t.allocator, 24, 80, 1);
+    defer s.deinit();
+    s.theme_colors.fg = .{ .r = 0xab, .g = 0xcd, .b = 0xef };
+    // Feed OSC 10;? sequence: ESC ] 1 0 ; ? BEL
+    const seq = "\x1b]10;?\x07";
+    var p = @import("parser.zig").Parser{};
+    for (seq) |byte| {
+        if (p.next(byte)) |action| {
+            s.apply(action);
+        }
+    }
+    const resp = s.drainResponse().?;
+    try t.expectEqualStrings("\x1b]10;rgb:abab/cdcd/efef\x07", resp);
 }
 
 pub fn respondDecRequestMode(self: *TerminalState, mode: u16) void {


### PR DESCRIPTION
## Summary

- **Fix `.palette` color resolution** — TUI frameworks like crossterm/ratatui emit `SGR 38;5;N` (256-color mode) even for basic ANSI colors 0-15, producing `.palette` cells instead of `.ansi`. The theme palette mapping only handled `.ansi`, so apps like atuin showed default terminal colors instead of the configured theme palette.
- **Add OSC 10/11/12/4 color query support** — Apps can now query the terminal's foreground, background, cursor, and palette colors. Responses use the active theme.
- **Daemon-side OSC interception** — In session mode, the daemon intercepts color queries and responds directly from pane theme state, avoiding round-trip latency. A new `set_theme_colors` protocol message syncs the client's theme to daemon panes.
- **Protocol resilience** — Unknown message types now skip the full message (header + payload) instead of just 1 byte, preventing stream desync when a newer client talks to an older daemon.
- **Set `COLORTERM=truecolor`** in PTY environment for better app compatibility.