### PR TITLE
feat: Headless mode

### DIFF
--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -287,12 +287,17 @@ fn sigusr1Handler(_: c_int) callconv(.c) void {
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
+/// Whether we are running in headless mode (no UI, IPC-only).
+pub var g_headless: bool = false;
+
 pub fn run(
     config: AppConfig,
     no_config: bool,
     config_path: ?[]const u8,
     args: []const [:0]const u8,
+    headless: bool,
 ) !void {
+    g_headless = headless;
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
@@ -744,7 +749,33 @@ pub fn run(
     const thread = try std.Thread.spawn(.{}, event_loop.ptyReaderThread, .{&ctx});
     defer thread.join();
 
-    c.attyx_run(render_cells.ptr, @intCast(config.cols), @intCast(config.rows));
+    if (headless) {
+        // Install SIGTERM/SIGINT handlers so headless can be stopped cleanly.
+        const sa_term = posix.Sigaction{
+            .handler = .{ .handler = headlessSignalHandler },
+            .mask = posix.sigemptyset(),
+            .flags = 0,
+        };
+        posix.sigaction(posix.SIG.TERM, &sa_term, null);
+        posix.sigaction(posix.SIG.INT, &sa_term, null);
+
+        const pid = std.c.getpid();
+        const stderr = std.fs.File.stderr();
+        var banner_buf: [256]u8 = undefined;
+        const banner = std.fmt.bufPrint(&banner_buf, "attyx: headless mode (pid {d})\n", .{pid}) catch "attyx: headless mode\n";
+        stderr.writeAll(banner) catch {};
+
+        // Block until quit signal (from PTY thread on last pane exit, or SIGTERM/SIGINT).
+        while (c.attyx_should_quit() == 0) {
+            posix.nanosleep(0, 50_000_000); // 50ms
+        }
+    } else {
+        c.attyx_run(render_cells.ptr, @intCast(config.cols), @intCast(config.rows));
+    }
+}
+
+fn headlessSignalHandler(_: c_int) callconv(.c) void {
+    c.attyx_request_quit();
 }
 
 fn buildProgramArgv(

--- a/src/config/cli.zig
+++ b/src/config/cli.zig
@@ -10,6 +10,7 @@ pub const CliResult = struct {
     action: Action,
     config_path: ?[]const u8 = null,
     no_config: bool = false,
+    headless: bool = false,
 };
 
 pub const Action = enum {
@@ -84,6 +85,8 @@ pub fn parse(args: []const [:0]const u8) CliResult {
             return result;
         } else if (std.mem.eql(u8, arg, "--print-config")) {
             result.action = .print_config;
+        } else if (std.mem.eql(u8, arg, "--headless")) {
+            result.headless = true;
         } else if (std.mem.eql(u8, arg, "--config")) {
             result.config_path = requireArg(args, &i, "--config");
         } else if (std.mem.eql(u8, arg, "--no-config")) {
@@ -352,6 +355,7 @@ pub fn applyCliOverrides(args: []const [:0]const u8, config: *config_mod.AppConf
         } else if (std.mem.eql(u8, arg, "--config") or
             std.mem.eql(u8, arg, "--no-config") or
             std.mem.eql(u8, arg, "--print-config") or
+            std.mem.eql(u8, arg, "--headless") or
             std.mem.eql(u8, arg, "--help") or
             std.mem.eql(u8, arg, "-h") or
             std.mem.eql(u8, arg, "--decorations") or

--- a/src/config/cli_help.zig
+++ b/src/config/cli_help.zig
@@ -154,6 +154,7 @@ const options =
     opt("--padding-x / --padding-y  ", "Horizontal / vertical padding") ++
     opt("--log-level <level>        ", "Log level: err, warn, info, debug, trace") ++
     opt("--log-file <path>          ", "Append logs to file (default: stderr)") ++
+    opt("--headless                  ", "Run without UI, controlled via IPC only") ++
     opt("--print-config             ", "Print merged config and exit") ++
     opt("--help, -h                 ", "Show this help") ++
     "\n";

--- a/src/main.zig
+++ b/src/main.zig
@@ -120,7 +120,7 @@ pub fn main() !void {
     logging.init(log_level, merged.log_file);
     defer logging.deinit();
 
-    try terminal.run(merged, result.no_config, result.config_path, args);
+    try terminal.run(merged, result.no_config, result.config_path, args, result.headless);
 }
 
 /// Load config with correct precedence: Defaults < ConfigFile < CLI.


### PR DESCRIPTION
This pull request adds support for running the application in a new "headless" mode, which allows it to operate without a UI and be controlled exclusively via IPC. The changes include a new command-line flag, updates to configuration parsing, signal handling for clean shutdown in headless mode, and documentation in the CLI help output.

**Headless mode support:**

* Added a new global variable `g_headless` and a `headless` parameter to the `run` function in `terminal.zig` to track and enable headless operation.
* Implemented logic in `run` to handle headless mode: installs SIGTERM/SIGINT handlers, prints a startup banner, and blocks until shutdown is requested. Added `headlessSignalHandler` for clean signal-based shutdown.

**CLI and configuration:**

* Added a `headless` field to the `CliResult` struct and support for the `--headless` flag in CLI parsing. [[1]](diffhunk://#diff-f2c6d4be7581410b5277f9cd35954bb7e98446843f32206a4bbe27d630eba275R13) [[2]](diffhunk://#diff-f2c6d4be7581410b5277f9cd35954bb7e98446843f32206a4bbe27d630eba275R88-R89)
* Updated `applyCliOverrides` to recognize and ignore the `--headless` flag when applying CLI overrides to the config.
* Updated CLI help output to document the new `--headless` option.

**Main entry point:**

* Modified the call to `terminal.run` in `main.zig` to pass the `headless` flag from CLI parsing.