### PR TITLE
Fix fallback font sizing causing incorrect glyph rendering

### DIFF
--- a/src/app/linux_font.c
+++ b/src/app/linux_font.c
@@ -164,6 +164,7 @@ GlyphCache createGlyphCache(FT_Library ft_lib, float contentScale) {
     gc.ft_bold_italic  = loadStyledFace(ft_lib, family, fontSize, 1, 1);
     gc.glyph_w    = gw;
     gc.glyph_h    = gh;
+    gc.font_size  = fontSize;
     gc.scale      = contentScale;
     gc.ascender   = ascender;
     gc.baseline_y_offset = baseline_y_offset;

--- a/src/app/linux_glyph.c
+++ b/src/app/linux_glyph.c
@@ -197,7 +197,7 @@ int glyphCacheRasterize(GlyphCache* gc, uint32_t cp) {
             if (!fbPath) continue;
             FT_Face candidate;
             if (FT_New_Face(gc->ft_lib, fbPath, 0, &candidate) == 0) {
-                FT_Set_Pixel_Sizes(candidate, 0, (int)gc->glyph_h);
+                FT_Set_Pixel_Sizes(candidate, 0, gc->font_size);
                 FT_UInt cgi = FT_Get_Char_Index(candidate, baseCp);
                 if (cgi != 0) {
                     gi = cgi;
@@ -224,7 +224,7 @@ int glyphCacheRasterize(GlyphCache* gc, uint32_t cp) {
                 FcPatternGetString(match, FC_FILE, 0, &file);
                 FcPatternGetInteger(match, FC_INDEX, 0, &index);
                 if (FT_New_Face(gc->ft_lib, (char*)file, index, &fallback) == 0) {
-                    FT_Set_Pixel_Sizes(fallback, 0, (int)gc->glyph_h);
+                    FT_Set_Pixel_Sizes(fallback, 0, gc->font_size);
                     gi = FT_Get_Char_Index(fallback, baseCp);
                     if (gi != 0) face = fallback;
                 }
@@ -235,12 +235,11 @@ int glyphCacheRasterize(GlyphCache* gc, uint32_t cp) {
         }
     }
 
-    // Block elements and braille patterns are drawn as geometry — no glyph needed.
+    // Block elements are drawn as geometry — no glyph needed.
     bool isBlock = (baseCp >= 0x2580 && baseCp <= 0x259F);
-    bool isBraille = (baseCp >= 0x2800 && baseCp <= 0x28FF);
 
-    // 2. If no glyph found and not a geometry-drawn char, return blank slot.
-    if (gi == 0 && !isBlock && !isBraille) {
+    // 2. If no glyph found and not a geometry-drawn block char, return blank slot.
+    if (gi == 0 && !isBlock) {
         if (face != gc->ft_face && face != gc->ft_bold && face != gc->ft_italic
             && face != gc->ft_bold_italic) FT_Done_Face(face);
         if (gc->next_slot >= gc->max_slots) glyphCacheGrow(gc);
@@ -267,7 +266,7 @@ int glyphCacheRasterize(GlyphCache* gc, uint32_t cp) {
                     || (baseCp >= 0x2500 && baseCp <= 0x257F);
     // isBlock declared above (needed before the early-return check)
     bool wide = false;
-    if (!isPowerline && !isBlock && !isBraille && canBeWide(baseCp)) {
+    if (!isPowerline && !isBlock && canBeWide(baseCp)) {
         int adv_px   = (int)(face->glyph->advance.x >> 6);
         int ink_right = face->glyph->bitmap_left + (int)bmp->width;
         int src_w    = adv_px > ink_right ? adv_px : ink_right;
@@ -440,63 +439,6 @@ int glyphCacheRasterize(GlyphCache* gc, uint32_t cp) {
                 }
             }
         }
-    } else if (isBraille) {
-        // Braille patterns U+2800–U+28FF: draw dots as geometry.
-        // Dot layout in a 2-column × 4-row grid:
-        //   [d1] [d4]    bits: 0, 3
-        //   [d2] [d5]    bits: 1, 4
-        //   [d3] [d6]    bits: 2, 5
-        //   [d7] [d8]    bits: 6, 7
-        int bits = (int)(baseCp - 0x2800);
-        if (bits > 0) {
-            // Dot positions: 2 columns, 4 rows within the cell.
-            // Use small padding so dots don't touch cell edges.
-            float padX = gw * 0.15f;
-            float padY = gh * 0.05f;
-            float dotAreaW = gw - 2 * padX;
-            float dotAreaH = gh - 2 * padY;
-            float colX[2] = { padX + dotAreaW * 0.25f, padX + dotAreaW * 0.75f };
-            float rowY[4] = {
-                padY + dotAreaH * 0.125f,
-                padY + dotAreaH * 0.375f,
-                padY + dotAreaH * 0.625f,
-                padY + dotAreaH * 0.875f
-            };
-            float dotR = fminf(dotAreaW * 0.22f, dotAreaH * 0.10f);
-            if (dotR < 1.0f) dotR = 1.0f;
-
-            // Dot-to-bit mapping: [row][col] → bit index
-            static const int dotBit[4][2] = {
-                {0, 3}, {1, 4}, {2, 5}, {6, 7}
-            };
-            for (int dr = 0; dr < 4; dr++) {
-                for (int dc = 0; dc < 2; dc++) {
-                    if (!(bits & (1 << dotBit[dr][dc]))) continue;
-                    float cx = colX[dc];
-                    float cy = rowY[dr];
-                    // Rasterize filled circle
-                    int iy0 = (int)(cy - dotR);
-                    int iy1 = (int)(cy + dotR + 1);
-                    int ix0 = (int)(cx - dotR);
-                    int ix1 = (int)(cx + dotR + 1);
-                    if (iy0 < 0) iy0 = 0;
-                    if (iy1 > gh) iy1 = gh;
-                    if (ix0 < 0) ix0 = 0;
-                    if (ix1 > gw) ix1 = gw;
-                    for (int dy = iy0; dy < iy1; dy++) {
-                        for (int dx = ix0; dx < ix1; dx++) {
-                            float dist = sqrtf((dx - cx) * (dx - cx) + (dy - cy) * (dy - cy));
-                            if (dist <= dotR + 0.5f) {
-                                uint8_t val = (dist <= dotR - 0.5f) ? 255
-                                    : (uint8_t)(255.0f * (dotR + 0.5f - dist));
-                                if (val > pixels[dy * gw + dx])
-                                    pixels[dy * gw + dx] = val;
-                            }
-                        }
-                    }
-                }
-            }
-        }
     } else {
         int bl    = face->glyph->bitmap_left;
         int bt    = face->glyph->bitmap_top;
@@ -557,7 +499,7 @@ int glyphCacheRasterizeCombined(GlyphCache* gc, uint32_t base, uint32_t c1, uint
             if (!fbPath) continue;
             FT_Face candidate;
             if (FT_New_Face(gc->ft_lib, fbPath, 0, &candidate) == 0) {
-                FT_Set_Pixel_Sizes(candidate, 0, (int)gc->glyph_h);
+                FT_Set_Pixel_Sizes(candidate, 0, gc->font_size);
                 FT_UInt cgi = FT_Get_Char_Index(candidate, base);
                 if (cgi != 0) {
                     baseIdx = cgi;
@@ -584,7 +526,7 @@ int glyphCacheRasterizeCombined(GlyphCache* gc, uint32_t base, uint32_t c1, uint
                 FcPatternGetString(match, FC_FILE, 0, &file);
                 FcPatternGetInteger(match, FC_INDEX, 0, &index);
                 if (FT_New_Face(gc->ft_lib, (char*)file, index, &fallbackFace) == 0) {
-                    FT_Set_Pixel_Sizes(fallbackFace, 0, (int)gc->glyph_h);
+                    FT_Set_Pixel_Sizes(fallbackFace, 0, gc->font_size);
                     baseIdx = FT_Get_Char_Index(fallbackFace, base);
                     if (baseIdx != 0) face = fallbackFace;
                 }

--- a/src/app/linux_internal.h
+++ b/src/app/linux_internal.h
@@ -168,6 +168,7 @@ typedef struct {
     FT_Face    ft_bold_italic;
     float      glyph_w;
     float      glyph_h;
+    int        font_size;       // primary font em-size in pixels (for fallback sizing)
     float      scale;
     float      ascender;
     float      baseline_y_offset;


### PR DESCRIPTION
Fixes #45 

## Summary
- Fallback fonts were loaded at `gc->glyph_h` (cell line height) instead of the primary font's em-size (`fontSize`), making all fallback-rendered glyphs oversized and misaligned
- This was most visible in tools like btop where braille patterns, symbols, and other chars from fallback fonts looked wrong compared to other terminal emulators
- Fix: store the primary font's pixel size in `GlyphCache.font_size` and use it consistently for all fallback font loading (both regular and combining mark paths)