### PR TITLE
fix: Skill improvement and stabilize pane ids for real

### DIFF
--- a/skills/claude/attyx/SKILL.md
+++ b/skills/claude/attyx/SKILL.md
@@ -100,6 +100,29 @@ attyx session kill 3                   # kill session 3
 
 ## Critical Rules
 
+### Always Pin Your Session
+The user can switch sessions at any time. If you send commands without `-s`, they'll hit whatever session is currently focused — which may not be yours.
+
+**At the start of every interaction**, discover your session and pane IDs and use them for all subsequent commands:
+```bash
+# Step 1: Find your session and pane from the full tree
+attyx list
+# Output:
+# Session 1 "myapp" *          ← your session (marked *)
+#   1	bash	*	80x24        ← your pane (marked *)
+#   3	python		40x24
+# Session 2 "server"
+#   4	bash	*	80x24
+
+# Step 2: Use -s <session_id> on EVERY command from now on
+attyx -s 1 split v --cmd htop
+attyx -s 1 send-keys -p 3 "print('hi'){Enter}"
+attyx -s 1 get-text -p 3
+attyx -s 1 tab create
+```
+
+**Never omit `-s`** after the initial discovery. Even if you think you're still in the same session, always be explicit — the user may have switched focus between your commands.
+
 ### Don't Close Yourself
 Before closing a pane, use targeted close with `--pane` / `-p`:
 ```bash
@@ -236,11 +259,11 @@ Without `--pane`, `send-keys` and `get-text` operate on the focused pane:
 
 ## Argument Handling
 
-If the user provides arguments, interpret them as a natural language instruction:
-- `/attyx open a split with htop` → `attyx split v --cmd htop`
-- `/attyx send "hello" to the other pane` → `attyx send-keys -p <id> "hello{Enter}"`
-- `/attyx close the other pane` → `attyx split close -p <id>`
-- `/attyx what's on screen in the right pane` → `attyx get-text -p <id>`
+If the user provides arguments, interpret them as a natural language instruction. Remember to always use `-s <session_id>` (discovered via `attyx list` at start):
+- `/attyx open a split with htop` → `attyx -s <sid> split v --cmd htop`
+- `/attyx send "hello" to the other pane` → `attyx -s <sid> send-keys -p <id> "hello{Enter}"`
+- `/attyx close the other pane` → `attyx -s <sid> split close -p <id>`
+- `/attyx what's on screen in the right pane` → `attyx -s <sid> get-text -p <id>`
 - `/attyx create a background session for ~/Projects/api` → `attyx session create ~/Projects/api -b`
 - `/attyx list sessions` → `attyx session list`
 - `/attyx create a tab in session 5` → `attyx -s 5 tab create`

--- a/src/app/tab_manager.zig
+++ b/src/app/tab_manager.zig
@@ -529,7 +529,13 @@ pub const TabManager = struct {
                         errdefer self.allocator.destroy(pane);
                         pane.* = try Pane.initDaemonBacked(self.allocator, rows, cols, scrollback_lines);
                         pane.daemon_pane_id = node.pane_id;
-                        self.assignIpcId(pane);
+                        // Use daemon pane ID as the IPC ID so it stays
+                        // stable across session switches.
+                        pane.ipc_id = node.pane_id;
+                        if (node.pane_id >= self.next_ipc_id) {
+                            self.next_ipc_id = node.pane_id +% 1;
+                            if (self.next_ipc_id == 0) self.next_ipc_id = 1;
+                        }
                         sl.pool[ni] = .{ .tag = .leaf, .pane = pane };
                         pane_count += 1;
                     },
@@ -571,3 +577,8 @@ pub const TabManager = struct {
         }
     }
 };
+
+// Tests are in tab_manager_test.zig
+test {
+    _ = @import("tab_manager_test.zig");
+}

--- a/src/app/tab_manager_test.zig
+++ b/src/app/tab_manager_test.zig
@@ -1,0 +1,201 @@
+// Attyx — TabManager unit tests: IPC ID stability across session switches
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const TabManager = @import("tab_manager.zig").TabManager;
+const Pane = @import("pane.zig").Pane;
+const layout_codec = @import("layout_codec.zig");
+
+const attyx = @import("attyx");
+const Engine = attyx.Engine;
+
+fn createTestPane(allocator: Allocator) !*Pane {
+    const pane = try allocator.create(Pane);
+    pane.* = .{
+        .engine = try Engine.init(allocator, 24, 80, attyx.RingBuffer.default_max_scrollback),
+        .pty = undefined,
+        .allocator = allocator,
+    };
+    return pane;
+}
+
+/// Build a LayoutInfo with a single tab containing N leaf panes with given daemon IDs.
+fn makeLayout(pane_ids: []const u32) layout_codec.LayoutInfo {
+    var info = layout_codec.LayoutInfo{};
+    info.tab_count = 1;
+    info.active_tab = 0;
+    info.focused_pane_id = pane_ids[0];
+
+    if (pane_ids.len == 1) {
+        info.tabs[0].node_count = 1;
+        info.tabs[0].root_idx = 0;
+        info.tabs[0].focused_idx = 0;
+        info.tabs[0].nodes[0] = .{ .tag = .leaf, .pane_id = pane_ids[0] };
+    } else if (pane_ids.len == 2) {
+        // branch(0) -> leaf(1), leaf(2)
+        info.tabs[0].node_count = 3;
+        info.tabs[0].root_idx = 0;
+        info.tabs[0].focused_idx = 1;
+        info.tabs[0].nodes[0] = .{
+            .tag = .branch,
+            .direction = .vertical,
+            .ratio_x100 = 50,
+            .child_left = 1,
+            .child_right = 2,
+        };
+        info.tabs[0].nodes[1] = .{ .tag = .leaf, .pane_id = pane_ids[0] };
+        info.tabs[0].nodes[2] = .{ .tag = .leaf, .pane_id = pane_ids[1] };
+    } else if (pane_ids.len == 3) {
+        // branch(0) -> leaf(1), branch(2) -> leaf(3), leaf(4)
+        info.tabs[0].node_count = 5;
+        info.tabs[0].root_idx = 0;
+        info.tabs[0].focused_idx = 1;
+        info.tabs[0].nodes[0] = .{
+            .tag = .branch,
+            .direction = .vertical,
+            .ratio_x100 = 50,
+            .child_left = 1,
+            .child_right = 2,
+        };
+        info.tabs[0].nodes[1] = .{ .tag = .leaf, .pane_id = pane_ids[0] };
+        info.tabs[0].nodes[2] = .{
+            .tag = .branch,
+            .direction = .horizontal,
+            .ratio_x100 = 50,
+            .child_left = 3,
+            .child_right = 4,
+        };
+        info.tabs[0].nodes[3] = .{ .tag = .leaf, .pane_id = pane_ids[1] };
+        info.tabs[0].nodes[4] = .{ .tag = .leaf, .pane_id = pane_ids[2] };
+    }
+    return info;
+}
+
+/// Collect ipc_ids from all panes in the TabManager (in tab/tree order).
+fn collectIpcIds(mgr: *TabManager, out: []u32) u32 {
+    var count: u32 = 0;
+    for (&mgr.tabs) |*slot| {
+        const lay = &(slot.* orelse continue);
+        for (&lay.pool) |*node| {
+            if (node.tag == .leaf) {
+                if (node.pane) |pane| {
+                    if (count < out.len) {
+                        out[count] = pane.ipc_id;
+                        count += 1;
+                    }
+                }
+            }
+        }
+    }
+    return count;
+}
+
+fn destroyMgr(mgr: *TabManager) void {
+    for (&mgr.tabs) |*slot| {
+        if (slot.*) |*lay| {
+            lay.deinitAll(mgr.allocator);
+            slot.* = null;
+        }
+    }
+}
+
+test "reconstructFromLayout: ipc_ids match daemon pane ids" {
+    const allocator = std.testing.allocator;
+    const daemon_ids = [_]u32{ 42, 99 };
+    var layout = makeLayout(&daemon_ids);
+
+    var mgr = TabManager{ .allocator = allocator };
+    try mgr.reconstructFromLayout(&layout, 24, 80, 100);
+    defer destroyMgr(&mgr);
+
+    var ids: [8]u32 = undefined;
+    const count = collectIpcIds(&mgr, &ids);
+    try std.testing.expectEqual(@as(u32, 2), count);
+    try std.testing.expectEqual(@as(u32, 42), ids[0]);
+    try std.testing.expectEqual(@as(u32, 99), ids[1]);
+}
+
+test "reconstructFromLayout: ids stable after switching sessions" {
+    // Simulate: reconstruct session A, then session B, then session A again.
+    // Pane IDs in A must be identical both times.
+    const allocator = std.testing.allocator;
+
+    const session_a_ids = [_]u32{ 10, 20, 30 };
+    const session_b_ids = [_]u32{ 50, 60 };
+
+    var layout_a = makeLayout(&session_a_ids);
+    var layout_b = makeLayout(&session_b_ids);
+
+    var mgr = TabManager{ .allocator = allocator };
+
+    // Load session A
+    try mgr.reconstructFromLayout(&layout_a, 24, 80, 100);
+    var ids: [8]u32 = undefined;
+    var count = collectIpcIds(&mgr, &ids);
+    try std.testing.expectEqual(@as(u32, 3), count);
+    try std.testing.expectEqual(@as(u32, 10), ids[0]);
+    try std.testing.expectEqual(@as(u32, 20), ids[1]);
+    try std.testing.expectEqual(@as(u32, 30), ids[2]);
+
+    // Switch to session B
+    try mgr.reconstructFromLayout(&layout_b, 24, 80, 100);
+    count = collectIpcIds(&mgr, &ids);
+    try std.testing.expectEqual(@as(u32, 2), count);
+    try std.testing.expectEqual(@as(u32, 50), ids[0]);
+    try std.testing.expectEqual(@as(u32, 60), ids[1]);
+
+    // Switch back to session A — IDs must be the same as the first time
+    try mgr.reconstructFromLayout(&layout_a, 24, 80, 100);
+    count = collectIpcIds(&mgr, &ids);
+    try std.testing.expectEqual(@as(u32, 3), count);
+    try std.testing.expectEqual(@as(u32, 10), ids[0]);
+    try std.testing.expectEqual(@as(u32, 20), ids[1]);
+    try std.testing.expectEqual(@as(u32, 30), ids[2]);
+
+    destroyMgr(&mgr);
+}
+
+test "reconstructFromLayout: next_ipc_id stays above max daemon id" {
+    // After reconstruction, locally created panes must not collide with daemon IDs.
+    const allocator = std.testing.allocator;
+
+    const daemon_ids = [_]u32{ 100, 200 };
+    var layout = makeLayout(&daemon_ids);
+
+    var mgr = TabManager{ .allocator = allocator };
+    try mgr.reconstructFromLayout(&layout, 24, 80, 100);
+    defer destroyMgr(&mgr);
+
+    // next_ipc_id must be > 200 (the max daemon id)
+    try std.testing.expect(mgr.next_ipc_id > 200);
+
+    // Simulate creating a local pane — its ID must not collide
+    var local_pane = try createTestPane(allocator);
+    defer {
+        local_pane.engine.deinit();
+        allocator.destroy(local_pane);
+    }
+    mgr.assignIpcId(local_pane);
+    try std.testing.expect(local_pane.ipc_id > 200);
+    try std.testing.expect(local_pane.ipc_id != 100);
+}
+
+test "reconstructFromLayout: high daemon ids near u32 max" {
+    const allocator = std.testing.allocator;
+
+    // Use a daemon ID near the u32 max to test wrapping
+    const daemon_ids = [_]u32{std.math.maxInt(u32)};
+    var layout = makeLayout(&daemon_ids);
+
+    var mgr = TabManager{ .allocator = allocator };
+    try mgr.reconstructFromLayout(&layout, 24, 80, 100);
+    defer destroyMgr(&mgr);
+
+    var ids: [8]u32 = undefined;
+    const count = collectIpcIds(&mgr, &ids);
+    try std.testing.expectEqual(@as(u32, 1), count);
+    try std.testing.expectEqual(std.math.maxInt(u32), ids[0]);
+
+    // next_ipc_id should have wrapped past 0 to 1
+    try std.testing.expectEqual(@as(u32, 1), mgr.next_ipc_id);
+}


### PR DESCRIPTION
This pull request improves the stability and correctness of pane ID handling in the Attyx project, ensuring that pane IPC IDs remain consistent across session switches and do not collide with daemon-assigned IDs. It also updates documentation to reinforce best practices for session targeting and adds thorough unit tests to verify the new behavior.

**Pane ID stability and session management:**

* Modified `TabManager` so that, during session reconstruction, each pane's `ipc_id` is set to its daemon-provided pane ID, ensuring stable and predictable IPC IDs across session switches. The `next_ipc_id` is advanced to avoid collisions with any existing daemon IDs, including proper handling of wraparound at the `u32` maximum.
* Added comprehensive unit tests in `tab_manager_test.zig` to verify that IPC IDs match daemon pane IDs after reconstruction, remain stable across session switches, and that `next_ipc_id` never collides with daemon IDs—even for high values near `u32` max.
* Registered the new test suite in `tab_manager.zig` for automated testing.

**Documentation updates:**

* Updated `SKILL.md` to strongly emphasize always specifying the session ID (`-s <session_id>`) in every Attyx command, preventing accidental command routing to the wrong session when the user switches focus.
* Adjusted all natural language command examples in `SKILL.md` to include explicit session targeting, further reinforcing this best practice.