### PR TITLE
fix: Session switch crash

### DIFF
--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -236,6 +236,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         // Direct session create (Ctrl+Shift+N without picker)
         if (@atomicRmw(i32, &terminal.g_create_session_direct, .Xchg, 0, .seq_cst) != 0) {
             session_actions.createSessionDirect(ctx);
+            if (ctx.tab_mgr.count == 0) continue :outer;
         }
 
         // Tick AI (auth/SSE state + streaming reveal)
@@ -257,6 +258,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         // Session picker input polling
         if (terminal.g_session_picker_active != 0) {
             _ = session_picker_ui.consumePickerInput(ctx);
+            if (ctx.tab_mgr.count == 0) continue :outer;
             session_picker_ui.tickFinder(ctx);
         }
 
@@ -385,8 +387,10 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
 
         resize_mod.handleResize(ctx, &buf);
         // Update viewport tracking after potential resize
-        if (publish.ctxEngine(ctx).state.viewport_offset != last_published_vp) {
-            last_published_vp = publish.ctxEngine(ctx).state.viewport_offset;
+        if (ctx.tab_mgr.count > 0) {
+            if (publish.ctxEngine(ctx).state.viewport_offset != last_published_vp) {
+                last_published_vp = publish.ctxEngine(ctx).state.viewport_offset;
+            }
         }
 
         // Build poll fd array:
@@ -442,6 +446,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         const poll_timeout: i32 = if (input.hasPendingPaste()) 1 else 16;
         _ = posix.poll(fds[0..nfds], poll_timeout) catch break;
 
+        if (ctx.tab_mgr.count == 0) continue :outer;
         const active_focused_pane = ctx.tab_mgr.activePane();
 
         // Drain session socket — route pane_output by daemon_pane_id


### PR DESCRIPTION
This pull request introduces several robustness improvements to the `ptyReaderThread` function in `src/app/ui/event_loop.zig`. The main goal is to ensure that operations are only performed when there are active tabs, preventing unnecessary processing and potential errors when the tab manager is empty.

Tab manager state checks:

* Added early `continue` statements after direct session creation and session picker input polling to skip further processing if `ctx.tab_mgr.count` is zero. [[1]](diffhunk://#diff-d7a7088cf97bfd228086028818e9cb643fe6e06bca7744e112eac5b6c6670682R239) [[2]](diffhunk://#diff-d7a7088cf97bfd228086028818e9cb643fe6e06bca7744e112eac5b6c6670682R261)
* Inserted a check to only update viewport tracking if there is at least one tab present in the tab manager.
* Added a check after polling file descriptors to skip further logic if the tab manager is empty.