### PR TITLE
fix: Git icons config

### DIFF
--- a/src/app/git_widget.zig
+++ b/src/app/git_widget.zig
@@ -13,6 +13,9 @@ const max_color_spans = statusbar.max_color_spans;
 pub const GitStatus = struct {
     branch: [64]u8 = undefined,
     branch_len: u8 = 0,
+    oid: [40]u8 = undefined,
+    oid_len: u8 = 0,
+    detached: bool = false,
     ahead: u16 = 0,
     behind: u16 = 0,
     staged: u16 = 0,
@@ -20,38 +23,51 @@ pub const GitStatus = struct {
     untracked: u16 = 0,
     stashed: u16 = 0,
     conflict: u16 = 0,
+    insertions: u32 = 0,
+    deletions: u32 = 0,
 };
 
 const Icons = struct {
     branch: []const u8,
+    hashprefix: []const u8,
     ahead: []const u8,
     behind: []const u8,
     staged: []const u8,
     modified: []const u8,
     untracked: []const u8,
+    conflict: []const u8,
     stashed: []const u8,
     clean: []const u8,
+    insertions: []const u8,
+    deletions: []const u8,
 };
 
 const default_icons = Icons{
     .branch = "⎇ ",
+    .hashprefix = "#",
     .ahead = "↑·",
     .behind = "↓·",
     .staged = "● ",
     .modified = "✚ ",
     .untracked = "… ",
+    .conflict = "✖ ",
     .stashed = "⚑ ",
     .clean = " ✔",
+    .insertions = "+",
+    .deletions = "-",
 };
 
 const Colors = struct {
     staged: Rgb,
     modified: Rgb,
     untracked: Rgb,
+    conflict: Rgb,
     stashed: Rgb,
     ahead: Rgb,
     behind: Rgb,
     clean: Rgb,
+    insertions: Rgb,
+    deletions: Rgb,
 };
 
 /// Parse `git status --porcelain=v2 --branch` output into GitStatus.
@@ -63,9 +79,18 @@ pub fn parseGitStatus(stdout: []const u8) GitStatus {
 
         if (std.mem.startsWith(u8, line, "# branch.head ")) {
             const name = line["# branch.head ".len..];
-            const len = @min(name.len, status.branch.len);
-            @memcpy(status.branch[0..len], name[0..len]);
-            status.branch_len = @intCast(len);
+            if (std.mem.eql(u8, name, "(detached)")) {
+                status.detached = true;
+            } else {
+                const len = @min(name.len, status.branch.len);
+                @memcpy(status.branch[0..len], name[0..len]);
+                status.branch_len = @intCast(len);
+            }
+        } else if (std.mem.startsWith(u8, line, "# branch.oid ")) {
+            const oid = line["# branch.oid ".len..];
+            const len = @min(oid.len, status.oid.len);
+            @memcpy(status.oid[0..len], oid[0..len]);
+            status.oid_len = @intCast(len);
         } else if (std.mem.startsWith(u8, line, "# branch.ab ")) {
             // Format: "# branch.ab +N -M"
             const ab = line["# branch.ab ".len..];
@@ -108,22 +133,44 @@ pub fn countStashes(output: []const u8) u16 {
     return count;
 }
 
+/// Parse `git diff --numstat` output into total insertions/deletions.
+pub fn parseDiffNumstat(stdout: []const u8) struct { insertions: u32, deletions: u32 } {
+    var ins: u32 = 0;
+    var del: u32 = 0;
+    var iter = std.mem.splitScalar(u8, stdout, '\n');
+    while (iter.next()) |line| {
+        if (line.len == 0) continue;
+        var parts = std.mem.splitScalar(u8, line, '\t');
+        if (parts.next()) |i_str| {
+            ins += std.fmt.parseInt(u32, i_str, 10) catch continue;
+            if (parts.next()) |d_str| {
+                del += std.fmt.parseInt(u32, d_str, 10) catch 0;
+            }
+        }
+    }
+    return .{ .insertions = ins, .deletions = del };
+}
+
 /// Resolve icons: use config param overrides or fall back to defaults.
 fn resolveIcons(wc: *const StatusbarWidgetConfig) Icons {
     return .{
         .branch = wc.getParam("icon_branch") orelse default_icons.branch,
+        .hashprefix = wc.getParam("icon_hashprefix") orelse default_icons.hashprefix,
         .ahead = wc.getParam("icon_ahead") orelse default_icons.ahead,
         .behind = wc.getParam("icon_behind") orelse default_icons.behind,
         .staged = wc.getParam("icon_staged") orelse default_icons.staged,
         .modified = wc.getParam("icon_modified") orelse default_icons.modified,
         .untracked = wc.getParam("icon_untracked") orelse default_icons.untracked,
+        .conflict = wc.getParam("icon_conflict") orelse default_icons.conflict,
         .stashed = wc.getParam("icon_stashed") orelse default_icons.stashed,
         .clean = wc.getParam("icon_clean") orelse default_icons.clean,
+        .insertions = wc.getParam("icon_insertions") orelse default_icons.insertions,
+        .deletions = wc.getParam("icon_deletions") orelse default_icons.deletions,
     };
 }
 
 /// Parse a hex color string like "82c378" or "#82c378" into Rgb.
-fn parseHexColor(s: []const u8) ?Rgb {
+pub fn parseHexColor(s: []const u8) ?Rgb {
     const hex = if (s.len > 0 and s[0] == '#') s[1..] else s;
     if (hex.len != 6) return null;
     const r = std.fmt.parseInt(u8, hex[0..2], 16) catch return null;
@@ -143,10 +190,13 @@ fn resolveColors(wc: *const StatusbarWidgetConfig, pal: *const [16]Rgb) Colors {
         .staged = resolveColor(wc, "color_staged", pal[10]), // bright green
         .modified = resolveColor(wc, "color_modified", pal[11]), // bright yellow
         .untracked = resolveColor(wc, "color_untracked", pal[8]), // bright black
+        .conflict = resolveColor(wc, "color_conflict", pal[9]), // bright red
         .stashed = resolveColor(wc, "color_stashed", pal[14]), // bright cyan
         .ahead = resolveColor(wc, "color_ahead", pal[10]), // bright green
         .behind = resolveColor(wc, "color_behind", pal[9]), // bright red
         .clean = resolveColor(wc, "color_clean", pal[10]), // bright green
+        .insertions = resolveColor(wc, "color_insertions", pal[10]), // bright green
+        .deletions = resolveColor(wc, "color_deletions", pal[9]), // bright red
     };
 }
 
@@ -157,9 +207,15 @@ pub fn formatOutput(ws: *WidgetState, status: *const GitStatus, wc: *const Statu
     var pos: usize = 0;
     ws.span_count = 0;
 
-    // Branch icon + name (default fg, no span)
-    pos = appendSlice(&ws.output, pos, icons.branch);
-    pos = appendSlice(&ws.output, pos, status.branch[0..status.branch_len]);
+    // Branch icon + name, or hash prefix for detached HEAD
+    if (status.detached) {
+        pos = appendSlice(&ws.output, pos, icons.hashprefix);
+        const hash_len = @min(status.oid_len, 7);
+        pos = appendSlice(&ws.output, pos, status.oid[0..hash_len]);
+    } else {
+        pos = appendSlice(&ws.output, pos, icons.branch);
+        pos = appendSlice(&ws.output, pos, status.branch[0..status.branch_len]);
+    }
 
     const is_clean = status.staged == 0 and status.modified == 0 and
         status.untracked == 0 and status.conflict == 0;
@@ -181,7 +237,12 @@ pub fn formatOutput(ws: *WidgetState, status: *const GitStatus, wc: *const Statu
     pos = appendCountColored(&ws.output, pos, icons.staged, status.staged, colors.staged, &ws.color_spans, &ws.span_count);
     pos = appendCountColored(&ws.output, pos, icons.modified, status.modified, colors.modified, &ws.color_spans, &ws.span_count);
     pos = appendCountColored(&ws.output, pos, icons.untracked, status.untracked, colors.untracked, &ws.color_spans, &ws.span_count);
+    pos = appendCountColored(&ws.output, pos, icons.conflict, status.conflict, colors.conflict, &ws.color_spans, &ws.span_count);
     pos = appendCountColored(&ws.output, pos, icons.stashed, status.stashed, colors.stashed, &ws.color_spans, &ws.span_count);
+
+    // Insertions/deletions
+    pos = appendCountColored32(&ws.output, pos, icons.insertions, status.insertions, colors.insertions, &ws.color_spans, &ws.span_count);
+    pos = appendCountColored32(&ws.output, pos, icons.deletions, status.deletions, colors.deletions, &ws.color_spans, &ws.span_count);
 
     ws.output_len = @intCast(pos);
 }
@@ -198,6 +259,21 @@ fn appendCountColored(buf: []u8, pos: usize, icon: []const u8, count: u16, color
     const color_start = p;
     p = appendSlice(buf, p, icon);
     var num_buf: [8]u8 = undefined;
+    const num = std.fmt.bufPrint(&num_buf, "{d}", .{count}) catch return p;
+    p = appendSlice(buf, p, num);
+    if (p > color_start and span_count.* < max_color_spans) {
+        spans[span_count.*] = .{ .start = @intCast(color_start), .end = @intCast(p), .fg = color };
+        span_count.* += 1;
+    }
+    return p;
+}
+
+fn appendCountColored32(buf: []u8, pos: usize, icon: []const u8, count: u32, color: Rgb, spans: *[max_color_spans]ColorSpan, span_count: *u8) usize {
+    if (count == 0) return pos;
+    var p = appendSlice(buf, pos, " ");
+    const color_start = p;
+    p = appendSlice(buf, p, icon);
+    var num_buf: [12]u8 = undefined;
     const num = std.fmt.bufPrint(&num_buf, "{d}", .{count}) catch return p;
     p = appendSlice(buf, p, num);
     if (p > color_start and span_count.* < max_color_spans) {
@@ -255,227 +331,30 @@ pub fn refresh(ws: *WidgetState, wc: *const StatusbarWidgetConfig, allocator: st
         status.stashed = countStashes(stash_result.stdout);
     }
 
+    // Run git diff --numstat for insertions/deletions
+    const diff_result = std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "git", "diff", "--numstat" },
+        .cwd = cwd,
+        .max_output_bytes = 8192,
+    }) catch {
+        formatOutput(ws, &status, wc, ansi_palette);
+        return;
+    };
+    defer {
+        allocator.free(diff_result.stdout);
+        allocator.free(diff_result.stderr);
+    }
+
+    if (diff_result.term.Exited == 0) {
+        const diff = parseDiffNumstat(diff_result.stdout);
+        status.insertions = diff.insertions;
+        status.deletions = diff.deletions;
+    }
+
     formatOutput(ws, &status, wc, ansi_palette);
 }
 
-// -------------------------------------------------------------------------
-// Tests
-// -------------------------------------------------------------------------
-
-test "parseGitStatus: branch and ahead/behind" {
-    const input =
-        \\# branch.head main
-        \\# branch.ab +3 -1
-        \\
-    ;
-    const s = parseGitStatus(input);
-    try std.testing.expectEqualStrings("main", s.branch[0..s.branch_len]);
-    try std.testing.expectEqual(@as(u16, 3), s.ahead);
-    try std.testing.expectEqual(@as(u16, 1), s.behind);
-}
-
-test "parseGitStatus: staged and modified counts" {
-    const input =
-        \\# branch.head feature
-        \\1 M. N... 100644 100644 100644 abc123 def456 file1.zig
-        \\1 .M N... 100644 100644 100644 abc123 def456 file2.zig
-        \\1 MM N... 100644 100644 100644 abc123 def456 file3.zig
-        \\
-    ;
-    const s = parseGitStatus(input);
-    try std.testing.expectEqual(@as(u16, 2), s.staged); // M. and MM
-    try std.testing.expectEqual(@as(u16, 2), s.modified); // .M and MM
-}
-
-test "parseGitStatus: untracked and conflict" {
-    const input =
-        \\# branch.head dev
-        \\? newfile.txt
-        \\? another.txt
-        \\u UU N... 100644 100644 100644 100644 abc def ghi conflict.txt
-        \\
-    ;
-    const s = parseGitStatus(input);
-    try std.testing.expectEqual(@as(u16, 2), s.untracked);
-    try std.testing.expectEqual(@as(u16, 1), s.conflict);
-}
-
-test "parseGitStatus: rename entry" {
-    const input =
-        \\# branch.head main
-        \\2 R. N... 100644 100644 abc123 def456 R100 old.zig\tnew.zig
-        \\
-    ;
-    const s = parseGitStatus(input);
-    try std.testing.expectEqual(@as(u16, 1), s.staged); // R in index
-    try std.testing.expectEqual(@as(u16, 0), s.modified); // . in worktree
-}
-
-test "countStashes: counts lines" {
-    const input = "stash@{0}: WIP on main: abc123 message\nstash@{1}: WIP on main: def456 msg\n";
-    try std.testing.expectEqual(@as(u16, 2), countStashes(input));
-}
-
-test "countStashes: empty output" {
-    try std.testing.expectEqual(@as(u16, 0), countStashes(""));
-}
-
-test "formatOutput: clean repo shows branch + clean icon" {
-    var status = GitStatus{};
-    const branch = "main";
-    @memcpy(status.branch[0..branch.len], branch);
-    status.branch_len = branch.len;
-
-    const wc = StatusbarWidgetConfig{ .name = "git" };
-    var ws = WidgetState{};
-    formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
-    const output = ws.output[0..ws.output_len];
-    // Should contain branch icon, branch name, and clean icon
-    try std.testing.expect(std.mem.indexOf(u8, output, "main") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, default_icons.clean) != null);
-    // Should NOT contain dirty indicators
-    try std.testing.expect(std.mem.indexOf(u8, output, default_icons.modified) == null);
-}
-
-test "formatOutput: dirty repo shows counts" {
-    var status = GitStatus{};
-    const branch = "dev";
-    @memcpy(status.branch[0..branch.len], branch);
-    status.branch_len = branch.len;
-    status.staged = 3;
-    status.modified = 2;
-    status.untracked = 1;
-    status.ahead = 1;
-    status.behind = 2;
-    status.stashed = 1;
-
-    const wc = StatusbarWidgetConfig{ .name = "git" };
-    var ws = WidgetState{};
-    formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
-    const output = ws.output[0..ws.output_len];
-
-    try std.testing.expect(std.mem.indexOf(u8, output, "dev") != null);
-    // Clean icon should NOT appear
-    try std.testing.expect(std.mem.indexOf(u8, output, default_icons.clean) == null);
-    // Counts should appear
-    try std.testing.expect(std.mem.indexOf(u8, output, "3") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "2") != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, "1") != null);
-}
-
-test "formatOutput: omits zero-count sections" {
-    var status = GitStatus{};
-    const branch = "main";
-    @memcpy(status.branch[0..branch.len], branch);
-    status.branch_len = branch.len;
-    status.modified = 5; // only modified
-
-    const wc = StatusbarWidgetConfig{ .name = "git" };
-    var ws = WidgetState{};
-    formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
-    const output = ws.output[0..ws.output_len];
-
-    // Modified should appear, but not staged/untracked/stashed icons
-    try std.testing.expect(std.mem.indexOf(u8, output, default_icons.modified) != null);
-    try std.testing.expect(std.mem.indexOf(u8, output, default_icons.staged) == null);
-    try std.testing.expect(std.mem.indexOf(u8, output, default_icons.untracked) == null);
-    try std.testing.expect(std.mem.indexOf(u8, output, default_icons.stashed) == null);
-}
-
-test "formatOutput: custom icons from config" {
-    var status = GitStatus{};
-    const branch = "main";
-    @memcpy(status.branch[0..branch.len], branch);
-    status.branch_len = branch.len;
-    status.modified = 1;
-
-    var wc = StatusbarWidgetConfig{ .name = "git" };
-    wc.params[0] = .{ .key = "icon_branch", .value = "B:" };
-    wc.params[1] = .{ .key = "icon_modified", .value = "M:" };
-    wc.param_count = 2;
-
-    var ws = WidgetState{};
-    formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
-    const output = ws.output[0..ws.output_len];
-
-    try std.testing.expect(std.mem.startsWith(u8, output, "B:main"));
-    try std.testing.expect(std.mem.indexOf(u8, output, "M:1") != null);
-}
-
-test "formatOutput: color spans for dirty repo stats" {
-    var status = GitStatus{};
-    const branch = "main";
-    @memcpy(status.branch[0..branch.len], branch);
-    status.branch_len = branch.len;
-    status.staged = 2;
-    status.modified = 1;
-
-    const wc = StatusbarWidgetConfig{ .name = "git" };
-    var ws = WidgetState{};
-    formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
-
-    // Should have 2 color spans: staged + modified
-    const pal = statusbar.default_ansi_palette;
-    try std.testing.expectEqual(@as(u8, 2), ws.span_count);
-    // First span (staged) should be bright green (ANSI 10)
-    try std.testing.expectEqual(pal[10].r, ws.color_spans[0].fg.r);
-    try std.testing.expectEqual(pal[10].g, ws.color_spans[0].fg.g);
-    // Second span (modified) should be bright yellow (ANSI 11)
-    try std.testing.expectEqual(pal[11].r, ws.color_spans[1].fg.r);
-    try std.testing.expectEqual(pal[11].g, ws.color_spans[1].fg.g);
-}
-
-test "formatOutput: clean repo has clean color span" {
-    var status = GitStatus{};
-    const branch = "main";
-    @memcpy(status.branch[0..branch.len], branch);
-    status.branch_len = branch.len;
-
-    const wc = StatusbarWidgetConfig{ .name = "git" };
-    var ws = WidgetState{};
-    formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
-
-    // Clean repo should have 1 span for the clean icon (bright green = ANSI 10)
-    try std.testing.expectEqual(@as(u8, 1), ws.span_count);
-    try std.testing.expectEqual(statusbar.default_ansi_palette[10].r, ws.color_spans[0].fg.r);
-}
-
-test "parseHexColor: valid 6-digit hex" {
-    const c = parseHexColor("82c378").?;
-    try std.testing.expectEqual(@as(u8, 0x82), c.r);
-    try std.testing.expectEqual(@as(u8, 0xc3), c.g);
-    try std.testing.expectEqual(@as(u8, 0x78), c.b);
-}
-
-test "parseHexColor: with # prefix" {
-    const c = parseHexColor("#ff0000").?;
-    try std.testing.expectEqual(@as(u8, 255), c.r);
-    try std.testing.expectEqual(@as(u8, 0), c.g);
-    try std.testing.expectEqual(@as(u8, 0), c.b);
-}
-
-test "parseHexColor: rejects invalid input" {
-    try std.testing.expect(parseHexColor("fff") == null);
-    try std.testing.expect(parseHexColor("zzzzzz") == null);
-    try std.testing.expect(parseHexColor("") == null);
-}
-
-test "formatOutput: custom colors from config" {
-    var status = GitStatus{};
-    const branch = "main";
-    @memcpy(status.branch[0..branch.len], branch);
-    status.branch_len = branch.len;
-    status.modified = 1;
-
-    var wc = StatusbarWidgetConfig{ .name = "git" };
-    wc.params[0] = .{ .key = "color_modified", .value = "ff0000" };
-    wc.param_count = 1;
-
-    var ws = WidgetState{};
-    formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
-
-    try std.testing.expectEqual(@as(u8, 1), ws.span_count);
-    try std.testing.expectEqual(@as(u8, 255), ws.color_spans[0].fg.r);
-    try std.testing.expectEqual(@as(u8, 0), ws.color_spans[0].fg.g);
-    try std.testing.expectEqual(@as(u8, 0), ws.color_spans[0].fg.b);
+test {
+    _ = @import("git_widget_test.zig");
 }

--- a/src/app/git_widget_test.zig
+++ b/src/app/git_widget_test.zig
@@ -1,0 +1,286 @@
+const std = @import("std");
+const git_widget = @import("git_widget.zig");
+const GitStatus = git_widget.GitStatus;
+const statusbar_config = @import("../config/statusbar_config.zig");
+const StatusbarWidgetConfig = statusbar_config.StatusbarWidgetConfig;
+const statusbar = @import("statusbar.zig");
+
+test "parseGitStatus: branch and ahead/behind" {
+    const input =
+        \\# branch.head main
+        \\# branch.ab +3 -1
+        \\
+    ;
+    const s = git_widget.parseGitStatus(input);
+    try std.testing.expectEqualStrings("main", s.branch[0..s.branch_len]);
+    try std.testing.expectEqual(@as(u16, 3), s.ahead);
+    try std.testing.expectEqual(@as(u16, 1), s.behind);
+}
+
+test "parseGitStatus: staged and modified counts" {
+    const input =
+        \\# branch.head feature
+        \\1 M. N... 100644 100644 100644 abc123 def456 file1.zig
+        \\1 .M N... 100644 100644 100644 abc123 def456 file2.zig
+        \\1 MM N... 100644 100644 100644 abc123 def456 file3.zig
+        \\
+    ;
+    const s = git_widget.parseGitStatus(input);
+    try std.testing.expectEqual(@as(u16, 2), s.staged); // M. and MM
+    try std.testing.expectEqual(@as(u16, 2), s.modified); // .M and MM
+}
+
+test "parseGitStatus: untracked and conflict" {
+    const input =
+        \\# branch.head dev
+        \\? newfile.txt
+        \\? another.txt
+        \\u UU N... 100644 100644 100644 100644 abc def ghi conflict.txt
+        \\
+    ;
+    const s = git_widget.parseGitStatus(input);
+    try std.testing.expectEqual(@as(u16, 2), s.untracked);
+    try std.testing.expectEqual(@as(u16, 1), s.conflict);
+}
+
+test "parseGitStatus: rename entry" {
+    const input =
+        \\# branch.head main
+        \\2 R. N... 100644 100644 abc123 def456 R100 old.zig\tnew.zig
+        \\
+    ;
+    const s = git_widget.parseGitStatus(input);
+    try std.testing.expectEqual(@as(u16, 1), s.staged); // R in index
+    try std.testing.expectEqual(@as(u16, 0), s.modified); // . in worktree
+}
+
+test "parseGitStatus: detached HEAD with oid" {
+    const input =
+        \\# branch.oid abc1234def5678901234567890abcdef12345678
+        \\# branch.head (detached)
+        \\
+    ;
+    const s = git_widget.parseGitStatus(input);
+    try std.testing.expect(s.detached);
+    try std.testing.expectEqualStrings("abc1234def5678901234567890abcdef12345678", s.oid[0..s.oid_len]);
+    try std.testing.expectEqual(@as(u8, 0), s.branch_len);
+}
+
+test "countStashes: counts lines" {
+    const input = "stash@{0}: WIP on main: abc123 message\nstash@{1}: WIP on main: def456 msg\n";
+    try std.testing.expectEqual(@as(u16, 2), git_widget.countStashes(input));
+}
+
+test "countStashes: empty output" {
+    try std.testing.expectEqual(@as(u16, 0), git_widget.countStashes(""));
+}
+
+test "parseDiffNumstat: counts insertions and deletions" {
+    const input = "10\t5\tfile1.zig\n3\t0\tfile2.zig\n";
+    const d = git_widget.parseDiffNumstat(input);
+    try std.testing.expectEqual(@as(u32, 13), d.insertions);
+    try std.testing.expectEqual(@as(u32, 5), d.deletions);
+}
+
+test "parseDiffNumstat: empty output" {
+    const d = git_widget.parseDiffNumstat("");
+    try std.testing.expectEqual(@as(u32, 0), d.insertions);
+    try std.testing.expectEqual(@as(u32, 0), d.deletions);
+}
+
+test "formatOutput: clean repo shows branch + clean icon" {
+    var status = GitStatus{};
+    const branch = "main";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+
+    const wc = StatusbarWidgetConfig{ .name = "git" };
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+    const output = ws.output[0..ws.output_len];
+    try std.testing.expect(std.mem.indexOf(u8, output, "main") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\xe2\x9c\x94") != null); // ✔
+    try std.testing.expect(std.mem.indexOf(u8, output, "\xe2\x9c\x9a") == null); // ✚
+}
+
+test "formatOutput: dirty repo shows counts" {
+    var status = GitStatus{};
+    const branch = "dev";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+    status.staged = 3;
+    status.modified = 2;
+    status.untracked = 1;
+    status.ahead = 1;
+    status.behind = 2;
+    status.stashed = 1;
+
+    const wc = StatusbarWidgetConfig{ .name = "git" };
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+    const output = ws.output[0..ws.output_len];
+
+    try std.testing.expect(std.mem.indexOf(u8, output, "dev") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\xe2\x9c\x94") == null); // no ✔
+    try std.testing.expect(std.mem.indexOf(u8, output, "3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "1") != null);
+}
+
+test "formatOutput: omits zero-count sections" {
+    var status = GitStatus{};
+    const branch = "main";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+    status.modified = 5;
+
+    const wc = StatusbarWidgetConfig{ .name = "git" };
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+    const output = ws.output[0..ws.output_len];
+
+    try std.testing.expect(std.mem.indexOf(u8, output, "\xe2\x9c\x9a") != null); // ✚
+    try std.testing.expect(std.mem.indexOf(u8, output, "\xe2\x97\x8f") == null); // ●
+    try std.testing.expect(std.mem.indexOf(u8, output, "\xe2\x80\xa6") == null); // …
+    try std.testing.expect(std.mem.indexOf(u8, output, "\xe2\x9a\x91") == null); // ⚑
+}
+
+test "formatOutput: custom icons from config" {
+    var status = GitStatus{};
+    const branch = "main";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+    status.modified = 1;
+
+    var wc = StatusbarWidgetConfig{ .name = "git" };
+    wc.params[0] = .{ .key = "icon_branch", .value = "B:" };
+    wc.params[1] = .{ .key = "icon_modified", .value = "M:" };
+    wc.param_count = 2;
+
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+    const output = ws.output[0..ws.output_len];
+
+    try std.testing.expect(std.mem.startsWith(u8, output, "B:main"));
+    try std.testing.expect(std.mem.indexOf(u8, output, "M:1") != null);
+}
+
+test "formatOutput: color spans for dirty repo stats" {
+    var status = GitStatus{};
+    const branch = "main";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+    status.staged = 2;
+    status.modified = 1;
+
+    const wc = StatusbarWidgetConfig{ .name = "git" };
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+
+    const pal = statusbar.default_ansi_palette;
+    try std.testing.expectEqual(@as(u8, 2), ws.span_count);
+    try std.testing.expectEqual(pal[10].r, ws.color_spans[0].fg.r);
+    try std.testing.expectEqual(pal[10].g, ws.color_spans[0].fg.g);
+    try std.testing.expectEqual(pal[11].r, ws.color_spans[1].fg.r);
+    try std.testing.expectEqual(pal[11].g, ws.color_spans[1].fg.g);
+}
+
+test "formatOutput: clean repo has clean color span" {
+    var status = GitStatus{};
+    const branch = "main";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+
+    const wc = StatusbarWidgetConfig{ .name = "git" };
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+
+    try std.testing.expectEqual(@as(u8, 1), ws.span_count);
+    try std.testing.expectEqual(statusbar.default_ansi_palette[10].r, ws.color_spans[0].fg.r);
+}
+
+test "parseHexColor: valid 6-digit hex" {
+    const c = git_widget.parseHexColor("82c378").?;
+    try std.testing.expectEqual(@as(u8, 0x82), c.r);
+    try std.testing.expectEqual(@as(u8, 0xc3), c.g);
+    try std.testing.expectEqual(@as(u8, 0x78), c.b);
+}
+
+test "parseHexColor: with # prefix" {
+    const c = git_widget.parseHexColor("#ff0000").?;
+    try std.testing.expectEqual(@as(u8, 255), c.r);
+    try std.testing.expectEqual(@as(u8, 0), c.g);
+    try std.testing.expectEqual(@as(u8, 0), c.b);
+}
+
+test "parseHexColor: rejects invalid input" {
+    try std.testing.expect(git_widget.parseHexColor("fff") == null);
+    try std.testing.expect(git_widget.parseHexColor("zzzzzz") == null);
+    try std.testing.expect(git_widget.parseHexColor("") == null);
+}
+
+test "formatOutput: custom colors from config" {
+    var status = GitStatus{};
+    const branch = "main";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+    status.modified = 1;
+
+    var wc = StatusbarWidgetConfig{ .name = "git" };
+    wc.params[0] = .{ .key = "color_modified", .value = "ff0000" };
+    wc.param_count = 1;
+
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+
+    try std.testing.expectEqual(@as(u8, 1), ws.span_count);
+    try std.testing.expectEqual(@as(u8, 255), ws.color_spans[0].fg.r);
+    try std.testing.expectEqual(@as(u8, 0), ws.color_spans[0].fg.g);
+    try std.testing.expectEqual(@as(u8, 0), ws.color_spans[0].fg.b);
+}
+
+test "formatOutput: detached HEAD shows hash prefix" {
+    var status = GitStatus{};
+    status.detached = true;
+    const oid = "abc1234def5678901234567890abcdef12345678";
+    @memcpy(status.oid[0..oid.len], oid);
+    status.oid_len = oid.len;
+
+    const wc = StatusbarWidgetConfig{ .name = "git" };
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+    const output = ws.output[0..ws.output_len];
+    try std.testing.expect(std.mem.indexOf(u8, output, "#abc1234") != null);
+}
+
+test "formatOutput: conflict count rendered" {
+    var status = GitStatus{};
+    const branch = "main";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+    status.conflict = 2;
+
+    const wc = StatusbarWidgetConfig{ .name = "git" };
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+    const output = ws.output[0..ws.output_len];
+    try std.testing.expect(std.mem.indexOf(u8, output, "\xe2\x9c\x96") != null); // ✖
+    try std.testing.expect(std.mem.indexOf(u8, output, "2") != null);
+}
+
+test "formatOutput: insertions and deletions rendered" {
+    var status = GitStatus{};
+    const branch = "main";
+    @memcpy(status.branch[0..branch.len], branch);
+    status.branch_len = branch.len;
+    status.modified = 1;
+    status.insertions = 42;
+    status.deletions = 7;
+
+    const wc = StatusbarWidgetConfig{ .name = "git" };
+    var ws = statusbar.WidgetState{};
+    git_widget.formatOutput(&ws, &status, &wc, &statusbar.default_ansi_palette);
+    const output = ws.output[0..ws.output_len];
+    try std.testing.expect(std.mem.indexOf(u8, output, "+42") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "-7") != null);
+}

--- a/src/config/statusbar_config.zig
+++ b/src/config/statusbar_config.zig
@@ -29,7 +29,7 @@ pub const WidgetParam = struct {
 };
 
 pub const max_widgets = 16;
-pub const max_params = 8;
+pub const max_params = 16;
 
 pub const StatusbarWidgetConfig = struct {
     name: []const u8 = "",


### PR DESCRIPTION
This pull request significantly expands the information shown in the Git status widget by adding support for displaying commit hashes for detached HEAD states, conflict counts, and insertions/deletions statistics. It also introduces new icons and color customizations for these fields, and refactors the code to parse and show this additional data. The test code has been moved to a separate file for better organization.

Enhancements to Git status display:

* Added fields to `GitStatus` for commit hash (`oid`), detached HEAD state, conflict count, and insertions/deletions statistics, along with corresponding icons and color settings in the widget.
* Updated the parsing logic to detect detached HEAD, extract commit hashes, and count conflicts from `git status`, and to parse insertions/deletions from `git diff --numstat`. [[1]](diffhunk://#diff-d9df32cc5374843d7caf2b8183fed200d7c6ef746deb1452e6ee0cdb41d1b736R82-R93) [[2]](diffhunk://#diff-d9df32cc5374843d7caf2b8183fed200d7c6ef746deb1452e6ee0cdb41d1b736R136-R173)
* Modified the output formatting to display hash prefix and short commit hash when detached, show conflict counts, and include insertions/deletions with their own icons and colors. [[1]](diffhunk://#diff-d9df32cc5374843d7caf2b8183fed200d7c6ef746deb1452e6ee0cdb41d1b736L160-R218) [[2]](diffhunk://#diff-d9df32cc5374843d7caf2b8183fed200d7c6ef746deb1452e6ee0cdb41d1b736R240-R246) [[3]](diffhunk://#diff-d9df32cc5374843d7caf2b8183fed200d7c6ef746deb1452e6ee0cdb41d1b736R193-R199) [[4]](diffhunk://#diff-d9df32cc5374843d7caf2b8183fed200d7c6ef746deb1452e6ee0cdb41d1b736R271-R285)

Code organization and refactoring:

* Moved all test cases out of `git_widget.zig` to a new file (`git_widget_test.zig`), streamlining the main widget code.

Configuration improvements:

* Added support for custom icons and colors for new fields via widget configuration parameters, allowing users to override defaults for hash prefix, conflict, insertions, and deletions. [[1]](diffhunk://#diff-d9df32cc5374843d7caf2b8183fed200d7c6ef746deb1452e6ee0cdb41d1b736R136-R173) [[2]](diffhunk://#diff-d9df32cc5374843d7caf2b8183fed200d7c6ef746deb1452e6ee0cdb41d1b736R193-R199)