### PR TITLE
fix: Ring buffer swap during session switch

### DIFF
--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -304,6 +304,11 @@ fn handleFocusPanes(
                     if (n == 0) break;
                 }
                 cl.sendPaneReplay(pane);
+                // Nudge the PTY size so TUI apps get a SIGWINCH and
+                // fully repaint. The client restores the correct size
+                // on replay_end, and the round-trip delay ensures the
+                // app processes this first SIGWINCH before the second.
+                pane.notifyRedraw();
                 cl.sendReplayEnd(new_id);
             }
         }

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -720,12 +720,15 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                         }
                     },
                     .replay_end => |pane_id| {
+                        // The daemon already nudged the PTY size (cols+1)
+                        // before sending replay_end. Restore the correct
+                        // size so the app gets a second SIGWINCH at the
+                        // right dimensions — the round-trip delay ensures
+                        // the first SIGWINCH was processed.
                         if (findPaneByDaemonId(ctx, pane_id)) |result| {
                             const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);
                             const cols: u16 = @intCast(result.pane.engine.state.ring.cols);
                             if (ctx.session_client) |scc| {
-                                const nudged = if (cols > 1) cols - 1 else cols + 1;
-                                scc.sendPaneResize(pane_id, rows, nudged) catch {};
                                 scc.sendPaneResize(pane_id, rows, cols) catch {};
                             }
                         }


### PR DESCRIPTION
This pull request improves the reliability of terminal UI (TUI) redraws during pane replay by ensuring applications receive the correct sequence of SIGWINCH (window size change) signals. The changes coordinate a temporary PTY size nudge on the daemon side, followed by a restoration of the correct size on the client side, to guarantee TUI apps fully repaint after replay.

**PTY resize signaling improvements:**

* Added a call to `pane.notifyRedraw()` in `handleFocusPanes` to nudge the PTY size, ensuring TUI apps receive a SIGWINCH and fully repaint before replay ends.
* Updated `ptyReaderThread` to restore the correct PTY size after replay, ensuring the app receives a second SIGWINCH at the intended dimensions and processes the redraw in the correct order.