### PR TITLE
fix: Correctly restore last session

### DIFF
--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -104,12 +104,14 @@ pub fn processTabActions(ctx: *PtyThreadCtx) void {
             if (ctx.tab_mgr.count <= 1) return;
             ctx.tab_mgr.nextTab();
             switchActiveTab(ctx);
+            saveSessionLayout(ctx);
             logging.info("tabs", "switched to tab {d}", .{ctx.tab_mgr.active + 1});
         },
         .tab_prev => {
             if (ctx.tab_mgr.count <= 1) return;
             ctx.tab_mgr.prevTab();
             switchActiveTab(ctx);
+            saveSessionLayout(ctx);
             logging.info("tabs", "switched to tab {d}", .{ctx.tab_mgr.active + 1});
         },
         .tab_move_left => {
@@ -134,6 +136,7 @@ pub fn processTabActions(ctx: *PtyThreadCtx) void {
             if (idx < ctx.tab_mgr.count and idx != ctx.tab_mgr.active) {
                 ctx.tab_mgr.switchTo(idx);
                 switchActiveTab(ctx);
+                saveSessionLayout(ctx);
                 logging.info("tabs", "switched to tab {d}", .{idx + 1});
             }
         },
@@ -189,10 +192,10 @@ pub fn processSplitActions(ctx: *PtyThreadCtx) void {
             switchActiveTab(ctx);
             saveSessionLayout(ctx);
         },
-        .pane_focus_up => { layout.navigate(.up); switchActiveTab(ctx); },
-        .pane_focus_down => { layout.navigate(.down); switchActiveTab(ctx); },
-        .pane_focus_left => { layout.navigate(.left); switchActiveTab(ctx); },
-        .pane_focus_right => { layout.navigate(.right); switchActiveTab(ctx); },
+        .pane_focus_up => { layout.navigate(.up); switchActiveTab(ctx); saveSessionLayout(ctx); },
+        .pane_focus_down => { layout.navigate(.down); switchActiveTab(ctx); saveSessionLayout(ctx); },
+        .pane_focus_left => { layout.navigate(.left); switchActiveTab(ctx); saveSessionLayout(ctx); },
+        .pane_focus_right => { layout.navigate(.right); switchActiveTab(ctx); saveSessionLayout(ctx); },
         .pane_resize_left, .pane_resize_right => {
             const pty_rows: u16 = @intCast(@max(1, @as(i32, ctx.grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
             if (layout.findResizeTarget(.vertical)) |target| {

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -43,13 +43,17 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
     var last_publish_ns: i128 = 0;
     const min_frame_ns: i128 = 16 * std.time.ns_per_ms; // ~60fps publish cap
 
-    // Save layout to daemon on clean shutdown (before terminal.zig closes the socket).
+    // Save layout and last-session on clean shutdown (before terminal.zig closes the socket).
     defer {
         if (ctx.session_client) |sc| {
             var save_buf: [4096]u8 = undefined;
             const save_len = ctx.tab_mgr.serializeLayout(&save_buf) catch 0;
             if (save_len > 0) {
                 sc.sendSaveLayout(save_buf[0..save_len]) catch {};
+            }
+            if (sc.attached_session_id) |sid| {
+                const session_connect = @import("../session_connect.zig");
+                session_connect.saveLastSession(sid);
             }
         }
     }


### PR DESCRIPTION
This pull request improves session persistence by ensuring that the session layout is saved more consistently whenever the user switches tabs or focuses panes, and also enhances shutdown behavior to save the last session ID. The most important changes are grouped below:

**Session Layout Persistence Improvements:**

* Added calls to `saveSessionLayout(ctx)` after switching tabs (via next, previous, or direct tab index) in `processTabActions`, ensuring the layout is saved whenever the active tab changes. [[1]](diffhunk://#diff-d4052522f312f8a9175368a0f72bd92c0c2b9187cc4a08b1b878595585909578R107-R114) [[2]](diffhunk://#diff-d4052522f312f8a9175368a0f72bd92c0c2b9187cc4a08b1b878595585909578R139)
* Added calls to `saveSessionLayout(ctx)` after pane focus navigation actions (up, down, left, right) in `processSplitActions`, so the layout is saved when pane focus changes.

**Shutdown Behavior Enhancements:**

* Updated the shutdown logic in `ptyReaderThread` to save both the session layout and the last attached session ID, improving session restoration on next startup.