### PR TITLE
fix: Config hotkey and statusbar search overlap

### DIFF
--- a/src/app/ui/dispatch.zig
+++ b/src/app/ui/dispatch.zig
@@ -264,9 +264,6 @@ extern fn execvp(file: [*:0]const u8, argv: [*]const ?[*:0]const u8) c_int;
 extern fn _exit(status: c_int) noreturn;
 
 fn openConfigInEditor() void {
-    const editor = std.posix.getenv("EDITOR") orelse
-        std.posix.getenv("VISUAL") orelse "vi";
-
     // Build config file path
     const home = std.posix.getenv("HOME") orelse return;
     const xdg = std.posix.getenv("XDG_CONFIG_HOME") orelse "";
@@ -285,15 +282,18 @@ fn openConfigInEditor() void {
         if (f) |file| file.close();
     }
 
+    // Use the platform's default file opener (open on macOS, xdg-open on Linux).
+    // This lets the OS pick the right editor and avoids issues with terminal
+    // editors needing a TTY that a GUI app doesn't have.
+    const opener = if (comptime @import("builtin").os.tag == .macos) "open" else "xdg-open";
+
     // Double-fork to avoid zombie
     const pid = posix.fork() catch return;
     if (pid == 0) {
         const pid2 = posix.fork() catch posix.abort();
         if (pid2 == 0) {
-            var editor_buf: [256]u8 = undefined;
-            const editor_z = std.fmt.bufPrintZ(&editor_buf, "{s}", .{editor}) catch posix.abort();
-            const argv = [_]?[*:0]const u8{ editor_z, config_path, null };
-            _ = execvp(editor_z, &argv);
+            const argv = [_]?[*:0]const u8{ opener, config_path, null };
+            _ = execvp(opener, &argv);
             posix.abort();
         }
         _exit(0);

--- a/src/app/ui/search.zig
+++ b/src/app/ui/search.zig
@@ -147,8 +147,8 @@ pub fn generateSearchBar(ctx: *PtyThreadCtx) void {
         .{},
     ) catch return;
 
-    // Place search bar below tab bar (if visible)
-    const search_row: u16 = if (ctx.tab_mgr.count > 1) 1 else 0;
+    // Place search bar below tab bar or statusbar (if visible at top)
+    const search_row: u16 = if (terminal.g_grid_top_offset > 1) 1 else 0;
     mgr.setContent(.search_bar, 0, search_row, result.width, result.height, result.cells) catch {
         mgr.allocator.free(result.cells);
         return;


### PR DESCRIPTION
This pull request updates how the configuration file is opened for editing and improves the placement logic for the search bar UI. The main changes focus on enhancing cross-platform compatibility and UI correctness.

**Platform integration and user experience improvements:**

* Changed the `openConfigInEditor` function in `dispatch.zig` to use the platform's default file opener (`open` on macOS, `xdg-open` on Linux) instead of relying on the `EDITOR` or `VISUAL` environment variables. This allows the OS to select the appropriate editor and avoids issues with terminal-based editors in GUI contexts. [[1]](diffhunk://#diff-81f8b464eafb015c275b526dc74521c11853a2f93c4a3750ff8981ea17ae3b6eL267-L269) [[2]](diffhunk://#diff-81f8b464eafb015c275b526dc74521c11853a2f93c4a3750ff8981ea17ae3b6eR285-R296)

**UI behavior improvements:**

* Updated the search bar placement logic in `search.zig` to position the search bar below the tab bar or status bar (if visible at the top), using `terminal.g_grid_top_offset` instead of the tab count for more accurate placement.