### PR TITLE
feat: Skill!

### DIFF
--- a/.claude/skills/attyx/SKILL.md
+++ b/.claude/skills/attyx/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: attyx
+description: Control the Attyx terminal via IPC — manage splits, send input, read output, orchestrate panes. Use when the user asks to interact with terminal panes, run commands in splits, or coordinate multi-pane workflows.
+allowed-tools: Bash
+argument-hint: [action] [args...]
+---
+
+# Attyx Terminal IPC Skill
+
+You are running inside Attyx, a terminal emulator with a full IPC interface. You can control it programmatically.
+
+## Available IPC Commands
+
+!`attyx --help 2>&1 | sed -n '/^IPC commands/,/^$/p'`
+
+## Critical Rules
+
+### Don't Close Yourself
+Before closing a pane, ALWAYS check which pane you're in:
+```bash
+attyx list splits
+```
+The pane marked with `*` is the ACTIVE pane — `attyx split close` will close THAT one. To close another pane:
+1. `attyx focus <direction>` to move to the target pane
+2. `attyx split close` to close it
+3. Focus returns to a remaining pane automatically
+
+Your pane is typically the one you started in. Track pane IDs from `attyx list splits` output.
+
+### Use \r for Enter, Not \n
+When sending input via `send-keys`, always use `\r` (carriage return) to submit:
+```bash
+attyx send-keys "ls -la\r"
+```
+
+### Reading Output — Don't Guess Sleep Times
+Instead of blind `sleep N && attyx get-text`, poll until output stabilizes:
+
+```bash
+# Wait for command output to stabilize (poll every 2s, 3 stable reads = done)
+stable=0; prev=""; for i in $(seq 1 15); do
+  sleep 2
+  curr=$(attyx get-text 2>/dev/null)
+  if [ "$curr" = "$prev" ] && [ -n "$curr" ]; then
+    stable=$((stable + 1))
+    [ $stable -ge 2 ] && break
+  else
+    stable=0
+  fi
+  prev="$curr"
+done
+echo "$curr"
+```
+
+For quick commands (ls, cat, etc.) a simple `sleep 1` is fine. Use polling for anything interactive or slow (builds, AI responses, installs).
+
+### Focus Management
+`send-keys` and `get-text` operate on the ACTIVE pane. To interact with a specific pane:
+1. `attyx focus <direction>` to switch to it
+2. Do your `send-keys` / `get-text`
+3. Focus back if needed
+
+## Argument Handling
+
+If the user provides arguments, interpret them as a natural language instruction:
+- `/attyx open a split with htop` → `attyx split v --cmd htop`
+- `/attyx send "hello" to the other pane` → focus + send-keys
+- `/attyx close the other pane` → focus + close (carefully!)
+- `/attyx what's on screen in the right pane` → focus + get-text
+
+If no arguments, ask the user what they'd like to do with the terminal.

--- a/.claude/skills/attyx/data.zig
+++ b/.claude/skills/attyx/data.zig
@@ -1,0 +1,1 @@
+pub const content = @embedFile("SKILL.md");

--- a/build.zig
+++ b/build.zig
@@ -87,10 +87,15 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("themes/themes.zig"),
     });
 
+    const skill_data_mod = b.createModule(.{
+        .root_source_file = b.path(".claude/skills/attyx/data.zig"),
+    });
+
     const cli_commands_mod = b.createModule(.{
         .root_source_file = b.path("src/cli/main.zig"),
         .imports = &.{
             .{ .name = "attyx", .module = mod },
+            .{ .name = "skill_data", .module = skill_data_mod },
         },
     });
 

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -265,6 +265,109 @@ pub fn doUninstall() void {
     stdout.writeAll("\nAttyx data cleaned up. You can now run `brew uninstall attyx`.\n") catch {};
 }
 
+// ── Skill install/uninstall ──
+
+const skill_content = @import("skill_data").content;
+
+pub fn doSkill(args: []const [:0]const u8) void {
+    const stdout = std.fs.File.stdout();
+
+    // Parse sub-subcommand: attyx skill <install|uninstall>
+    const sub = if (args.len > 2) args[2] else "";
+
+    if (std.mem.eql(u8, sub, "install")) {
+        doSkillInstall(stdout);
+    } else if (std.mem.eql(u8, sub, "uninstall")) {
+        doSkillUninstall(stdout);
+    } else {
+        stdout.writeAll(skill_help) catch {};
+    }
+}
+
+fn doSkillInstall(stdout: std.fs.File) void {
+    const home = std.posix.getenv("HOME") orelse {
+        stdout.writeAll("error: HOME not set\n") catch {};
+        return;
+    };
+
+    // Build path: ~/.claude/skills/attyx/SKILL.md
+    var dir_buf: [512]u8 = undefined;
+    const dir_path = std.fmt.bufPrint(&dir_buf, "{s}/.claude/skills/attyx", .{home}) catch {
+        stdout.writeAll("error: path too long\n") catch {};
+        return;
+    };
+
+    var file_buf: [512]u8 = undefined;
+    const file_path = std.fmt.bufPrint(&file_buf, "{s}/.claude/skills/attyx/SKILL.md", .{home}) catch {
+        stdout.writeAll("error: path too long\n") catch {};
+        return;
+    };
+
+    // Create directory tree
+    std.fs.cwd().makePath(dir_path) catch |err| {
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "error: could not create {s}: {s}\n", .{ dir_path, @errorName(err) }) catch "error: could not create skill directory\n";
+        stdout.writeAll(msg) catch {};
+        return;
+    };
+
+    // Write SKILL.md
+    const file = std.fs.cwd().createFile(file_path, .{}) catch |err| {
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "error: could not write {s}: {s}\n", .{ file_path, @errorName(err) }) catch "error: could not write skill file\n";
+        stdout.writeAll(msg) catch {};
+        return;
+    };
+    defer file.close();
+    file.writeAll(skill_content) catch {
+        stdout.writeAll("error: failed to write skill content\n") catch {};
+        return;
+    };
+
+    stdout.writeAll("Installed Claude Code skill to ~/.claude/skills/attyx/\n") catch {};
+    stdout.writeAll("Use /attyx in Claude Code to control the terminal.\n") catch {};
+}
+
+fn doSkillUninstall(stdout: std.fs.File) void {
+    const home = std.posix.getenv("HOME") orelse {
+        stdout.writeAll("error: HOME not set\n") catch {};
+        return;
+    };
+
+    var dir_buf: [512]u8 = undefined;
+    const dir_path = std.fmt.bufPrint(&dir_buf, "{s}/.claude/skills/attyx", .{home}) catch {
+        stdout.writeAll("error: path too long\n") catch {};
+        return;
+    };
+
+    std.fs.cwd().deleteTree(dir_path) catch |err| {
+        if (err == error.FileNotFound) {
+            stdout.writeAll("Skill not installed.\n") catch {};
+            return;
+        }
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "error: could not remove {s}: {s}\n", .{ dir_path, @errorName(err) }) catch "error: could not remove skill\n";
+        stdout.writeAll(msg) catch {};
+        return;
+    };
+
+    stdout.writeAll("Removed Claude Code skill from ~/.claude/skills/attyx/\n") catch {};
+}
+
+const skill_help =
+    \\Install or remove the Attyx skill for Claude Code.
+    \\
+    \\Usage: attyx skill <command>
+    \\
+    \\Commands:
+    \\  install      Install the /attyx skill to ~/.claude/skills/attyx/
+    \\  uninstall    Remove the /attyx skill
+    \\
+    \\The skill lets Claude Code control Attyx via IPC — manage splits,
+    \\send input, read output, and orchestrate panes.
+    \\
+;
+
 pub fn printField(stdout: std.fs.File, label: []const u8, value: []const u8) void {
     var buf: [512]u8 = undefined;
     const line = std.fmt.bufPrint(&buf, "{s}: {s}\n", .{ label, value }) catch return;

--- a/src/config/cli.zig
+++ b/src/config/cli.zig
@@ -19,6 +19,7 @@ pub const Action = enum {
     login,
     device,
     uninstall,
+    skill,
     daemon,
     daemon_restore,
     kill_daemon,
@@ -55,6 +56,9 @@ pub fn parse(args: []const [:0]const u8) CliResult {
             return result;
         } else if (std.mem.eql(u8, first, "uninstall")) {
             result.action = .uninstall;
+            return result;
+        } else if (std.mem.eql(u8, first, "skill")) {
+            result.action = .skill;
             return result;
         } else if (std.mem.eql(u8, first, "daemon")) {
             // Check for --restore <path> arg
@@ -373,76 +377,7 @@ fn isIpcSubcommand(arg: []const u8) bool {
     return false;
 }
 
-pub fn printUsage() void {
-    const usage =
-        \\Attyx — GPU-accelerated VT-compatible terminal emulator
-        \\
-        \\Usage:
-        \\  attyx [options]            Launch terminal (GPU-accelerated)
-        \\  attyx <command>            Run a subcommand
-        \\
-        \\Commands:
-        \\  login                      Authenticate with Attyx AI services
-        \\  device                     Show device and account info
-        \\  uninstall                  Remove config, auth tokens, and desktop entry
-        \\  daemon                     Run the session daemon
-        \\  kill-daemon                Kill the session daemon and remove socket
-        \\
-        \\IPC commands (control a running instance, usable by agents/scripts):
-        \\  tab          Manage tabs (create, close, switch, move, rename)
-        \\  split        Manage pane splits (create, close, rotate, zoom)
-        \\  focus        Move focus between panes (up, down, left, right)
-        \\  session      Manage sessions (list, create, kill, switch, rename)
-        \\  send-keys    Send keystrokes with escape sequences (\n, \x03, etc.)
-        \\  send-text    Send raw text (no escape processing)
-        \\  get-text     Read visible text from the active pane
-        \\  reload       Reload configuration from disk
-        \\  theme        Switch to a named theme
-        \\  scroll-to    Scroll the viewport (top, bottom, page-up, page-down)
-        \\  list         Query tabs, panes, sessions (supports --json)
-        \\  popup        Open a popup terminal overlay
-        \\  run          Open a new tab with a command
-        \\
-        \\Options:
-        \\  --rows N                   Terminal rows (default: 24)
-        \\  --cols N                   Terminal cols (default: 80)
-        \\  -e, -c, --cmd <command...> Override shell command
-        \\  --config <path>            Load config from a specific file
-        \\  --no-config                Skip reading config from disk
-        \\  --font-family <string>     Font family (default: "JetBrains Mono")
-        \\  --font-size <int>          Font size in points (default: 14)
-        \\  --cell-width <value>       Cell width: points (e.g. 10) or percent (e.g. "110%")
-        \\  --cell-height <value>      Cell height: points (e.g. 20) or percent (e.g. "115%")
-        \\  --theme <string>           Theme name (default: "default")
-        \\  --scrollback-lines <int>   Scrollback buffer lines (default: 20000)
-        \\  --reflow / --no-reflow     Enable/disable reflow on resize
-        \\  --cursor-shape <shape>     Cursor shape: block, beam, underline
-        \\  --cursor-blink / --no-cursor-blink
-        \\                             Enable/disable cursor blinking
-        \\  --cursor-trail / --no-cursor-trail
-        \\                             Enable/disable cursor trail effect
-        \\  --font-ligatures / --no-font-ligatures
-        \\                             Enable/disable font ligatures (default: on)
-        \\  --shell <path>             Shell program (default: $SHELL or /bin/sh)
-        \\  -d, --working-directory <path>
-        \\                             Initial working directory (default: ~)
-        \\  --background-opacity <f>   Background opacity 0.0-1.0 (default: 1.0)
-        \\  --background-blur <int>    Background blur radius when opacity < 1 (default: 30)
-        \\  --decorations / --no-decorations
-        \\                             Show/hide window title bar (default: shown)
-        \\  --padding <int>            Window padding on all sides (logical pixels)
-        \\  --padding-x <int>         Left + right padding
-        \\  --padding-y <int>         Top + bottom padding
-        \\  --padding-left/right/top/bottom <int>
-        \\                             Per-side padding
-        \\  --log-level <level>        Log level: err, warn, info, debug, trace (default: info)
-        \\  --log-file <path>          Append logs to file (default: stderr only)
-        \\  --print-config             Print merged config and exit
-        \\  --help, -h                 Show this help
-        \\
-    ;
-    std.debug.print("{s}", .{usage});
-}
+pub const printUsage = @import("cli_help.zig").printUsage;
 
 test "positional arg treated as working directory" {
     const args = [_][:0]const u8{ "attyx", "/tmp/some/dir" };

--- a/src/config/cli_help.zig
+++ b/src/config/cli_help.zig
@@ -1,0 +1,199 @@
+// Attyx — Styled help output
+//
+// Uses ANSI escape codes for colors/formatting.
+// Comptime string concatenation keeps the source readable.
+
+const std = @import("std");
+
+// ── ANSI style tokens ───────────────────────────────────────────────────
+const b = "\x1b[1m"; // bold
+const d = "\x1b[2m"; // dim
+const c = "\x1b[36m"; // cyan
+const g = "\x1b[32m"; // green
+const y = "\x1b[33m"; // yellow
+const m = "\x1b[35m"; // magenta
+const r = "\x1b[0m"; // reset
+const bc = b ++ c; // bold cyan
+const bd = b ++ d; // bold dim
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Format an IPC command entry: cyan name + default description
+fn cmd(comptime name: []const u8, comptime desc: []const u8) []const u8 {
+    return "  " ++ c ++ name ++ r ++ desc ++ "\n";
+}
+
+/// Format an option entry: yellow flag + default description
+fn opt(comptime flag: []const u8, comptime desc: []const u8) []const u8 {
+    return "  " ++ y ++ flag ++ r ++ desc ++ "\n";
+}
+
+/// Format a dim example line
+fn ex(comptime line: []const u8) []const u8 {
+    return "  " ++ d ++ line ++ r ++ "\n";
+}
+
+/// Indented continuation line (for multi-line descriptions)
+fn cont(comptime line: []const u8) []const u8 {
+    return "  " ++ line ++ "\n";
+}
+
+// ── Help sections ───────────────────────────────────────────────────────
+
+const title =
+    "\n" ++
+    bc ++ "  Attyx" ++ r ++ "  GPU-accelerated VT-compatible terminal emulator\n" ++
+    "\n";
+
+const usage =
+    b ++ "USAGE" ++ r ++ "\n" ++
+    "  " ++ c ++ "attyx" ++ r ++ " [options]            Launch terminal\n" ++
+    "  " ++ c ++ "attyx" ++ r ++ " <command>            Run a subcommand\n" ++
+    "\n";
+
+const commands =
+    b ++ "COMMANDS" ++ r ++ "\n" ++
+    cmd("login                      ", "Authenticate with Attyx AI services") ++
+    cmd("device                     ", "Show device and account info") ++
+    cmd("uninstall                  ", "Remove config, auth tokens, and desktop entry") ++
+    cmd("skill <install|uninstall>  ", "Install/remove the Claude Code skill") ++
+    cmd("daemon                     ", "Run the session daemon") ++
+    cmd("kill-daemon                ", "Kill the session daemon and remove socket") ++
+    "\n";
+
+const ipc_header =
+    b ++ "IPC COMMANDS" ++ r ++ d ++ "  control a running instance, usable by agents/scripts" ++ r ++ "\n" ++
+    "\n" ++
+    d ++ "  All commands operate on the currently focused Attyx window." ++ r ++ "\n" ++
+    d ++ "  Use --json for machine-readable output. Run 'attyx <cmd> --help' for details." ++ r ++ "\n" ++
+    "\n";
+
+const ipc_tabs =
+    "  " ++ d ++ "Tabs" ++ r ++ "\n" ++
+    cmd("tab create [--cmd <cmd>] [--wait]   ", "Create a new tab") ++
+    cmd("tab close                            ", "Close the active tab") ++
+    cmd("tab next" ++ r ++ " / " ++ c ++ "tab prev                  ", "Switch tabs") ++
+    cmd("tab select <1-9>                     ", "Switch to tab by number") ++
+    cmd("tab move <left|right>                ", "Reorder the active tab") ++
+    cmd("tab rename <name>                    ", "Set a custom tab title") ++
+    "\n";
+
+const ipc_splits =
+    "  " ++ d ++ "Panes" ++ r ++ "\n" ++
+    cmd("split vertical [--cmd <cmd>] [--wait]   ", "New pane to the right " ++ d ++ "(alias: v)" ++ r) ++
+    cmd("split horizontal [--cmd <cmd>] [--wait]  ", "New pane below " ++ d ++ "(alias: h)" ++ r) ++
+    cmd("split close                              ", "Close the active pane") ++
+    cmd("split rotate                             ", "Rotate the split layout") ++
+    cmd("split zoom                               ", "Toggle zoom on active pane") ++
+    "\n";
+
+const ipc_focus =
+    "  " ++ d ++ "Focus" ++ r ++ "\n" ++
+    cmd("focus <up|down|left|right>           ", "Move focus to a neighboring pane") ++
+    "\n";
+
+const ipc_io =
+    "  " ++ d ++ "Input / Output" ++ r ++ "\n" ++
+    cmd("send-keys <keys>       ", "Send keystrokes to the active pane") ++
+    cont("                       " ++ d ++ "Escapes: \\n \\t \\x03 \\x04 \\x1b \\x7f \\x1b[A/B/C/D" ++ r) ++
+    cmd("send-text <text>       ", "Send raw text (same escape support)") ++
+    cmd("get-text [--json]      ", "Read visible screen text from the active pane") ++
+    "\n";
+
+const ipc_misc =
+    "  " ++ d ++ "Utilities" ++ r ++ "\n" ++
+    cmd("list [tabs|splits|sessions] [--json]   ", "Query tabs, panes, or sessions") ++
+    cmd("scroll-to <top|bottom|page-up|page-down>   ", "Scroll the viewport") ++
+    cmd("reload                 ", "Hot-reload config from disk") ++
+    cmd("theme <name>           ", "Switch to a named theme") ++
+    cmd("popup <cmd> [-w N] [--height N] [-b <style>]   ", "Floating overlay terminal") ++
+    cmd("run <cmd> [--wait]     ", "Open a new tab with a command") ++
+    "\n";
+
+const ipc_sessions =
+    "  " ++ d ++ "Sessions" ++ r ++ "\n" ++
+    cmd("session list           ", "List all daemon sessions") ++
+    cmd("session create         ", "Create a new empty session") ++
+    cmd("session switch <id>    ", "Switch to a session by ID") ++
+    cmd("session rename [id] <name>   ", "Rename a session") ++
+    cmd("session kill <id>      ", "Kill a session and all its panes") ++
+    "\n";
+
+const agent_workflow =
+    b ++ "AGENT WORKFLOW" ++ r ++ "\n" ++
+    ex("attyx split v --cmd \"your-tool\"    " ++ r ++ d ++ "# open a side pane") ++
+    ex("attyx get-text                     " ++ r ++ d ++ "# read its output") ++
+    ex("attyx send-keys \"some input\\n\"     " ++ r ++ d ++ "# type into it") ++
+    ex("attyx get-text                     " ++ r ++ d ++ "# read the result") ++
+    ex("attyx focus left                   " ++ r ++ d ++ "# go back to your pane") ++
+    ex("attyx split close                  " ++ r ++ d ++ "# clean up when done") ++
+    "\n";
+
+const options =
+    b ++ "OPTIONS" ++ r ++ "\n" ++
+    opt("--rows N                   ", "Terminal rows (default: 24)") ++
+    opt("--cols N                   ", "Terminal cols (default: 80)") ++
+    opt("-e, -c, --cmd <command...> ", "Override shell command") ++
+    opt("--config <path>            ", "Load config from a specific file") ++
+    opt("--no-config                ", "Skip reading config from disk") ++
+    opt("--font-family <string>     ", "Font family (default: \"JetBrains Mono\")") ++
+    opt("--font-size <int>          ", "Font size in points (default: 14)") ++
+    opt("--cell-width <value>       ", "Cell width: points or percent (e.g. \"110%\")") ++
+    opt("--cell-height <value>      ", "Cell height: points or percent (e.g. \"115%\")") ++
+    opt("--theme <string>           ", "Theme name (default: \"default\")") ++
+    opt("--scrollback-lines <int>   ", "Scrollback buffer lines (default: 20000)") ++
+    opt("--reflow / --no-reflow     ", "Enable/disable reflow on resize") ++
+    opt("--cursor-shape <shape>     ", "Cursor shape: block, beam, underline") ++
+    opt("--cursor-blink             ", "Enable cursor blinking " ++ d ++ "(--no-cursor-blink to disable)" ++ r) ++
+    opt("--cursor-trail             ", "Enable cursor trail " ++ d ++ "(--no-cursor-trail to disable)" ++ r) ++
+    opt("--font-ligatures           ", "Enable ligatures " ++ d ++ "(--no-font-ligatures to disable, default: on)" ++ r) ++
+    opt("--shell <path>             ", "Shell program (default: $SHELL or /bin/sh)") ++
+    opt("-d, --working-directory    ", "Initial working directory (default: ~)") ++
+    opt("--background-opacity <f>   ", "Background opacity 0.0\u{2013}1.0 (default: 1.0)") ++
+    opt("--background-blur <int>    ", "Blur radius when opacity < 1 (default: 30)") ++
+    opt("--decorations              ", "Show/hide title bar " ++ d ++ "(--no-decorations)" ++ r) ++
+    opt("--padding <int>            ", "Window padding on all sides") ++
+    opt("--padding-x / --padding-y  ", "Horizontal / vertical padding") ++
+    opt("--log-level <level>        ", "Log level: err, warn, info, debug, trace") ++
+    opt("--log-file <path>          ", "Append logs to file (default: stderr)") ++
+    opt("--print-config             ", "Print merged config and exit") ++
+    opt("--help, -h                 ", "Show this help") ++
+    "\n";
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+pub const help_text = title ++ usage ++ commands ++
+    ipc_header ++ ipc_tabs ++ ipc_splits ++ ipc_focus ++ ipc_io ++ ipc_misc ++ ipc_sessions ++
+    agent_workflow ++ options;
+
+/// Plain-text version for non-TTY output and AI consumption.
+/// Strips all ANSI escape codes at comptime.
+pub const help_text_plain = stripAnsi(help_text);
+
+pub fn printUsage() void {
+    // Use styled output when stderr is a terminal, plain otherwise.
+    const stderr = std.posix.STDERR_FILENO;
+    const is_tty = std.posix.isatty(stderr);
+    const text = if (is_tty) help_text else help_text_plain;
+    std.debug.print("{s}", .{text});
+}
+
+fn stripAnsi(comptime input: []const u8) []const u8 {
+    @setEvalBranchQuota(input.len * 4);
+    comptime {
+        var out: []const u8 = "";
+        var i: usize = 0;
+        while (i < input.len) {
+            if (input[i] == '\x1b' and i + 1 < input.len and input[i + 1] == '[') {
+                // Skip until we find the terminating letter (@ through ~)
+                i += 2;
+                while (i < input.len and input[i] < 0x40) : (i += 1) {}
+                if (i < input.len) i += 1; // skip the terminator
+            } else {
+                out = out ++ input[i .. i + 1];
+                i += 1;
+            }
+        }
+        return out;
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -59,6 +59,10 @@ pub fn main() !void {
             cli_commands.doUninstall();
             return;
         },
+        .skill => {
+            cli_commands.doSkill(args);
+            return;
+        },
         .daemon => {
             daemon.run(allocator, null) catch |err| {
                 var buf: [256]u8 = undefined;


### PR DESCRIPTION
This pull request introduces a new "Claude Code skill" integration for the Attyx terminal, allowing Claude Code to control Attyx via IPC for advanced terminal automation. It also refactors the CLI help output to be more readable and visually appealing, and adds a new `skill` subcommand to install or uninstall the skill. The most important changes are grouped below:

**Claude Code Skill Integration:**

* Adds a new `.claude/skills/attyx/SKILL.md` file describing the Attyx IPC skill, including usage rules and best practices.
* Embeds the skill content via `.claude/skills/attyx/data.zig`, making it available at build time.
* Implements `doSkillInstall` and `doSkillUninstall` functions in `src/cli/main.zig` to install or remove the skill file in the user's home directory, and adds a `doSkill` dispatcher for the new subcommand.
* Updates the build system (`build.zig`) to include the skill data module and import it into the CLI commands.

**CLI Enhancements:**

* Adds a new `skill` action to the CLI parser and dispatch logic, enabling the `attyx skill <install|uninstall>` command. [[1]](diffhunk://#diff-f2c6d4be7581410b5277f9cd35954bb7e98446843f32206a4bbe27d630eba275R22) [[2]](diffhunk://#diff-f2c6d4be7581410b5277f9cd35954bb7e98446843f32206a4bbe27d630eba275R60-R62) [[3]](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730R62-R65)
* Refactors the CLI help output: moves the help text to a new `src/config/cli_help.zig` module, which generates styled, colorized help output with ANSI codes for improved readability, and provides a plain-text fallback for non-TTY output. [[1]](diffhunk://#diff-88311af82bcbfd3cd8f77e720d847f958ad68d43bb96cc05c595908b6b77fd82R1-R199) [[2]](diffhunk://#diff-f2c6d4be7581410b5277f9cd35954bb7e98446843f32206a4bbe27d630eba275L376-R380)

These changes together provide a user-friendly way to install, remove, and learn about the new Claude Code skill, while also improving the overall CLI experience.