### PR TITLE
fix: Windows updater not updating the app

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -203,7 +203,10 @@ pub fn build(b: *std.Build) void {
         exe.addCSourceFile(.{ .file = b.path("src/app/windows_text_util.c"), .flags = win_flags });
         exe.addCSourceFile(.{ .file = b.path("src/app/windows_menu.c"),      .flags = win_flags });
         exe.addCSourceFile(.{ .file = b.path("src/app/windows_native_tabs.c"), .flags = win_flags });
-        exe.addCSourceFile(.{ .file = b.path("src/app/windows_updater.c"), .flags = win_flags });
+        // Updater needs to know if this is a dev build so staging path matches
+        // the daemon's expected filename (upgrade-dev.exe vs upgrade.exe).
+        const updater_flags: []const []const u8 = if (optimize == .Debug) &.{"-DATTYX_DEV"} else &.{};
+        exe.addCSourceFile(.{ .file = b.path("src/app/windows_updater.c"), .flags = updater_flags });
         exe.addWin32ResourceFile(.{ .file = b.path("src/app/attyx.rc") });
         exe.subsystem = .Windows; // No console window — CLI paths use AttachConsole
         exe.root_module.linkSystemLibrary("kernel32", .{});

--- a/src/app/windows_updater.c
+++ b/src/app/windows_updater.c
@@ -370,7 +370,11 @@ static int get_staging_path(wchar_t *buf, int buf_len) {
     wchar_t appdata[MAX_PATH];
     if (FAILED(SHGetFolderPathW(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appdata)))
         return 0;
+#ifdef ATTYX_DEV
     _snwprintf(buf, buf_len, L"%s\\attyx\\upgrade-dev.exe", appdata);
+#else
+    _snwprintf(buf, buf_len, L"%s\\attyx\\upgrade.exe", appdata);
+#endif
     return 1;
 }
 
@@ -494,14 +498,25 @@ static DWORD WINAPI download_thread(LPVOID param) {
         PROCESS_INFORMATION pi = {0};
         wchar_t cmdline[MAX_PATH + 32];
         _snwprintf(cmdline, MAX_PATH + 32, L"\"%s\" /update", staging);
+        int setup_ok = 0;
         if (CreateProcessW(NULL, cmdline, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) {
-            WaitForSingleObject(pi.hProcess, 30000); // Wait up to 30s
+            WaitForSingleObject(pi.hProcess, 30000);
+            DWORD exit_code = 1;
+            GetExitCodeProcess(pi.hProcess, &exit_code);
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);
+            setup_ok = (exit_code == 0);
         }
         DeleteFileW(staging); // Clean up setup exe
 
-        strcpy(g_dl_status, "Update installed. Restarting...");
+        if (setup_ok) {
+            // Setup succeeded — it already relaunched attyx.exe via ShellExecute,
+            // and KillAttyxAll() will terminate this process shortly.
+            strcpy(g_dl_status, "Update installed. Restarting...");
+        } else {
+            strcpy(g_dl_status, "Update failed. Please try again.");
+            updateLog("download: setup /update failed or timed out");
+        }
         if (g_update_hwnd) InvalidateRect(g_update_hwnd, NULL, FALSE);
     } else {
         // Legacy path: stage bare exe for daemon hot-swap (no sysroot update)


### PR DESCRIPTION
This pull request improves the handling of the Windows updater by making the updater executable filename and behavior conditional on whether the build is a development or release build. It also enhances error handling and user feedback during the update process.

**Build system and updater integration:**

* The build script (`build.zig`) now passes a `-DATTYX_DEV` flag to the updater source file when building in Debug mode, ensuring the updater uses the correct staging filename (`upgrade-dev.exe` for dev builds, `upgrade.exe` for release).

**Updater logic and user feedback:**

* The updater (`windows_updater.c`) now selects the staging path for the update executable based on whether the `ATTYX_DEV` flag is set, matching the build type.
* Improved the update installation process to check the exit code of the setup process. If the update succeeds, a success message is shown; if it fails or times out, a failure message is shown and a log entry is written.