### PR TITLE
chore: Update session picker behavior

### DIFF
--- a/src/app/ui/session_picker_ui.zig
+++ b/src/app/ui/session_picker_ui.zig
@@ -52,23 +52,9 @@ pub fn openSessionPicker(ctx: *PtyThreadCtx) void {
     const panel_h = @as(u16, @intCast(@max(3, ctx.grid_rows))) / 2;
     const visible = if (panel_h > 5) @as(u8, @intCast(panel_h - 5)) else 3;
 
-    state.entry_count = count;
-    state.current_session_id = if (sc.attached_session_id) |sid| sid else null;
+    const current_id: ?u32 = if (sc.attached_session_id) |sid| sid else null;
+    state.load(state.entries[0..count], count, current_id);
     state.visible_rows = visible;
-    state.applyFilter();
-
-    // Pre-select first non-current alive session
-    var found_preselect = false;
-    for (0..state.filtered_count) |i| {
-        const e = &state.entries[state.filtered_indices[i]];
-        if (e.alive and (state.current_session_id == null or e.id != state.current_session_id.?)) {
-            state.selected = @intCast(i);
-            found_preselect = true;
-            break;
-        }
-    }
-    if (!found_preselect) state.selected = 0;
-    state.adjustScroll();
 
     g_picker_state = state;
     @atomicStore(i32, &terminal.g_session_picker_active, 1, .seq_cst);

--- a/src/config/commands.zig
+++ b/src/config/commands.zig
@@ -76,7 +76,7 @@ pub const registry = [_]CommandDef{
     .{ .action = .pane_resize_grow, .name = "pane_resize_grow", .description = "Grow focused pane", .scope = .global, .mac_hotkey = "cmd+ctrl+=", .linux_hotkey = "ctrl+alt+=" },
     .{ .action = .pane_resize_shrink, .name = "pane_resize_shrink", .description = "Shrink focused pane", .scope = .global, .mac_hotkey = "cmd+ctrl+-", .linux_hotkey = "ctrl+alt+-" },
     .{ .action = .clear_screen, .name = "clear_screen", .description = "Clear screen and scrollback", .scope = .global, .mac_hotkey = "cmd+k", .linux_hotkey = "ctrl+shift+k" },
-    .{ .action = .session_switcher_toggle, .name = "session_switcher_toggle", .description = "Toggle session switcher", .scope = .global, .mac_hotkey = "ctrl+shift+s", .linux_hotkey = "ctrl+shift+s" },
+    .{ .action = .session_switcher_toggle, .name = "session_switcher_toggle", .description = "Toggle session switcher", .scope = .global, .mac_hotkey = "cmd+shift+s", .linux_hotkey = "ctrl+shift+s" },
     .{ .action = .session_create, .name = "session_create", .description = "Create new session", .scope = .global, .mac_hotkey = "ctrl+shift+n", .linux_hotkey = "ctrl+shift+n" },
     .{ .action = .session_kill, .name = "session_kill", .description = "Kill current session", .scope = .global, .mac_hotkey = "ctrl+d", .linux_hotkey = "ctrl+d" },
     .{ .action = .command_palette_toggle, .name = "command_palette_toggle", .description = "Toggle command palette", .scope = .global, .mac_hotkey = "cmd+shift+p", .linux_hotkey = "ctrl+shift+p" },

--- a/src/overlay/session_picker.zig
+++ b/src/overlay/session_picker.zig
@@ -87,19 +87,6 @@ pub const SessionPickerState = struct {
         self.filter_len = 0;
         self.rename_len = 0;
         self.applyFilter();
-        self.preselect();
-    }
-
-    /// Pre-select first non-current alive session.
-    fn preselect(self: *SessionPickerState) void {
-        for (0..self.filtered_count) |i| {
-            const e = &self.entries[self.filtered_indices[i]];
-            if (e.alive and (self.current_session_id == null or e.id != self.current_session_id.?)) {
-                self.selected = @intCast(i);
-                self.adjustScroll();
-                return;
-            }
-        }
     }
 
     /// Handle a character input. Returns action if one should be executed.


### PR DESCRIPTION
- Active session is always at the top
- Session cursor starts always at the top
- macOS hotkey is cmd+shift+s now