### PR TITLE
fix: Proper re-rendering on session restoration

### DIFF
--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -297,6 +297,13 @@ fn handleFocusPanes(
                 }
                 cl.sendPaneReplay(pane);
                 cl.sendReplayEnd(new_id);
+                // Force TUI apps to do a full repaint after session
+                // switch. Many frameworks (Node.js, React TUIs) only
+                // trigger a full redraw when the terminal size actually
+                // changes — a same-size SIGWINCH is ignored. Briefly
+                // shrink then restore the PTY size so the app sees a
+                // real resize event and invalidates its screen buffer.
+                pane.notifyRedraw();
             }
         }
     }

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -236,6 +236,17 @@ pub const DaemonPane = struct {
         self.cols = cols;
     }
 
+    /// Force a full repaint by nudging the PTY size by one column.
+    /// Many TUI frameworks (Node.js, ncurses, React-based) only trigger
+    /// a full redraw on an actual size change — a same-size SIGWINCH is
+    /// silently ignored. We bump cols+1 here; the client restores the
+    /// correct size on replay_end, providing a second SIGWINCH after the
+    /// round-trip delay ensures the app has processed the first one.
+    pub fn notifyRedraw(self: *DaemonPane) void {
+        const nudged = if (self.cols < std.math.maxInt(u16)) self.cols + 1 else self.cols - 1;
+        self.pty.resize(self.rows, nudged) catch {};
+    }
+
     /// Non-blocking check if child process has exited.
     /// Returns exit code if exited, null if still running.
     pub fn checkExit(self: *DaemonPane) ?u8 {

--- a/src/app/pty.zig
+++ b/src/app/pty.zig
@@ -26,6 +26,7 @@ extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 extern "c" fn execvp(file: [*:0]const u8, argv: [*]const ?[*:0]const u8) c_int;
 extern "c" fn chdir(path: [*:0]const u8) c_int;
 extern "c" fn waitpid(pid: c_int, status: ?*c_int, options: c_int) c_int;
+extern "c" fn tcgetpgrp(fd: c_int) posix.pid_t;
 extern "c" fn getuid() c_uint;
 extern "c" fn access(path: [*:0]const u8, mode: c_int) c_int;
 extern "c" fn readlink(path: [*:0]const u8, buf: [*]u8, bufsiz: usize) isize;
@@ -206,6 +207,16 @@ pub const Pty = struct {
 
     pub fn writeToPty(self: *Pty, bytes: []const u8) !usize {
         return posix.write(self.master, bytes);
+    }
+
+    /// Send SIGWINCH to the PTY's foreground process group.
+    /// Used after session switch to force TUI apps to repaint even
+    /// when the terminal size hasn't changed.
+    pub fn sendSigwinch(self: *Pty) void {
+        const pgrp = tcgetpgrp(self.master);
+        if (pgrp > 0) {
+            posix.kill(-pgrp, posix.SIG.WINCH) catch {};
+        }
     }
 
     pub fn resize(self: *Pty, rows: u16, cols: u16) !void {

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -528,7 +528,19 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                                         if (result.tab_idx == ctx.tab_mgr.active) got_data = true;
                                     }
                                 },
-                                .replay_end => {},
+                                .replay_end => |pane_id| {
+                                    // The daemon nudged the PTY size (+1 col) after
+                                    // replay to force a SIGWINCH.  Restore the correct
+                                    // size so the app gets a second resize event and
+                                    // repaints at the right dimensions.
+                                    if (findPaneByDaemonId(ctx, pane_id)) |result| {
+                                        const rows: u16 = @intCast(result.pane.engine.state.grid.rows);
+                                        const cols: u16 = @intCast(result.pane.engine.state.grid.cols);
+                                        if (ctx.session_client) |scc| {
+                                            scc.sendPaneResize(pane_id, rows, cols) catch {};
+                                        }
+                                    }
+                                },
                                 .layout_sync => |sync| {
                                     session_actions.handleLayoutSync(ctx, sync.layout);
                                     got_data = true;

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -274,9 +274,13 @@ pub fn printField(stdout: std.fs.File, label: []const u8, value: []const u8) voi
 // ── Socket path (must match session_connect.zig) ──
 
 fn getSocketPath(buf: *[256]u8) ?[]const u8 {
-    const home = std.posix.getenv("HOME") orelse return null;
     const suffix = if (comptime @import("builtin").mode == .Debug) "-dev" else "";
-    return std.fmt.bufPrint(buf, "{s}/.config/attyx/sessions{s}.sock", .{ home, suffix }) catch null;
+    if (std.posix.getenv("XDG_STATE_HOME")) |sh| {
+        if (sh.len > 0)
+            return std.fmt.bufPrint(buf, "{s}/attyx/sessions{s}.sock", .{ sh, suffix }) catch null;
+    }
+    const home = std.posix.getenv("HOME") orelse return null;
+    return std.fmt.bufPrint(buf, "{s}/.local/state/attyx/sessions{s}.sock", .{ home, suffix }) catch null;
 }
 
 /// Find the JSON object substring containing "is_current":true


### PR DESCRIPTION
## Summary

- **Fix TUI apps rendering broken after session switch.** Live-updating TUI apps (especially those using diff renderers like React-based frameworks) would show missing labels, headers, and static content when switching back to their session. The ring buffer replay only contains recent incremental updates — static content from the initial full draw is long gone.

  The fix nudges the PTY size by +1 column after replay, triggering a real SIGWINCH that forces the app to do a full repaint. The client then restores the correct size on `replay_end`, producing a second SIGWINCH at the right dimensions. The round-trip delay between the two ensures the app processes each resize event.

- **Fix `kill-daemon` command not finding the daemon.** The CLI `kill-daemon` subcommand was looking for the socket in `~/.config/attyx/` (pre-XDG migration path) instead of `~/.local/state/attyx/`. Now uses the correct XDG state directory, matching the actual daemon socket location.
