### PR TITLE
fix: Clicking on tabs doesn't work

### DIFF
--- a/src/app/ui/input.zig
+++ b/src/app/ui/input.zig
@@ -158,7 +158,6 @@ pub fn pickerCmd(cmd: c_int) void {
 // ---------------------------------------------------------------------------
 
 pub var g_tab_action_request: i32 = 0;
-pub var g_tab_count: i32 = 1;
 pub var g_tab_click_index: i32 = -1;
 
 pub fn tabAction(action: c_int) void {
@@ -169,7 +168,7 @@ pub fn tabBarClick(col: c_int, grid_cols: c_int) void {
     if (terminal.g_grid_top_offset <= 0) return;
     const idx = tab_bar_mod.tabIndexAtCol(
         @intCast(@max(0, col)),
-        @intCast(@atomicLoad(i32, &g_tab_count, .seq_cst)),
+        @intCast(@atomicLoad(i32, &terminal.g_tab_count, .seq_cst)),
         @intCast(@max(1, grid_cols)),
     ) orelse return;
     @atomicStore(i32, &g_tab_click_index, @as(i32, idx), .seq_cst);
@@ -185,7 +184,7 @@ pub fn statusbarTabClick(col: c_int, grid_cols: c_int) void {
     const remaining: u16 = @intCast(@max(1, grid_cols) -| offset);
     const idx = tab_bar_mod.tabIndexAtCol(
         adjusted_col,
-        @intCast(@atomicLoad(i32, &g_tab_count, .seq_cst)),
+        @intCast(@atomicLoad(i32, &terminal.g_tab_count, .seq_cst)),
         remaining,
     ) orelse return;
     @atomicStore(i32, &g_tab_click_index, @as(i32, idx), .seq_cst);


### PR DESCRIPTION
Fixes #145 

This pull request updates how the tab count is accessed in the UI input logic. Instead of using a global `g_tab_count` variable, the code now consistently references `terminal.g_tab_count` for tab-related operations. This improves encapsulation and ensures the tab count reflects the current terminal state.

Tab count handling:

* Removed the global `g_tab_count` variable from `src/app/ui/input.zig` and updated all references to use `terminal.g_tab_count` instead, ensuring tab count is always in sync with the terminal state. [[1]](diffhunk://#diff-cec73f0fffe5c8db8c77fcf9ba5b0a4b55b28bf54f7e114c53fb5fa7e3655e0aL161) [[2]](diffhunk://#diff-cec73f0fffe5c8db8c77fcf9ba5b0a4b55b28bf54f7e114c53fb5fa7e3655e0aL172-R171) [[3]](diffhunk://#diff-cec73f0fffe5c8db8c77fcf9ba5b0a4b55b28bf54f7e114c53fb5fa7e3655e0aL188-R187)