### PR TITLE
fix: Properly update/re-render tab titles

### DIFF
--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -610,6 +610,24 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
 
         publish.syncViewportFromC(&publish.ctxEngine(ctx).state);
 
+        // Check all panes for title changes (background tabs included).
+        // This ensures tab bar / statusbar update even when the active tab
+        // is idle but a background tab's process sends an OSC title.
+        var title_changed = false;
+        for (ctx.tab_mgr.tabs[0..ctx.tab_mgr.count]) |*maybe_layout| {
+            if (maybe_layout.*) |*lay| {
+                var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
+                const lc = lay.collectLeaves(&leaves);
+                for (leaves[0..lc]) |leaf| {
+                    if (leaf.pane.engine.state.title_changed) {
+                        leaf.pane.engine.state.title_changed = false;
+                        title_changed = true;
+                    }
+                }
+            }
+        }
+        if (title_changed) got_data = true;
+
         const viewport_changed = (publish.ctxEngine(ctx).state.viewport_offset != last_published_vp);
         const need_update = got_data or viewport_changed;
 

--- a/src/term/state.zig
+++ b/src/term/state.zig
@@ -63,6 +63,7 @@ pub const TerminalState = struct {
     link_uris: std.ArrayListUnmanaged([]const u8) = .{},
     next_link_id: u32 = 1,
     title: ?[]const u8 = null,
+    title_changed: bool = false,
     working_directory: ?[]const u8 = null,
     shell_path: ?[]const u8 = null,
 

--- a/src/term/state_osc.zig
+++ b/src/term/state_osc.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const TerminalState = @import("state.zig").TerminalState;
 
 pub fn startHyperlink(self: *TerminalState, uri: []const u8) void {
@@ -21,12 +22,19 @@ pub fn endHyperlink(self: *TerminalState) void {
 
 pub fn setTitle(self: *TerminalState, title_slice: []const u8) void {
     const alloc = self.grid.allocator;
+    // Detect whether the title actually changed before replacing.
+    const changed = if (self.title) |old|
+        old.len != title_slice.len or !std.mem.eql(u8, old, title_slice)
+    else
+        title_slice.len > 0;
+
     if (self.title) |old| alloc.free(old);
     if (title_slice.len == 0) {
         self.title = null;
-        return;
+    } else {
+        self.title = alloc.dupe(u8, title_slice) catch null;
     }
-    self.title = alloc.dupe(u8, title_slice) catch null;
+    if (changed) self.title_changed = true;
 }
 
 pub fn setCwd(self: *TerminalState, uri: []const u8) void {


### PR DESCRIPTION
This pull request improves how tab and window titles are updated in the UI, ensuring that title changes in any tab (including background tabs) are properly detected and reflected in the tab bar and status bar. The main focus is on reliably tracking when a terminal's title changes and triggering UI updates accordingly.

**Title Change Detection and UI Updates**

* Added a `title_changed` boolean field to `TerminalState` to track when the terminal title is updated.
* Updated the `setTitle` function in `state_osc.zig` to detect if the title actually changed before updating, and set `title_changed` to true only when necessary.
* In the UI event loop (`event_loop.zig`), added logic to scan all panes (including background tabs) for title changes and trigger a UI update if any are found, ensuring that title changes are always reflected in the tab bar/status bar.

**Code Quality Improvements**

* Added a missing `std` import in `state_osc.zig` for memory comparison utilities.