### PR TITLE
fix: Updater timing

### DIFF
--- a/src/app/macos_updater.m
+++ b/src/app/macos_updater.m
@@ -533,7 +533,9 @@ static BOOL isPackageManaged(void) {
 static void doCheckSilent(void) {
     NSURL *url = [NSURL URLWithString:g_feedURL];
     if (!url) return;
-    [[NSURLSession.sharedSession dataTaskWithURL:url completionHandler:
+    NSURLRequest *req = [NSURLRequest requestWithURL:url
+        cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:30];
+    [[NSURLSession.sharedSession dataTaskWithRequest:req completionHandler:
       ^(NSData *data, NSURLResponse *resp, NSError *err) {
         if (err || !data) return;
         AttyxAppcastItem *item = [[AttyxAppcastParser new] parseData:data];
@@ -564,7 +566,9 @@ static void doCheckInteractive(void) {
         return;
     }
 
-    [[NSURLSession.sharedSession dataTaskWithURL:url completionHandler:
+    NSURLRequest *req = [NSURLRequest requestWithURL:url
+        cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:30];
+    [[NSURLSession.sharedSession dataTaskWithRequest:req completionHandler:
       ^(NSData *data, NSURLResponse *resp, NSError *err) {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (err || !data) {

--- a/src/app/ui/ai.zig
+++ b/src/app/ui/ai.zig
@@ -366,6 +366,14 @@ pub fn tickUpdateCheck(ctx: *PtyThreadCtx) void {
     const mgr = ctx.overlay_mgr orelse return;
     var checker = &(g_update_checker orelse return);
 
+    // Periodic re-check: if the previous check completed and enough time
+    // has passed, kick off a new background check.
+    if (checker.shouldRecheck()) {
+        logging.info("update", "starting periodic re-check", .{});
+        checker.start();
+        return;
+    }
+
     const status = checker.getStatus();
     switch (status) {
         .update_available => {
@@ -397,22 +405,14 @@ pub fn tickUpdateCheck(ctx: *PtyThreadCtx) void {
                 logging.info("update", "overlay published", .{});
             }
             checker.tryJoin();
-            g_update_checker = null;
         },
         .up_to_date => {
             logging.info("update", "up to date", .{});
             checker.tryJoin();
-            g_update_checker = null;
-        },
-        .throttled => {
-            logging.info("update", "throttled (checked within 24h)", .{});
-            checker.tryJoin();
-            g_update_checker = null;
         },
         .failed => {
             logging.warn("update", "update check failed", .{});
             checker.tryJoin();
-            g_update_checker = null;
         },
         else => {},
     }

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -85,7 +85,9 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         logging.info("update", "update check disabled by config", .{});
     }
     defer {
-        if (ai.g_update_checker) |*uc| uc.tryJoin();
+        if (ai.g_update_checker) |*uc| {
+            uc.tryJoin();
+        }
         ai.g_update_checker = null;
     }
 

--- a/src/overlay/update_check.zig
+++ b/src/overlay/update_check.zig
@@ -17,7 +17,6 @@ pub const CheckStatus = enum(u8) {
     update_available = 2,
     up_to_date = 3,
     failed = 4,
-    throttled = 5,
 };
 
 pub const UpdateChecker = struct {
@@ -27,6 +26,11 @@ pub const UpdateChecker = struct {
     version_len: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
     thread: ?std.Thread = null,
     allocator: std.mem.Allocator,
+    /// Timestamp (seconds) of the last completed check, for periodic re-checking.
+    last_check_ts: i64 = 0,
+
+    /// How often to re-check while the app is running (4 hours).
+    const recheck_interval: i64 = 4 * 3600;
 
     pub fn start(self: *UpdateChecker) void {
         if (self.thread != null) return;
@@ -53,6 +57,14 @@ pub const UpdateChecker = struct {
             self.thread = null;
         }
     }
+
+    /// Returns true if enough time has passed for a periodic re-check.
+    pub fn shouldRecheck(self: *const UpdateChecker) bool {
+        if (self.thread != null) return false; // already running
+        if (self.last_check_ts == 0) return false; // never completed
+        const now = std.time.timestamp();
+        return (now - self.last_check_ts) >= recheck_interval;
+    }
 };
 
 /// Background worker thread.
@@ -63,27 +75,16 @@ fn updateWorker(checker: *UpdateChecker) void {
 }
 
 fn updateWorkerInner(checker: *UpdateChecker) !void {
-    // 1. Read throttle file — skip if checked within 24h
-    const throttle_path = getThrottlePath(checker.allocator) catch {
-        checker.status.store(@intFromEnum(CheckStatus.failed), .release);
-        return;
-    };
-    defer checker.allocator.free(throttle_path);
-
-    if (shouldSkipCheck(throttle_path)) {
-        checker.status.store(@intFromEnum(CheckStatus.throttled), .release);
-        return;
-    }
-
-    // 2. Fetch latest release from GitHub
+    // Fetch latest release from GitHub (no throttling — checks every launch
+    // and periodically while running)
     const response = fetchGithubRelease(checker.allocator) catch {
         checker.status.store(@intFromEnum(CheckStatus.failed), .release);
         return;
     };
     defer checker.allocator.free(response.body);
 
-    // 3. Write current timestamp to throttle file
-    writeThrottleTimestamp(throttle_path);
+    // Record completion time for periodic re-check scheduling
+    checker.last_check_ts = std.time.timestamp();
 
     if (response.status != 200) {
         checker.status.store(@intFromEnum(CheckStatus.failed), .release);
@@ -180,43 +181,6 @@ fn fetchGithubRelease(allocator: std.mem.Allocator) !ai_auth.HttpResponse {
     };
 
     return .{ .status = status, .body = resp_body };
-}
-
-fn getThrottlePath(allocator: std.mem.Allocator) ![]const u8 {
-    const home = std.posix.getenv("HOME") orelse return error.NoHomeDir;
-    const config_base = std.posix.getenv("XDG_CONFIG_HOME") orelse "";
-    if (config_base.len > 0) {
-        return std.fmt.allocPrint(allocator, "{s}/attyx/last_update_check", .{config_base});
-    }
-    return std.fmt.allocPrint(allocator, "{s}/.config/attyx/last_update_check", .{home});
-}
-
-fn shouldSkipCheck(path: []const u8) bool {
-    const file = std.fs.openFileAbsolute(path, .{}) catch return false;
-    defer file.close();
-
-    var buf: [20]u8 = undefined;
-    const n = file.readAll(&buf) catch return false;
-    if (n == 0) return false;
-
-    const ts = std.fmt.parseInt(i64, std.mem.trimRight(u8, buf[0..n], "\n\r "), 10) catch return false;
-    const now = std.time.timestamp();
-    const elapsed = now - ts;
-    return elapsed < 86400; // 24 hours
-}
-
-fn writeThrottleTimestamp(path: []const u8) void {
-    // Ensure parent directory exists
-    if (std.fs.path.dirname(path)) |dir| {
-        std.fs.makeDirAbsolute(dir) catch {};
-    }
-
-    const file = std.fs.createFileAbsolute(path, .{}) catch return;
-    defer file.close();
-
-    var buf: [20]u8 = undefined;
-    const ts_str = std.fmt.bufPrint(&buf, "{d}", .{std.time.timestamp()}) catch return;
-    file.writeAll(ts_str) catch {};
 }
 
 pub const UpdateCardResult = struct {


### PR DESCRIPTION
This pull request updates the application's update-checking logic to remove the old throttle-file mechanism and instead support periodic in-memory re-checks while the app is running. It also improves how HTTP requests are made for update checks and cleans up related code.

Update check logic improvements:
* Removed the throttle file mechanism and related code, so update checks are no longer limited by writing/reading a timestamp to disk. Instead, periodic re-checks are now managed in memory using a `last_check_ts` timestamp and a 4-hour interval. This allows the app to check for updates every launch and periodically while running, without relying on file I/O. (`src/overlay/update_check.zig`) [[1]](diffhunk://#diff-2c79ea0163da5fe8c905ac20d96322d410a2c8ea5f45de72f8e79305e9e03e3eL66-R87) [[2]](diffhunk://#diff-2c79ea0163da5fe8c905ac20d96322d410a2c8ea5f45de72f8e79305e9e03e3eL185-L221) [[3]](diffhunk://#diff-2c79ea0163da5fe8c905ac20d96322d410a2c8ea5f45de72f8e79305e9e03e3eL20) [[4]](diffhunk://#diff-2c79ea0163da5fe8c905ac20d96322d410a2c8ea5f45de72f8e79305e9e03e3eR29-R33)
* Added logic to trigger a new background update check if enough time has passed since the last completed check, enabling seamless periodic re-checks during runtime. (`src/app/ui/ai.zig`)
* Removed the `throttled` status from the update check status enum, since throttling is no longer needed. (`src/overlay/update_check.zig`)

HTTP request improvements:
* Changed update check HTTP requests to always bypass local caches and set a timeout, making update checks more reliable and responsive. (`src/app/macos_updater.m`) [[1]](diffhunk://#diff-1a9f7840a9ffb7d72e5973768d1a5b41b44dfc572386721a585857da1d5949bcL536-R538) [[2]](diffhunk://#diff-1a9f7840a9ffb7d72e5973768d1a5b41b44dfc572386721a585857da1d5949bcL567-R571)

Code cleanup:
* Moved cleanup of the global update checker instance (`g_update_checker`) to the main event loop, ensuring proper thread joining and resource management. (`src/app/ui/event_loop.zig`, `src/app/ui/ai.zig`) [[1]](diffhunk://#diff-d7a7088cf97bfd228086028818e9cb643fe6e06bca7744e112eac5b6c6670682L88-R90) [[2]](diffhunk://#diff-ce57ca222827bb21dabf2e11ef9f5824076149d74a97082f53774b13e73979d4L400-L415)