### PR TITLE
feat: Enable Monterey (macOS 12+)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
                 <title>Attyx v${VERSION}</title>
                 <pubDate>${PUB_DATE}</pubDate>
                 <sparkle:releaseNotesLink>https://semos.sh/releases/attyx/${VERSION}/sparkle</sparkle:releaseNotesLink>
-                <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+                <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
                 <enclosure
                   url="${DOWNLOAD_BASE}/attyx-darwin-arm64.zip"
                   sparkle:version="${BUNDLE_VERSION}"
@@ -147,7 +147,7 @@ jobs:
                 <title>Attyx v${VERSION}</title>
                 <pubDate>${PUB_DATE}</pubDate>
                 <sparkle:releaseNotesLink>https://semos.sh/releases/attyx/${VERSION}/sparkle</sparkle:releaseNotesLink>
-                <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+                <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
                 <enclosure
                   url="${DOWNLOAD_BASE}/attyx-darwin-x64.zip"
                   sparkle:version="${BUNDLE_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Strip binary
         run: strip zig-out/bin/attyx
 
-      - name: Set minimum macOS version to 13.0
-        run: vtool -set-build-version macos 13.0 15.0 -replace -output zig-out/bin/attyx zig-out/bin/attyx
+      - name: Set minimum macOS version to 12.0
+        run: vtool -set-build-version macos 12.0 15.0 -replace -output zig-out/bin/attyx zig-out/bin/attyx
 
       - name: Create .icns from PNG
         run: |

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>
-    <string>13.0</string>
+    <string>12.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/scripts/test-update.sh
+++ b/scripts/test-update.sh
@@ -55,7 +55,7 @@ make_plist() {
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>
-    <string>13.0</string>
+    <string>12.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>SUFeedURL</key>


### PR DESCRIPTION
This pull request lowers the minimum required macOS version for running the application from 13.0 to 12.0 across all build, packaging, and update scripts. This change ensures that users on macOS 12.0 and above can install and run the application.

Key changes by theme:

Minimum macOS version updates:

* Updated the `LSMinimumSystemVersion` in `resources/Info.plist` to `12.0` to allow the app to run on macOS 12 and newer.
* Changed the minimum system version in the Sparkle appcast XML generation for both ARM64 and x64 builds in `.github/workflows/publish.yml` from `13.0` to `12.0`. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L126-R126) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L150-R150)
* Modified the `vtool` command in `.github/workflows/release.yml` to set the minimum macOS version to `12.0` for the binary build.
* Updated the minimum system version in the test update script `scripts/test-update.sh` to `12.0`.