### PR TITLE
feat: Track fg process cwd

### DIFF
--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -481,6 +481,15 @@ pub const DaemonClient = struct {
         self.sendRaw(m);
     }
 
+    /// Send a PaneFgCwd notification.
+    pub fn sendPaneFgCwd(self: *DaemonClient, pane_id: u32, cwd: []const u8) void {
+        var buf: [protocol.header_size + 4 + 2 + 512]u8 = undefined;
+        var payload: [4 + 2 + 512]u8 = undefined;
+        const p = protocol.encodePaneFgCwd(&payload, pane_id, cwd) catch return;
+        const m = protocol.encodeMessage(&buf, .pane_fg_cwd, p) catch return;
+        self.sendRaw(m);
+    }
+
     /// Send a HelloAck response with daemon's version string.
     pub fn sendHelloAck(self: *DaemonClient, version: []const u8) void {
         var payload: [256]u8 = undefined;

--- a/src/app/daemon/daemon.zig
+++ b/src/app/daemon/daemon.zig
@@ -345,7 +345,7 @@ pub fn run(allocator: std.mem.Allocator, restore_path: ?[]const u8) !void {
             }
         }
 
-        // Periodically check foreground process name for active panes (~1s).
+        // Periodically check foreground process name + CWD for active panes (~1s).
         proc_name_tick += 1;
         if (proc_name_tick >= 20) {
             proc_name_tick = 0;
@@ -359,6 +359,15 @@ pub fn run(allocator: std.mem.Allocator, restore_path: ?[]const u8) !void {
                                         if (cslot.*) |*cl| {
                                             if (cl.attached_session == s.id and cl.isPaneActive(pane.id)) {
                                                 cl.sendPaneProcName(pane.id, name);
+                                            }
+                                        }
+                                    }
+                                }
+                                if (pane.checkFgCwdChanged()) |cwd| {
+                                    for (&clients) |*cslot| {
+                                        if (cslot.*) |*cl| {
+                                            if (cl.attached_session == s.id and cl.isPaneActive(pane.id)) {
+                                                cl.sendPaneFgCwd(pane.id, cwd);
                                             }
                                         }
                                     }

--- a/src/app/daemon/daemon_windows.zig
+++ b/src/app/daemon/daemon_windows.zig
@@ -529,6 +529,14 @@ fn pollProcNames(st: *DaemonState) void {
                                 }
                             }
                         }
+                        if (pane.checkFgCwdChanged()) |cwd| {
+                            for (st.clients) |*cslot| {
+                                if (cslot.*) |*cl| {
+                                    if (cl.attached_session == s.id and cl.isPaneActive(pane.id))
+                                        cl.sendPaneFgCwd(pane.id, cwd);
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -33,6 +33,9 @@ pub const DaemonPane = struct {
     /// Cached foreground process name for change detection.
     proc_name: [64]u8 = .{0} ** 64,
     proc_name_len: u8 = 0,
+    /// Cached foreground process CWD for change detection.
+    fg_cwd: [512]u8 = .{0} ** 512,
+    fg_cwd_len: u16 = 0,
     /// Tracked OSC 7 working directory (file:// URI) for replay restoration.
     osc7_cwd: [512]u8 = .{0} ** 512,
     osc7_cwd_len: u16 = 0,
@@ -464,6 +467,24 @@ pub const DaemonPane = struct {
         @memcpy(self.proc_name[0..len], resolved[0..len]);
         self.proc_name_len = len;
         return self.proc_name[0..len];
+    }
+
+    /// Check if the foreground process CWD changed. Returns the new CWD if changed, null otherwise.
+    pub fn checkFgCwdChanged(self: *DaemonPane) ?[]const u8 {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const cwd = if (comptime is_windows)
+            @as(?[]const u8, null)
+        else
+            platform.getForegroundCwdBuf(self.pty.master, &buf);
+
+        const resolved = cwd orelse return null;
+        const len: u16 = @intCast(@min(resolved.len, 512));
+        if (len == self.fg_cwd_len and std.mem.eql(u8, self.fg_cwd[0..len], resolved[0..len])) {
+            return null; // unchanged
+        }
+        @memcpy(self.fg_cwd[0..len], resolved[0..len]);
+        self.fg_cwd_len = len;
+        return self.fg_cwd[0..len];
     }
 
     const pane_queries = @import("pane_queries.zig");

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -34,6 +34,7 @@ pub const MessageType = enum(u8) {
     replay_end = 0x8B,
     layout_sync = 0x8C,
     hello_ack = 0x8D,
+    pane_fg_cwd = 0x8E,
 };
 
 pub const header_size: usize = 5; // 4-byte payload length + 1-byte message type
@@ -572,6 +573,29 @@ pub fn decodePaneProcName(payload: []const u8) !PaneProcNameMsg {
     const name_len = payload[4];
     if (payload.len < 5 + @as(usize, name_len)) return error.PayloadTooShort;
     return .{ .pane_id = pane_id, .name = payload[5 .. 5 + name_len] };
+}
+
+// ── PaneFgCwd ──
+
+/// Encode PaneFgCwd payload: pane_id:u32, cwd_len:u16, cwd:[N]u8
+pub fn encodePaneFgCwd(buf: []u8, pane_id: u32, cwd: []const u8) ![]u8 {
+    const cwd_len: u16 = @intCast(@min(cwd.len, 512));
+    const total: usize = 4 + 2 + cwd_len;
+    if (buf.len < total) return error.BufferTooSmall;
+    std.mem.writeInt(u32, buf[0..4], pane_id, .little);
+    std.mem.writeInt(u16, buf[4..6], cwd_len, .little);
+    @memcpy(buf[6 .. 6 + cwd_len], cwd[0..cwd_len]);
+    return buf[0..total];
+}
+
+pub const PaneFgCwdMsg = struct { pane_id: u32, cwd: []const u8 };
+
+pub fn decodePaneFgCwd(payload: []const u8) !PaneFgCwdMsg {
+    if (payload.len < 6) return error.PayloadTooShort;
+    const pane_id = std.mem.readInt(u32, payload[0..4], .little);
+    const cwd_len = std.mem.readInt(u16, payload[4..6], .little);
+    if (payload.len < 6 + @as(usize, cwd_len)) return error.PayloadTooShort;
+    return .{ .pane_id = pane_id, .cwd = payload[6 .. 6 + cwd_len] };
 }
 
 // ── Hello / HelloAck (version handshake) ──

--- a/src/app/daemon/upgrade.zig
+++ b/src/app/daemon/upgrade.zig
@@ -9,7 +9,7 @@ const spawn = @import("../spawn.zig");
 const protocol = @import("protocol.zig");
 
 const magic = "ATUP";
-const format_version: u8 = 2;
+const format_version: u8 = 3;
 const max_sessions: usize = 32;
 const max_panes_per_session = @import("session.zig").max_panes_per_session;
 
@@ -156,6 +156,10 @@ fn serializePane(w: ListWriter, p: *DaemonPane) !void {
     try writeU16(w, p.osc7337_path_len);
     try writeBytes(w, p.osc7337_path[0..p.osc7337_path_len]);
 
+    // Foreground process CWD
+    try writeU16(w, p.fg_cwd_len);
+    try writeBytes(w, p.fg_cwd[0..p.fg_cwd_len]);
+
     const slices = p.replay.readSlices();
     const ring_len: u32 = @intCast(slices.totalLen());
     try writeU32(w, ring_len);
@@ -178,7 +182,7 @@ pub fn deserialize(
     if (!std.mem.eql(u8, &magic_buf, magic)) return error.InvalidMagic;
 
     const ver = try r.readByte();
-    if (ver != 1 and ver != format_version) return error.UnsupportedVersion;
+    if (ver != 1 and ver != 2 and ver != format_version) return error.UnsupportedVersion;
 
     next_session_id.* = try r.readU32();
     next_pane_id.* = try r.readU32();
@@ -266,6 +270,12 @@ fn deserializePane(r: *SliceReader, ver: u8, allocator: std.mem.Allocator) !Daem
         osc7337_path_slice = try r.readSlice(osc7337_path_len);
     }
 
+    var fg_cwd_slice: []const u8 = &.{};
+    if (ver >= 3) {
+        const fg_cwd_len = try r.readU16();
+        fg_cwd_slice = try r.readSlice(fg_cwd_len);
+    }
+
     const ring_len = try r.readU32();
     const ring_data = try r.readSlice(ring_len);
 
@@ -292,6 +302,10 @@ fn deserializePane(r: *SliceReader, ver: u8, allocator: std.mem.Allocator) !Daem
     const path_len: u16 = @intCast(@min(osc7337_path_slice.len, pane.osc7337_path.len));
     @memcpy(pane.osc7337_path[0..path_len], osc7337_path_slice[0..path_len]);
     pane.osc7337_path_len = path_len;
+
+    const fg_len: u16 = @intCast(@min(fg_cwd_slice.len, pane.fg_cwd.len));
+    @memcpy(pane.fg_cwd[0..fg_len], fg_cwd_slice[0..fg_len]);
+    pane.fg_cwd_len = fg_len;
 
     return pane;
 }

--- a/src/app/daemon/upgrade_windows.zig
+++ b/src/app/daemon/upgrade_windows.zig
@@ -61,7 +61,7 @@ const DETACHED_PROCESS: DWORD = 0x00000008;
 const CREATE_NEW_PROCESS_GROUP: DWORD = 0x00000200;
 
 const magic = "ATUW";
-const format_version: u8 = 2; // v2: host process model (no HANDLE inheritance)
+const format_version: u8 = 3; // v3: fg_cwd field
 const max_sessions: usize = 32;
 const max_panes_per_session = @import("session.zig").max_panes_per_session;
 
@@ -169,6 +169,10 @@ fn serializePane(w: ListWriter, p: *DaemonPane) !void {
     try writeU16(w, p.osc7337_path_len);
     try writeBytes(w, p.osc7337_path[0..p.osc7337_path_len]);
 
+    // Foreground process CWD
+    try writeU16(w, p.fg_cwd_len);
+    try writeBytes(w, p.fg_cwd[0..p.fg_cwd_len]);
+
     const slices = p.replay.readSlices();
     const ring_len: u32 = @intCast(slices.totalLen());
     try writeU32(w, ring_len);
@@ -190,7 +194,7 @@ pub fn deserialize(
     try r.readInto(&magic_buf);
     if (!std.mem.eql(u8, &magic_buf, magic)) return error.InvalidMagic;
     const ver = try r.readByte();
-    if (ver != format_version) return error.UnsupportedVersion;
+    if (ver != 2 and ver != format_version) return error.UnsupportedVersion;
 
     next_session_id.* = try r.readU32();
     next_pane_id.* = try r.readU32();
@@ -201,7 +205,7 @@ pub fn deserialize(
         const slot = for (sessions) |*slot| {
             if (slot.* == null) break slot;
         } else continue;
-        deserializeSessionInto(&r, allocator, slot) catch |err| {
+        deserializeSessionInto(&r, allocator, slot, ver) catch |err| {
             daemonLog2("deserialize: session {d} failed: {s} at pos {d}/{d}", .{ si, @errorName(err), r.pos, r.data.len });
             continue;
         };
@@ -210,7 +214,7 @@ pub fn deserialize(
     return restored;
 }
 
-fn deserializeSessionInto(r: *SliceReader, allocator: std.mem.Allocator, slot: *?DaemonSession) !void {
+fn deserializeSessionInto(r: *SliceReader, allocator: std.mem.Allocator, slot: *?DaemonSession, ver: u8) !void {
     slot.* = DaemonSession{ .id = try r.readU32(), .rows = 24, .cols = 80 };
     var s = &(slot.*.?);
     errdefer {
@@ -236,13 +240,13 @@ fn deserializeSessionInto(r: *SliceReader, allocator: std.mem.Allocator, slot: *
         const pane_slot = for (&s.panes) |*pslot| {
             if (pslot.* == null) break pslot;
         } else continue;
-        try deserializePaneInto(r, allocator, pane_slot);
+        try deserializePaneInto(r, allocator, pane_slot, ver);
         s.pane_count += 1;
     }
 }
 
 /// Deserialize a pane and reconnect to its host process pipe.
-fn deserializePaneInto(r: *SliceReader, allocator: std.mem.Allocator, slot: *?DaemonPane) !void {
+fn deserializePaneInto(r: *SliceReader, allocator: std.mem.Allocator, slot: *?DaemonPane, ver: u8) !void {
     const id = try r.readU32();
     const rows = try r.readU16();
     const cols = try r.readU16();
@@ -257,6 +261,11 @@ fn deserializePaneInto(r: *SliceReader, allocator: std.mem.Allocator, slot: *?Da
     const osc7_cwd_slice = try r.readSlice(osc7_cwd_len);
     const osc7337_path_len = try r.readU16();
     const osc7337_path_slice = try r.readSlice(osc7337_path_len);
+    var fg_cwd_slice: []const u8 = &.{};
+    if (ver >= 3) {
+        const fg_cwd_len = try r.readU16();
+        fg_cwd_slice = try r.readSlice(fg_cwd_len);
+    }
     const ring_len = try r.readU32();
     const ring_data = try r.readSlice(ring_len);
 
@@ -293,6 +302,9 @@ fn deserializePaneInto(r: *SliceReader, allocator: std.mem.Allocator, slot: *?Da
     const plen: u16 = @intCast(@min(osc7337_path_slice.len, pane.osc7337_path.len));
     @memcpy(pane.osc7337_path[0..plen], osc7337_path_slice[0..plen]);
     pane.osc7337_path_len = plen;
+    const flen: u16 = @intCast(@min(fg_cwd_slice.len, pane.fg_cwd.len));
+    @memcpy(pane.fg_cwd[0..flen], fg_cwd_slice[0..flen]);
+    pane.fg_cwd_len = flen;
 }
 
 // ── Upgrade path helpers ──

--- a/src/app/pane.zig
+++ b/src/app/pane.zig
@@ -47,6 +47,9 @@ pub const Pane = struct {
     /// Foreground process name reported by the daemon (for title fallback).
     daemon_proc_name: [64]u8 = undefined,
     daemon_proc_name_len: u8 = 0,
+    /// Foreground process CWD reported by the daemon (for popup CWD).
+    daemon_fg_cwd: [512]u8 = undefined,
+    daemon_fg_cwd_len: u16 = 0,
     /// IPC --wait: fd to write exit code to when this pane's process exits.
     /// Set by IPC handler when a client requests --wait. The fd is owned by
     /// this pane: deinit writes the exit code response and closes it.

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -50,6 +50,7 @@ pub const DaemonMessage = union(enum) {
     pane_created: u32,
     pane_died: struct { pane_id: u32, exit_code: u8, stdout: []const u8 = "" },
     pane_proc_name: struct { pane_id: u32, name: []const u8 },
+    pane_fg_cwd: struct { pane_id: u32, cwd: []const u8 },
     replay_end: u32,
     session_attached: struct { session_id: u32, layout: []const u8, pane_ids: [32]u32, pane_count: u8 },
     layout_sync: struct { session_id: u32, layout: []const u8, pane_ids: [32]u32, pane_count: u8 },
@@ -63,8 +64,10 @@ pub const SessionClient = struct {
     /// Max buffered events captured during blocking waits.
     const max_buffered_deaths = 16;
     const max_buffered_proc_names = 16;
+    const max_buffered_fg_cwds = 16;
     pub const BufferedDeath = struct { pane_id: u32, exit_code: u8 };
     pub const BufferedProcName = struct { pane_id: u32, name: [64]u8 = undefined, name_len: u8 = 0 };
+    pub const BufferedFgCwd = struct { pane_id: u32, cwd: [512]u8 = undefined, cwd_len: u16 = 0 };
 
     socket_fd: SocketFd = invalid_fd,
     read_buf: [65536]u8 = undefined,
@@ -87,6 +90,9 @@ pub const SessionClient = struct {
     /// Buffered pane_proc_name events captured during blocking waits.
     buffered_proc_names: [max_buffered_proc_names]BufferedProcName = undefined,
     buffered_proc_name_count: u8 = 0,
+    /// Buffered pane_fg_cwd events captured during blocking waits.
+    buffered_fg_cwds: [max_buffered_fg_cwds]BufferedFgCwd = undefined,
+    buffered_fg_cwd_count: u8 = 0,
 
     /// True if daemon did not respond to hello (pre-upgrade legacy daemon).
     legacy_daemon: bool = false,
@@ -398,6 +404,20 @@ pub const SessionClient = struct {
         return entry;
     }
 
+    /// Pop the next buffered fg cwd captured during a blocking wait.
+    pub fn popBufferedFgCwd(self: *SessionClient) ?BufferedFgCwd {
+        if (self.buffered_fg_cwd_count == 0) return null;
+        const entry = self.buffered_fg_cwds[0];
+        self.buffered_fg_cwd_count -= 1;
+        if (self.buffered_fg_cwd_count > 0) {
+            var i: u8 = 0;
+            while (i < self.buffered_fg_cwd_count) : (i += 1) {
+                self.buffered_fg_cwds[i] = self.buffered_fg_cwds[i + 1];
+            }
+        }
+        return entry;
+    }
+
     pub fn killSession(self: *SessionClient, session_id: u32) !void {
         var payload_buf: [4]u8 = undefined;
         const payload = try protocol.encodeKill(&payload_buf, session_id);
@@ -580,6 +600,17 @@ pub const SessionClient = struct {
                     self.buffered_proc_name_count += 1;
                 }
             } else |_| {}
+        } else if (msg_type == .pane_fg_cwd) {
+            if (protocol.decodePaneFgCwd(payload)) |fc| {
+                if (self.buffered_fg_cwd_count < max_buffered_fg_cwds) {
+                    var entry = BufferedFgCwd{ .pane_id = fc.pane_id };
+                    const len: u16 = @intCast(@min(fc.cwd.len, 512));
+                    @memcpy(entry.cwd[0..len], fc.cwd[0..len]);
+                    entry.cwd_len = len;
+                    self.buffered_fg_cwds[self.buffered_fg_cwd_count] = entry;
+                    self.buffered_fg_cwd_count += 1;
+                }
+            } else |_| {}
         }
         self.consumeBytes(total);
     }
@@ -719,6 +750,12 @@ fn readMessageImpl(self: *SessionClient) ?DaemonMessage {
                 @memcpy(self.output_buf[0..msg.name.len], msg.name);
                 self.consumeBytes(total);
                 return .{ .pane_proc_name = .{ .pane_id = msg.pane_id, .name = self.output_buf[0..msg.name.len] } };
+            },
+            .pane_fg_cwd => {
+                const msg = protocol.decodePaneFgCwd(payload) catch { self.consumeBytes(total); continue; };
+                @memcpy(self.output_buf[0..msg.cwd.len], msg.cwd);
+                self.consumeBytes(total);
+                return .{ .pane_fg_cwd = .{ .pane_id = msg.pane_id, .cwd = self.output_buf[0..msg.cwd.len] } };
             },
             .replay_end => {
                 if (payload.len < 4) { self.consumeBytes(total); continue; }

--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -480,6 +480,12 @@ pub fn resolveFocusedCwd(ctx: *PtyThreadCtx, osc7_buf: *[statusbar.max_output_le
         }
         logging.info("cwd", "platform lookup failed, trying OSC 7 fallback", .{});
     }
+    // Daemon-backed pane: use foreground CWD reported by the daemon.
+    if (pane.daemon_pane_id != null and pane.daemon_fg_cwd_len > 0) {
+        const cwd = pane.daemon_fg_cwd[0..pane.daemon_fg_cwd_len];
+        logging.info("cwd", "resolved via daemon fg_cwd: {s}", .{cwd});
+        return .{ .cwd = cwd, .owned = false };
+    }
     // Fallback: OSC 7 working directory from engine state
     if (pane.engine.state.working_directory) |uri| {
         if (statusbar.parseFileUri(uri, osc7_buf)) |path| {

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -778,6 +778,13 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                             if (result.tab_idx == ctx.tab_mgr.active) got_data = true;
                         }
                     },
+                    .pane_fg_cwd => |fc| {
+                        if (findPaneByDaemonId(ctx, fc.pane_id)) |result| {
+                            const len: u16 = @intCast(@min(fc.cwd.len, 512));
+                            @memcpy(result.pane.daemon_fg_cwd[0..len], fc.cwd[0..len]);
+                            result.pane.daemon_fg_cwd_len = len;
+                        }
+                    },
                     .replay_end => |pane_id| {
                         // The daemon already nudged the PTY size (cols+1)
                         // before sending replay_end. Restore the correct
@@ -1453,6 +1460,13 @@ fn drainBufferedDeaths(ctx: *PtyThreadCtx) DrainResult {
         if (findPaneByDaemonId(ctx, pn.pane_id)) |result| {
             @memcpy(result.pane.daemon_proc_name[0..pn.name_len], pn.name[0..pn.name_len]);
             result.pane.daemon_proc_name_len = pn.name_len;
+        }
+    }
+    // Drain buffered fg cwd updates
+    while (sc.popBufferedFgCwd()) |fc| {
+        if (findPaneByDaemonId(ctx, fc.pane_id)) |result| {
+            @memcpy(result.pane.daemon_fg_cwd[0..fc.cwd_len], fc.cwd[0..fc.cwd_len]);
+            result.pane.daemon_fg_cwd_len = fc.cwd_len;
         }
     }
     return .ok;

--- a/src/app/ui/win_daemon.zig
+++ b/src/app/ui/win_daemon.zig
@@ -45,6 +45,13 @@ pub fn drainDaemon(ctx: *WinCtx) bool {
                     if (result.tab_idx == ctx.tab_mgr.active) got_output = true;
                 }
             },
+            .pane_fg_cwd => |fc| {
+                if (findPaneByDaemonId(ctx, fc.pane_id)) |result| {
+                    const len: u16 = @intCast(@min(fc.cwd.len, 512));
+                    @memcpy(result.pane.daemon_fg_cwd[0..len], fc.cwd[0..len]);
+                    result.pane.daemon_fg_cwd_len = len;
+                }
+            },
             .replay_end => |pane_id| {
                 if (findPaneByDaemonId(ctx, pane_id)) |result| {
                     const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);

--- a/src/platform/linux.zig
+++ b/src/platform/linux.zig
@@ -66,6 +66,19 @@ pub fn getCwdForPid(allocator: std.mem.Allocator, pid: std.posix.pid_t) ?[]const
     return allocator.dupe(u8, target) catch null;
 }
 
+/// Non-allocating CWD lookup — copies into a caller-provided buffer.
+pub fn getCwdForPidBuf(pid: std.posix.pid_t, buf: []u8) ?[]const u8 {
+    var link_path_buf: [64:0]u8 = undefined;
+    const link_path = std.fmt.bufPrintZ(&link_path_buf, "/proc/{d}/cwd", .{pid}) catch return null;
+
+    var tmp: [std.fs.max_path_bytes]u8 = undefined;
+    const target = std.posix.readlinkZ(link_path, &tmp) catch return null;
+    if (target.len == 0 or target.len > buf.len) return null;
+
+    @memcpy(buf[0..target.len], target[0..target.len]);
+    return buf[0..target.len];
+}
+
 /// Return the foreground process group PID on the given PTY master fd.
 pub fn getPtyForegroundPid(master_fd: std.posix.fd_t) ?std.posix.pid_t {
     const pid = tcgetpgrp(master_fd);

--- a/src/platform/macos.zig
+++ b/src/platform/macos.zig
@@ -86,6 +86,26 @@ pub fn getCwdForPid(allocator: std.mem.Allocator, pid: std.posix.pid_t) ?[]const
     return allocator.dupe(u8, path_bytes[0..len]) catch null;
 }
 
+/// Non-allocating CWD lookup — copies into a caller-provided buffer.
+pub fn getCwdForPidBuf(pid: std.posix.pid_t, buf: []u8) ?[]const u8 {
+    var info: ProcVnodePathInfo = undefined;
+    const ret = proc_pidinfo(
+        @intCast(pid),
+        PROC_PIDVNODEPATHINFO,
+        0,
+        @ptrCast(&info),
+        @intCast(@sizeOf(ProcVnodePathInfo)),
+    );
+    if (ret <= 0) return null;
+
+    const path_bytes = &info.cdir.path;
+    const len = std.mem.indexOfScalar(u8, path_bytes, 0) orelse MAXPATHLEN;
+    if (len == 0 or len > buf.len) return null;
+
+    @memcpy(buf[0..len], path_bytes[0..len]);
+    return buf[0..len];
+}
+
 /// Return the foreground process group PID on the given PTY master fd.
 pub fn getPtyForegroundPid(master_fd: std.posix.fd_t) ?std.posix.pid_t {
     const pid = tcgetpgrp(master_fd);

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -114,3 +114,12 @@ pub fn getForegroundCwd(allocator: std.mem.Allocator, master_fd: std.posix.fd_t)
     // Direct lookup — works when the fg process is a plain shell.
     return impl.getCwdForPid(allocator, fg_pid);
 }
+
+/// Non-allocating foreground CWD lookup — writes into a caller-provided buffer.
+/// Skips tmux detection (too expensive for periodic polling).
+/// POSIX-only — on Windows, always returns null.
+pub fn getForegroundCwdBuf(master_fd: std.posix.fd_t, buf: []u8) ?[]const u8 {
+    if (!is_posix) return null;
+    const fg_pid = impl.getPtyForegroundPid(master_fd) orelse return null;
+    return impl.getCwdForPidBuf(fg_pid, buf);
+}

--- a/src/platform/windows.zig
+++ b/src/platform/windows.zig
@@ -78,6 +78,11 @@ pub fn getCwdForPid(_: std.mem.Allocator, _: i32) ?[]const u8 {
     return null;
 }
 
+/// Stub — non-allocating CWD lookup.
+pub fn getCwdForPidBuf(_: i32, _: []u8) ?[]const u8 {
+    return null;
+}
+
 // ── ToolHelp32 process tree walking ──
 
 const windows = std.os.windows;


### PR DESCRIPTION
This pull request adds support for tracking and synchronizing the foreground process's current working directory (CWD) for each pane in the daemon and client. This enables clients to receive updates when the foreground process's CWD changes, similar to how process names are tracked and reported. The changes include protocol updates, serialization/deserialization adjustments, event buffering, and message handling for this new feature.

**Foreground Process CWD Tracking and Synchronization:**

* Added `fg_cwd` and `fg_cwd_len` fields to `DaemonPane` and `Pane` structs to cache and track the foreground process's CWD. Introduced `checkFgCwdChanged` method to detect CWD changes and return the new value. (`src/app/daemon/pane.zig`, `src/app/pane.zig`) [[1]](diffhunk://#diff-e1e6190873829ab4fae202f869a563e551dd6462905585d443ce07052598ef28R36-R38) [[2]](diffhunk://#diff-e1e6190873829ab4fae202f869a563e551dd6462905585d443ce07052598ef28R472-R489) [[3]](diffhunk://#diff-127b383c63c0dce440e149f5d6a48e13e27d11b8cac18832defd04755af3625dR50-R52)
* Updated the daemon main loop and Windows process polling to check for CWD changes in active panes and notify all relevant clients when a change is detected. (`src/app/daemon/daemon.zig`, `src/app/daemon/daemon_windows.zig`) [[1]](diffhunk://#diff-f212edfffe62530310bb1e357af0e7901a2997e1ed764d29c350d220c623ea27L348-R348) [[2]](diffhunk://#diff-f212edfffe62530310bb1e357af0e7901a2997e1ed764d29c350d220c623ea27R366-R374) [[3]](diffhunk://#diff-aefc3a8f118117172c38b2dc29f30a41f2d46814e65b171c4c3444c1c8ed0086R532-R539)

**Protocol and Message Handling:**

* Added a new message type `pane_fg_cwd` to the protocol, with encoding/decoding functions for sending the CWD. Updated `DaemonClient` to support sending this message. (`src/app/daemon/protocol.zig`, `src/app/daemon/client.zig`) [[1]](diffhunk://#diff-5b8db8ab9c83dd4eee2561724dee878082d972ea565e1f818515e41ca9bfb303R37) [[2]](diffhunk://#diff-5b8db8ab9c83dd4eee2561724dee878082d972ea565e1f818515e41ca9bfb303R578-R600) [[3]](diffhunk://#diff-d9d1842a56ff3380ef11259acdd39e672a4c1d9431add89753cf371c80e60fd8R484-R492)
* Updated the client-side code to handle `pane_fg_cwd` messages, including event buffering, message parsing, and providing a way to pop buffered CWD events. (`src/app/session_client.zig`) [[1]](diffhunk://#diff-39633822e2cf3e29f78b9de4db179f2f24515182972e4ffe2109770eda72db30R53) [[2]](diffhunk://#diff-39633822e2cf3e29f78b9de4db179f2f24515182972e4ffe2109770eda72db30R67-R70) [[3]](diffhunk://#diff-39633822e2cf3e29f78b9de4db179f2f24515182972e4ffe2109770eda72db30R93-R95) [[4]](diffhunk://#diff-39633822e2cf3e29f78b9de4db179f2f24515182972e4ffe2109770eda72db30R407-R420) [[5]](diffhunk://#diff-39633822e2cf3e29f78b9de4db179f2f24515182972e4ffe2109770eda72db30R603-R613) [[6]](diffhunk://#diff-39633822e2cf3e29f78b9de4db179f2f24515182972e4ffe2109770eda72db30R754-R759)

**Persistence and Upgrade Path:**

* Updated serialization and deserialization logic for panes to include the foreground process CWD, and bumped the format version for both Unix and Windows upgrade paths. Added backward compatibility for previous versions. (`src/app/daemon/upgrade.zig`, `src/app/daemon/upgrade_windows.zig`) [[1]](diffhunk://#diff-278242f1d67924a4bc4005599246945895a9a7ce54e02ac9c87d64aeb85b69b0L12-R12) [[2]](diffhunk://#diff-278242f1d67924a4bc4005599246945895a9a7ce54e02ac9c87d64aeb85b69b0R159-R162) [[3]](diffhunk://#diff-278242f1d67924a4bc4005599246945895a9a7ce54e02ac9c87d64aeb85b69b0L181-R185) [[4]](diffhunk://#diff-278242f1d67924a4bc4005599246945895a9a7ce54e02ac9c87d64aeb85b69b0R273-R278) [[5]](diffhunk://#diff-278242f1d67924a4bc4005599246945895a9a7ce54e02ac9c87d64aeb85b69b0R306-R309) [[6]](diffhunk://#diff-265104aed26a1a9d1186a0ac8d23cb354f506b086fe4a4d6078a931aa48ba3bfL64-R64) [[7]](diffhunk://#diff-265104aed26a1a9d1186a0ac8d23cb354f506b086fe4a4d6078a931aa48ba3bfR172-R175) [[8]](diffhunk://#diff-265104aed26a1a9d1186a0ac8d23cb354f506b086fe4a4d6078a931aa48ba3bfL193-R197) [[9]](diffhunk://#diff-265104aed26a1a9d1186a0ac8d23cb354f506b086fe4a4d6078a931aa48ba3bfL204-R208) [[10]](diffhunk://#diff-265104aed26a1a9d1186a0ac8d23cb354f506b086fe4a4d6078a931aa48ba3bfL213-R217) [[11]](diffhunk://#diff-265104aed26a1a9d1186a0ac8d23cb354f506b086fe4a4d6078a931aa48ba3bfL239-R249) [[12]](diffhunk://#diff-265104aed26a1a9d1186a0ac8d23cb354f506b086fe4a4d6078a931aa48ba3bfR264-R268) [[13]](diffhunk://#diff-265104aed26a1a9d1186a0ac8d23cb354f506b086fe4a4d6078a931aa48ba3bfR305-R307)