### PR TITLE
fix: Popup return cmd not spawning process

### DIFF
--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -527,7 +527,9 @@ pub fn handlePopupExit(ctx: *PtyThreadCtx, ps: *popup_mod.PopupState) void {
                         cmd, text, publish.ctxEngine(ctx).state.alt_active,
                     });
                     defer ctx.allocator.free(text);
-                    if (publish.ctxEngine(ctx).state.alt_active and !pcfg.inject_alt) {
+                    const use_detached = publish.ctxEngine(ctx).state.alt_active and !pcfg.inject_alt;
+                    const is_daemon = ctx.tab_mgr.activePane().daemon_pane_id != null;
+                    if (use_detached or is_daemon) {
                         popup_mod.execDetached(ctx.allocator, cmd, text);
                     } else {
                         const full = std.fmt.allocPrint(ctx.allocator, "{s} {s}\r", .{ cmd, text }) catch return;


### PR DESCRIPTION
This pull request updates the logic for handling popup exits in the UI actions. The main change is an improvement to the condition that determines when to execute commands in a detached mode, now also considering whether the active pane is a daemon pane.

Execution logic improvements:

* Updated the condition in `handlePopupExit` so that commands are executed in detached mode if either the alternate mode is active and not injected, or if the active pane is a daemon pane. This ensures proper handling for daemon panes in addition to the previous logic.