### PR TITLE
fix: Smart config opening

### DIFF
--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -353,7 +353,7 @@ pub fn run(
     defer if (session_client) |*sc| sc.deinit();
     var sessions_enabled = false;
 
-    if (config.sessions_enabled) {
+    if (config.sessions_enabled and config.argv == null) {
         if (SessionClient.connect(allocator)) |sc| {
             session_client = sc;
             sessions_enabled = true;

--- a/src/app/ui/dispatch.zig
+++ b/src/app/ui/dispatch.zig
@@ -257,8 +257,14 @@ pub export fn attyx_dispatch_action(action_raw: u8) u8 {
 }
 
 // ---------------------------------------------------------------------------
-// Open config file in $EDITOR
+// Open config file in $EDITOR (smart dispatch)
 // ---------------------------------------------------------------------------
+
+const is_macos = builtin.os.tag == .macos;
+
+const macos_ffi = if (is_macos) struct {
+    extern "c" fn _NSGetExecutablePath(buf: [*]u8, bufsize: *u32) c_int;
+} else struct {};
 
 fn openConfigInEditor() void {
     // Build config file path
@@ -279,11 +285,97 @@ fn openConfigInEditor() void {
         if (f) |file| file.close();
     }
 
-    // Use the platform's default file opener (open on macOS, xdg-open on Linux).
-    const opener = if (comptime @import("builtin").os.tag == .macos) "open" else "xdg-open";
+    const editor_raw = std.posix.getenv("VISUAL") orelse
+        std.posix.getenv("EDITOR") orelse "";
 
-    // posix_spawn instead of fork+exec — safe in multithreaded processes.
+    if (editor_raw.len == 0) {
+        systemOpen(config_path);
+        return;
+    }
+
+    const basename = editorBasename(editor_raw);
     const spawn = @import("../spawn.zig");
-    const argv: [3:null]?[*:0]const u8 = .{ opener, config_path, null };
-    _ = spawn.spawnp(opener, &argv, false).ok;
+
+    if (isTuiEditor(basename)) {
+        // TUI editor — open in a new attyx window via --cmd sh -c '...'
+        const exe = getSelfExePath() orelse return;
+        var sh_buf: [1024]u8 = undefined;
+        const sh_cmd = std.fmt.bufPrintZ(
+            &sh_buf,
+            "{s} '{s}'",
+            .{ editor_raw, config_path },
+        ) catch return;
+        const argv: [6:null]?[*:0]const u8 = .{ exe, "--cmd", "sh", "-c", sh_cmd, null };
+        _ = spawn.spawnp(exe, &argv, false);
+    } else if (isGuiEditor(basename)) {
+        // GUI editor — launch directly via sh -c to handle multi-word $EDITOR
+        var sh_buf: [1024]u8 = undefined;
+        const sh_cmd = std.fmt.bufPrintZ(
+            &sh_buf,
+            "{s} '{s}'",
+            .{ editor_raw, config_path },
+        ) catch return;
+        const argv: [4:null]?[*:0]const u8 = .{ "sh", "-c", sh_cmd, null };
+        _ = spawn.spawnp("sh", &argv, false);
+    } else {
+        // Unknown editor — fall back to system opener (open / xdg-open)
+        systemOpen(config_path);
+    }
+}
+
+/// Extract the basename of the first word in an editor string.
+/// e.g. "/usr/bin/nvim -u NONE" → "nvim"
+fn editorBasename(editor: []const u8) []const u8 {
+    const cmd_end = std.mem.indexOfScalar(u8, editor, ' ') orelse editor.len;
+    const cmd = editor[0..cmd_end];
+    const slash = std.mem.lastIndexOfScalar(u8, cmd, '/');
+    return if (slash) |i| cmd[i + 1 ..] else cmd;
+}
+
+fn isTuiEditor(basename: []const u8) bool {
+    const tui = [_][]const u8{
+        "vi", "vim", "nvim", "nano", "pico", "micro",
+        "helix", "hx", "joe", "jed", "ne", "kak", "vis", "mg", "ed",
+    };
+    for (tui) |e| {
+        if (std.mem.eql(u8, basename, e)) return true;
+    }
+    return false;
+}
+
+fn isGuiEditor(basename: []const u8) bool {
+    const gui = [_][]const u8{
+        "code",           "code-insiders", "codium",    "vscodium",
+        "zed",            "subl",          "sublime_text",
+        "atom",           "gedit",         "kate",      "mousepad",
+        "idea",           "goland",        "pycharm",   "webstorm",
+        "rustrover",      "fleet",         "emacs",     "emacsclient",
+    };
+    for (gui) |e| {
+        if (std.mem.eql(u8, basename, e)) return true;
+    }
+    return false;
+}
+
+fn systemOpen(path: [:0]const u8) void {
+    const opener: [*:0]const u8 = if (comptime is_macos) "open" else "xdg-open";
+    const spawn = @import("../spawn.zig");
+    const argv: [3:null]?[*:0]const u8 = .{ opener, path, null };
+    _ = spawn.spawnp(opener, &argv, false);
+}
+
+var exe_path_buf: [4096]u8 = undefined;
+
+fn getSelfExePath() ?[:0]const u8 {
+    if (comptime is_macos) {
+        var size: u32 = @intCast(exe_path_buf.len);
+        if (macos_ffi._NSGetExecutablePath(&exe_path_buf, &size) != 0) return null;
+        const len = std.mem.indexOfScalar(u8, &exe_path_buf, 0) orelse return null;
+        return exe_path_buf[0..len :0];
+    } else {
+        const link = posix.readlinkZ("/proc/self/exe", &exe_path_buf) catch return null;
+        if (link.len >= exe_path_buf.len) return null;
+        exe_path_buf[link.len] = 0;
+        return exe_path_buf[0..link.len :0];
+    }
 }

--- a/src/config/cli.zig
+++ b/src/config/cli.zig
@@ -182,7 +182,9 @@ pub fn parse(args: []const [:0]const u8) CliResult {
             result.config.log_level = requireArg(args, &i, "--log-level");
         } else if (std.mem.eql(u8, arg, "--log-file")) {
             result.config.log_file = requireArg(args, &i, "--log-file");
-        } else if (std.mem.eql(u8, arg, "--cmd")) {
+        } else if (std.mem.eql(u8, arg, "--cmd") or std.mem.eql(u8, arg, "--command") or
+            std.mem.eql(u8, arg, "-e") or std.mem.eql(u8, arg, "-c"))
+        {
             result.config.argv = @ptrCast(args[i + 1 ..]);
             break;
         } else {
@@ -316,7 +318,9 @@ pub fn applyCliOverrides(args: []const [:0]const u8, config: *config_mod.AppConf
         } else if (std.mem.eql(u8, arg, "--log-file")) {
             i += 1;
             if (i < args.len) config.log_file = args[i];
-        } else if (std.mem.eql(u8, arg, "--cmd")) {
+        } else if (std.mem.eql(u8, arg, "--cmd") or std.mem.eql(u8, arg, "--command") or
+            std.mem.eql(u8, arg, "-e") or std.mem.eql(u8, arg, "-c"))
+        {
             config.argv = @ptrCast(args[i + 1 ..]);
             break;
         } else if (std.mem.eql(u8, arg, "--config") or
@@ -350,7 +354,7 @@ pub fn printUsage() void {
         \\Options:
         \\  --rows N                   Terminal rows (default: 24)
         \\  --cols N                   Terminal cols (default: 80)
-        \\  --cmd <command...>         Override shell command
+        \\  -e, -c, --cmd <command...> Override shell command
         \\  --config <path>            Load config from a specific file
         \\  --no-config                Skip reading config from disk
         \\  --font-family <string>     Font family (default: "JetBrains Mono")

--- a/src/overlay/update_check.zig
+++ b/src/overlay/update_check.zig
@@ -55,6 +55,7 @@ pub const UpdateChecker = struct {
         if (self.thread) |t| {
             t.join();
             self.thread = null;
+            self.status.store(@intFromEnum(CheckStatus.idle), .release);
         }
     }
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes across CLI argument handling, session management, and editor launching logic. The most notable changes are expanded CLI flag support, smarter handling of config file editing (with better detection of TUI/GUI editors), and a session connection fix. Below are the key changes grouped by theme:

**CLI Argument Handling:**

* Added support for `-e`, `-c`, and `--command` as aliases for `--cmd` to override the shell command, and updated usage documentation accordingly (`src/config/cli.zig`). [[1]](diffhunk://#diff-f2c6d4be7581410b5277f9cd35954bb7e98446843f32206a4bbe27d630eba275L185-R187) [[2]](diffhunk://#diff-f2c6d4be7581410b5277f9cd35954bb7e98446843f32206a4bbe27d630eba275L319-R323) [[3]](diffhunk://#diff-f2c6d4be7581410b5277f9cd35954bb7e98446843f32206a4bbe27d630eba275L353-R357)

**Config File Editing Logic:**

* Reworked `openConfigInEditor()` to detect if the user’s `$EDITOR` is a TUI or GUI editor, launching accordingly: TUI editors open in a new window, GUI editors launch directly, and unknown editors fall back to the system opener (`src/app/ui/dispatch.zig`).
* Added helper functions to extract the editor basename, identify TUI/GUI editors, and robustly determine the current executable path for launching new windows (`src/app/ui/dispatch.zig`).

**Session Management:**

* Fixed a bug where session support could be incorrectly enabled if a command override was present by checking both `sessions_enabled` and that `argv` is null (`src/app/terminal.zig`).

**Update Checker:**

* Ensured the update checker's status is reset to `idle` after its thread joins, improving state consistency (`src/overlay/update_check.zig`).