### PR TITLE
fix: Completion and search alignment for multi-pane

### DIFF
--- a/src/app/linux_render.c
+++ b/src/app/linux_render.c
@@ -516,9 +516,11 @@ int drawFrame(void) {
         int srchRow = g_search_cur_vis_row;
         int srchCs = g_search_cur_vis_cs;
         int srchCe = g_search_cur_vis_ce;
+        int spr = g_pane_rect_row, spc = g_pane_rect_col;
         for (int vi = 0; vi < visCount && vi < ATTYX_SEARCH_VIS_MAX; vi++) {
             AttyxSearchVis m = g_search_vis[vi];
-            if (m.row < 0 || m.row >= visibleRows) continue;
+            int drawRow = m.row + spr;
+            if (m.row < 0 || drawRow >= visibleRows) continue;
             int isCurrent = (m.row == srchRow && m.col_start == srchCs && m.col_end == srchCe);
             float hr, hg, hb, ha;
             if (isCurrent) {
@@ -528,8 +530,8 @@ int drawFrame(void) {
             }
             for (int cc = m.col_start; cc < m.col_end && cc < cols; cc++) {
                 if (bgVertCount + 6 > g_bg_vert_cap) break;
-                float lx0 = offX + cc * gw, lx1 = lx0 + gw;
-                float ly0 = offY + m.row * gh, ly1 = ly0 + gh;
+                float lx0 = offX + (spc + cc) * gw, lx1 = lx0 + gw;
+                float ly0 = offY + drawRow * gh, ly1 = ly0 + gh;
                 g_bg_verts[bgVertCount+0] = (Vertex){ lx0,ly0, 0,0, hr,hg,hb,ha };
                 g_bg_verts[bgVertCount+1] = (Vertex){ lx1,ly0, 0,0, hr,hg,hb,ha };
                 g_bg_verts[bgVertCount+2] = (Vertex){ lx0,ly1, 0,0, hr,hg,hb,ha };

--- a/src/app/macos_renderer_draw.m
+++ b/src/app/macos_renderer_draw.m
@@ -393,10 +393,12 @@ static int emitRectV(Vertex* v, int i, float x, float y, float w, float h,
             int sCurRow = g_search_cur_vis_row;
             int curCs = g_search_cur_vis_cs;
             int curCe = g_search_cur_vis_ce;
+            int spr = g_pane_rect_row, spc = g_pane_rect_col;
             float ulH = gh;
             for (int vi = 0; vi < visCount && vi < ATTYX_SEARCH_VIS_MAX; vi++) {
                 AttyxSearchVis m = g_search_vis[vi];
-                if (m.row < 0 || m.row >= visibleRows) continue;
+                int drawRow = m.row + spr;
+                if (m.row < 0 || drawRow >= visibleRows) continue;
                 BOOL isCurrent = (m.row == sCurRow && m.col_start == curCs && m.col_end == curCe);
                 float hr, hg, hb, ha;
                 if (isCurrent) {
@@ -406,8 +408,8 @@ static int emitRectV(Vertex* v, int i, float x, float y, float w, float h,
                 }
                 for (int cc = m.col_start; cc < m.col_end && cc < cols; cc++) {
                     if (bgVertCount + 6 > _metalBufCapBg) break;
-                    float lx0 = offX + cc * gw, lx1 = lx0 + gw;
-                    float ly0 = offY + m.row * gh, ly1 = ly0 + ulH;
+                    float lx0 = offX + (spc + cc) * gw, lx1 = lx0 + gw;
+                    float ly0 = offY + drawRow * gh, ly1 = ly0 + ulH;
                     _bgVerts[bgVertCount+0] = (Vertex){ lx0,ly0, 0,0, hr,hg,hb,ha };
                     _bgVerts[bgVertCount+1] = (Vertex){ lx1,ly0, 0,0, hr,hg,hb,ha };
                     _bgVerts[bgVertCount+2] = (Vertex){ lx0,ly1, 0,0, hr,hg,hb,ha };

--- a/src/app/ui/publish.zig
+++ b/src/app/ui/publish.zig
@@ -316,6 +316,14 @@ pub fn viewportInfoFromCtx(ctx: *PtyThreadCtx) overlay_anchor.ViewportInfo {
     const sel_active_raw: i32 = @bitCast(c.g_sel_active);
     const sel_end_row_raw: i32 = @bitCast(c.g_sel_end_row);
     const sel_end_col_raw: i32 = @bitCast(c.g_sel_end_col);
+
+    // Pane offset converts pane-relative placement to window-absolute coords.
+    const layout = ctx.tab_mgr.activeLayout();
+    const in_split = layout.pane_count > 1 and !layout.isZoomed();
+    const pane_row: u16 = if (in_split) @intCast(layout.pool[layout.focused].rect.row) else 0;
+    const pane_col: u16 = if (in_split) @intCast(layout.pool[layout.focused].rect.col) else 0;
+    const top_offset: u16 = @intCast(terminal.g_grid_top_offset);
+
     return .{
         .grid_cols = @intCast(eng.state.ring.cols),
         .grid_rows = @intCast(eng.state.ring.screen_rows),
@@ -325,6 +333,8 @@ pub fn viewportInfoFromCtx(ctx: *PtyThreadCtx) overlay_anchor.ViewportInfo {
         .sel_end_row = if (sel_end_row_raw >= 0) @intCast(@as(u32, @bitCast(sel_end_row_raw))) else 0,
         .sel_end_col = if (sel_end_col_raw >= 0) @intCast(@as(u32, @bitCast(sel_end_col_raw))) else 0,
         .alt_active = eng.state.alt_active,
+        .offset_row = pane_row + top_offset,
+        .offset_col = pane_col,
     };
 }
 

--- a/src/app/windows_renderer_draw.c
+++ b/src/app/windows_renderer_draw.c
@@ -152,16 +152,18 @@ static int build_search_highlights(WinVertex* verts, int bgVertCount, int vertCa
     int srchRow = g_search_cur_vis_row;
     int srchCs  = g_search_cur_vis_cs;
     int srchCe  = g_search_cur_vis_ce;
+    int spr = g_pane_rect_row, spc = g_pane_rect_col;
     for (int vi = 0; vi < visCount && vi < ATTYX_SEARCH_VIS_MAX; vi++) {
         AttyxSearchVis m = g_search_vis[vi];
-        if (m.row < 0 || m.row >= visibleRows) continue;
+        int drawRow = m.row + spr;
+        if (m.row < 0 || drawRow >= visibleRows) continue;
         int isCur = (m.row == srchRow && m.col_start == srchCs && m.col_end == srchCe);
         float hr = 1.0f, hg = 0.6f, hb = 0.0f;
         float ha = isCur ? 0.75f : 0.28f;
         for (int cc = m.col_start; cc < m.col_end && cc < cols; cc++) {
             if (bgVertCount + 6 > vertCap) break;
             bgVertCount = winEmitRect(verts, bgVertCount,
-                                       offX + cc * gw, offY + m.row * gh,
+                                       offX + (spc + cc) * gw, offY + drawRow * gh,
                                        gw, gh, hr, hg, hb, ha);
         }
     }

--- a/src/overlay/anchor.zig
+++ b/src/overlay/anchor.zig
@@ -48,6 +48,9 @@ pub const ViewportInfo = struct {
     sel_end_row: u16,
     sel_end_col: u16,
     alt_active: bool,
+    /// Offset to convert pane-relative placement to window-absolute coords.
+    offset_row: u16 = 0,
+    offset_col: u16 = 0,
 };
 
 pub const PlacementConstraints = struct {

--- a/src/overlay/overlay.zig
+++ b/src/overlay/overlay.zig
@@ -146,8 +146,8 @@ pub const OverlayManager = struct {
                     vp,
                     layer.placement_constraints,
                 );
-                layer.col = rect.col;
-                layer.row = rect.row;
+                layer.col = rect.col + vp.offset_col;
+                layer.row = rect.row + vp.offset_row;
             } else {
                 // Fallback: simple clamp
                 if (layer.width > vp.grid_cols) {


### PR DESCRIPTION
This pull request updates the rendering and overlay placement logic to correctly account for pane offsets in split-pane layouts. This ensures that search highlights and overlays are positioned accurately relative to the entire window, rather than just the pane, across all supported platforms (Linux, macOS, Windows). Additionally, new fields are introduced to propagate pane offset information through the UI and overlay systems.

**Rendering and UI updates for pane-relative placement:**

* All renderers (`linux_render.c`, `macos_renderer_draw.m`, `windows_renderer_draw.c`) now calculate search highlight positions using pane-relative offsets (`g_pane_rect_row`, `g_pane_rect_col`) to ensure highlights are drawn in the correct window location, even in split-pane mode. [[1]](diffhunk://#diff-28b9e73824caff1293f5b6deaaad0bd9cf0c59a3928d631fa4aca18143885a07R519-R523) [[2]](diffhunk://#diff-28b9e73824caff1293f5b6deaaad0bd9cf0c59a3928d631fa4aca18143885a07L531-R534) [[3]](diffhunk://#diff-55bc404a1777d5e0d881b15830f03a384cfb928cf5e150f02ddc53017426d0faR396-R401) [[4]](diffhunk://#diff-55bc404a1777d5e0d881b15830f03a384cfb928cf5e150f02ddc53017426d0faL409-R412) [[5]](diffhunk://#diff-b8e69acea16dd882ad42a995d5c1f213f740368902dc036ebfe3994b15661d06R155-R166)

**Overlay and viewport information propagation:**

* The `ViewportInfo` struct in `overlay/anchor.zig` now includes `offset_row` and `offset_col` fields to represent the pane-to-window offset, with logic in `publish.zig` to compute these offsets based on the current layout and zoom state. [[1]](diffhunk://#diff-153dc911887a1b7767aa48c4e10f10acc93188552b2e22ab35e7dc21e8563469R319-R326) [[2]](diffhunk://#diff-153dc911887a1b7767aa48c4e10f10acc93188552b2e22ab35e7dc21e8563469R336-R337) [[3]](diffhunk://#diff-2a1060e62e570d2409e376019bed650ad6c244f97f544d8c4ca874f8c9e8fea8R51-R53)
* Overlay placement in `overlay.zig` now adds these offsets when computing the absolute position of overlays, ensuring overlays are correctly positioned in multi-pane scenarios.