### PR TITLE
fix: Viewport sync timer

### DIFF
--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -498,6 +498,10 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         if (ctx.tab_mgr.count == 0) continue :outer;
         const active_focused_pane = ctx.tab_mgr.activePane();
 
+        // Sync viewport from C BEFORE feeding PTY data, so that
+        // fullScreenScroll's viewport_offset bump is not overwritten.
+        publish.syncViewportFromC(&publish.ctxEngine(ctx).state);
+
         // Drain session socket — route pane_output by daemon_pane_id
         if (session_fd_idx) |si| {
             if (fds[si].revents & (POLLIN | POLLHUP) != 0) {
@@ -661,8 +665,6 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                 ps.publishImagePlacements(pcfg);
             }
         }
-
-        publish.syncViewportFromC(&publish.ctxEngine(ctx).state);
 
         // Check all panes for title changes (background tabs included).
         // This ensures tab bar / statusbar update even when the active tab


### PR DESCRIPTION
This pull request makes a targeted adjustment to the order of operations in the `ptyReaderThread` function to ensure viewport synchronization happens at the correct time. Specifically, it moves the call to `publish.syncViewportFromC` so that the viewport state is updated before processing new PTY data, preventing the viewport offset from being inadvertently overwritten.

Key change:

- Moved the call to `publish.syncViewportFromC` to occur before PTY data is processed, ensuring that the viewport offset is correctly preserved when full-screen scroll actions occur. [[1]](diffhunk://#diff-d7a7088cf97bfd228086028818e9cb643fe6e06bca7744e112eac5b6c6670682R501-R504) [[2]](diffhunk://#diff-d7a7088cf97bfd228086028818e9cb643fe6e06bca7744e112eac5b6c6670682L665-L666)