### PR TITLE
fix: Proper link clicking behavior

### DIFF
--- a/src/app/linux_input.c
+++ b/src/app/linux_input.c
@@ -700,6 +700,42 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
                 }
             }
 
+            // Ctrl-click on a link bypasses mouse reporting so TUIs don't
+            // swallow the click before we can open the URL. Falls through
+            // when there's no link at the clicked cell.
+            if (mods & GLFW_MOD_CONTROL) {
+                int cc, cr;
+                mouseToCell(mx, my, &cc, &cr);
+                cr -= g_grid_top_offset;
+                if (cr >= 0) {
+                    int cols = g_cols, nrows = g_rows;
+                    if (g_cells && cc >= 0 && cc < cols && cr < nrows) {
+                        uint32_t lid = g_cells[cr * cols + cc].link_id;
+                        if (lid != 0) {
+                            char uri_buf[2048];
+                            int uri_len = attyx_get_link_uri(lid, uri_buf, sizeof(uri_buf));
+                            if (uri_len > 0) {
+                                char cmd[2200];
+                                snprintf(cmd, sizeof(cmd), "xdg-open '%s' &", uri_buf);
+                                (void)system(cmd);
+                            }
+                            g_left_down = 1;
+                            return;
+                        }
+                        int dStart, dEnd;
+                        char dUrl[DETECTED_URL_MAX];
+                        int dLen = 0;
+                        if (detectUrlAtCell(cr, cc, cols, &dStart, &dEnd, dUrl, DETECTED_URL_MAX, &dLen) && dLen > 0) {
+                            char cmd[2200];
+                            snprintf(cmd, sizeof(cmd), "xdg-open '%s' &", dUrl);
+                            (void)system(cmd);
+                            g_left_down = 1;
+                            return;
+                        }
+                    }
+                }
+            }
+
             if (g_mouse_tracking && g_mouse_sgr) {
                 int col, row;
                 mouseToCell1(mx, my, &col, &row);
@@ -750,37 +786,8 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
                 if (col >= pce) col = pce - 1;
             }
 
-            // Ctrl+click opens hyperlink
-            if (mods & GLFW_MOD_CONTROL) {
-                int cols = g_cols, nrows = g_rows;
-                if (g_cells && col >= 0 && col < cols && row >= 0 && row < nrows) {
-                    // OSC 8 link takes priority
-                    uint32_t lid = g_cells[row * cols + col].link_id;
-                    if (lid != 0) {
-                        char uri_buf[2048];
-                        int uri_len = attyx_get_link_uri(lid, uri_buf, sizeof(uri_buf));
-                        if (uri_len > 0) {
-                            char cmd[2200];
-                            snprintf(cmd, sizeof(cmd), "xdg-open '%s' &", uri_buf);
-                            (void)system(cmd);
-                        }
-                        g_left_down = 1;
-                        return;
-                    }
-
-                    // Fallback: regex-detected URL
-                    int dStart, dEnd;
-                    char dUrl[DETECTED_URL_MAX];
-                    int dLen = 0;
-                    if (detectUrlAtCell(row, col, cols, &dStart, &dEnd, dUrl, DETECTED_URL_MAX, &dLen) && dLen > 0) {
-                        char cmd[2200];
-                        snprintf(cmd, sizeof(cmd), "xdg-open '%s' &", dUrl);
-                        (void)system(cmd);
-                        g_left_down = 1;
-                        return;
-                    }
-                }
-            }
+            // Ctrl-click link handling runs earlier (before mouse-reporting)
+            // so it works inside TUIs.
 
             // Shift-click extends existing selection
             if ((mods & GLFW_MOD_SHIFT) && g_sel_active) {
@@ -965,11 +972,14 @@ static void cursorPosCallback(GLFWwindow* w, double mx, double my) {
     if (!g_left_down && g_mouse_tracking == 3 && g_mouse_sgr) {
         int col, row;
         mouseToCell1(mx, my, &col, &row);
-        if (col == g_last_motion_col && row == g_last_motion_row) return;
-        sendSgrMouse(35, col, row, 1);
-        g_last_motion_col = col;
-        g_last_motion_row = row;
-        return;
+        if (col != g_last_motion_col || row != g_last_motion_row) {
+            sendSgrMouse(35, col, row, 1);
+            g_last_motion_col = col;
+            g_last_motion_row = row;
+        }
+        // Fall through so hover-link detection still runs — TUIs with
+        // motion reporting (Claude Code, etc.) should still show the
+        // hand cursor and underline for OSC 8 hyperlinks.
     }
     if (g_selecting && g_left_down) {
         // Auto-scroll when dragging past top/bottom edge
@@ -1031,8 +1041,10 @@ static void cursorPosCallback(GLFWwindow* w, double mx, double my) {
         return;
     }
 
-    // Hyperlink hover detection (when mouse mode is off)
-    if (!g_mouse_tracking && !g_left_down) {
+    // Hyperlink hover detection. Runs even when mouse reporting is active
+    // (but not while dragging a selection) so OSC 8 links highlight inside
+    // TUIs like Claude Code.
+    if (!g_left_down) {
         int col, row;
         mouseToCell(mx, my, &col, &row);
         row -= g_grid_top_offset;

--- a/src/app/macos_input.m
+++ b/src/app/macos_input.m
@@ -333,6 +333,49 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
         }
     }
 
+    // Cmd-click on a link bypasses mouse reporting so TUIs (Claude Code,
+    // vim, etc.) don't swallow the click before we can open the URL.
+    // Falls through to the normal mouse-reporting / selection path when
+    // there's no link at the clicked cell.
+    if (event.modifierFlags & NSEventModifierFlagCommand) {
+        int cc, cr;
+        mouseCell0(event, self, &cc, &cr);
+        cr -= g_grid_top_offset;
+        if (cr >= 0) {
+            int cols = g_cols, rows_n = g_rows;
+            if (g_cells && cc >= 0 && cc < cols && cr < rows_n) {
+                uint32_t lid = g_cells[cr * cols + cc].link_id;
+                if (lid != 0) {
+                    char uri_buf[2048];
+                    int uri_len = attyx_get_link_uri(lid, uri_buf, sizeof(uri_buf));
+                    if (uri_len > 0) {
+                        NSString* urlStr = [[NSString alloc] initWithBytes:uri_buf
+                                                                   length:uri_len
+                                                                 encoding:NSUTF8StringEncoding];
+                        if (urlStr) {
+                            NSURL* url = [NSURL URLWithString:urlStr];
+                            if (url) [[NSWorkspace sharedWorkspace] openURL:url];
+                        }
+                    }
+                    return;
+                }
+                int dStart, dEnd;
+                char dUrl[DETECTED_URL_MAX];
+                int dLen = 0;
+                if (detectUrlAtCell(cr, cc, cols, &dStart, &dEnd, dUrl, DETECTED_URL_MAX, &dLen) && dLen > 0) {
+                    NSString* urlStr = [[NSString alloc] initWithBytes:dUrl
+                                                               length:dLen
+                                                             encoding:NSUTF8StringEncoding];
+                    if (urlStr) {
+                        NSURL* url = [NSURL URLWithString:urlStr];
+                        if (url) [[NSWorkspace sharedWorkspace] openURL:url];
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
     if (g_mouse_tracking && g_mouse_sgr) {
         int col, row;
         mouseCell(event, self, &col, &row);
@@ -386,40 +429,9 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
         if (col >= pce) col = pce - 1;
     }
 
-    if (event.modifierFlags & NSEventModifierFlagCommand) {
-        int cols = g_cols, rows_n = g_rows;
-        if (g_cells && col >= 0 && col < cols && row >= 0 && row < rows_n) {
-            uint32_t lid = g_cells[row * cols + col].link_id;
-            if (lid != 0) {
-                char uri_buf[2048];
-                int uri_len = attyx_get_link_uri(lid, uri_buf, sizeof(uri_buf));
-                if (uri_len > 0) {
-                    NSString* urlStr = [[NSString alloc] initWithBytes:uri_buf
-                                                               length:uri_len
-                                                             encoding:NSUTF8StringEncoding];
-                    if (urlStr) {
-                        NSURL* url = [NSURL URLWithString:urlStr];
-                        if (url) [[NSWorkspace sharedWorkspace] openURL:url];
-                    }
-                }
-                return;
-            }
+    // Cmd-click link handling runs earlier (before mouse-reporting) so it
+    // works inside TUIs. By this point we know no link was at the click.
 
-            int dStart, dEnd;
-            char dUrl[DETECTED_URL_MAX];
-            int dLen = 0;
-            if (detectUrlAtCell(row, col, cols, &dStart, &dEnd, dUrl, DETECTED_URL_MAX, &dLen) && dLen > 0) {
-                NSString* urlStr = [[NSString alloc] initWithBytes:dUrl
-                                                           length:dLen
-                                                         encoding:NSUTF8StringEncoding];
-                if (urlStr) {
-                    NSURL* url = [NSURL URLWithString:urlStr];
-                    if (url) [[NSWorkspace sharedWorkspace] openURL:url];
-                }
-                return;
-            }
-        }
-    }
     // Shift-click extends existing selection
     if ((event.modifierFlags & NSEventModifierFlagShift) && g_sel_active) {
         g_sel_end_row = row;
@@ -815,18 +827,11 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
     }
 
     int tracking = g_mouse_tracking;
-    if (tracking == 3 && g_mouse_sgr) {
-        int col, row;
-        mouseCell(event, self, &col, &row);
-        if (col == _lastMouseCol && row == _lastMouseRow) return;
-        int btn = 35 | mouseModifiers(event.modifierFlags);
-        sendSgrMouse(btn, col, row, YES);
-        _lastMouseCol = col;
-        _lastMouseRow = row;
-        return;
-    }
 
-    if (!tracking) {
+    // Run hover-link detection unconditionally so OSC 8 hyperlinks still
+    // show the hand cursor and hover underline even when a TUI has mouse
+    // motion reporting enabled.
+    {
         int col, row;
         mouseCell0(event, self, &col, &row);
 
@@ -892,6 +897,17 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
             if (row >= 0 && row < 256 && isLink)
                 __sync_fetch_and_or((volatile uint64_t*)&g_dirty[row >> 6], (uint64_t)1 << (row & 63));
         }
+    }
+
+    // Forward SGR motion reports to the app when any-motion tracking is on.
+    if (tracking == 3 && g_mouse_sgr) {
+        int col, row;
+        mouseCell(event, self, &col, &row);
+        if (col == _lastMouseCol && row == _lastMouseRow) return;
+        int btn = 35 | mouseModifiers(event.modifierFlags);
+        sendSgrMouse(btn, col, row, YES);
+        _lastMouseCol = col;
+        _lastMouseRow = row;
     }
 }
 

--- a/src/app/windows_mouse.c
+++ b/src/app/windows_mouse.c
@@ -225,6 +225,41 @@ LRESULT win_handleLButtonDown(HWND hwnd, LPARAM lParam) {
         }
     }
 
+    // Ctrl-click on a link bypasses mouse reporting so TUIs don't swallow
+    // the click before we can open the URL. Falls through when there's no
+    // link at the clicked cell.
+    if (GetKeyState(VK_CONTROL) & 0x8000) {
+        int cc, cr;
+        mouseToCell(px, py, &cc, &cr);
+        cr -= g_grid_top_offset;
+        if (cr >= 0) {
+            int cols = g_cols, nrows = g_rows;
+            if (g_cells && cc >= 0 && cc < cols && cr < nrows) {
+                uint32_t lid = g_cells[cr * cols + cc].link_id;
+                if (lid != 0) {
+                    char uri_buf[2048];
+                    int uri_len = attyx_get_link_uri(lid, uri_buf, sizeof(uri_buf));
+                    if (uri_len > 0) {
+                        uri_buf[uri_len] = '\0';
+                        ShellExecuteA(NULL, "open", uri_buf, NULL, NULL, SW_SHOW);
+                    }
+                    g_left_down = 1;
+                    return 0;
+                }
+                int dStart, dEnd;
+                char dUrl[DETECTED_URL_MAX];
+                int dLen = 0;
+                if (detectUrlAtCell(cr, cc, cols, &dStart, &dEnd,
+                                    dUrl, DETECTED_URL_MAX, &dLen) && dLen > 0) {
+                    dUrl[dLen] = '\0';
+                    ShellExecuteA(NULL, "open", dUrl, NULL, NULL, SW_SHOW);
+                    g_left_down = 1;
+                    return 0;
+                }
+            }
+        }
+    }
+
     if (g_mouse_tracking && g_mouse_sgr) {
         int col, row;
         mouseToCell1(px, py, &col, &row);
@@ -267,33 +302,8 @@ LRESULT win_handleLButtonDown(HWND hwnd, LPARAM lParam) {
         if (col >= pce) col = pce - 1;
     }
 
-    // Ctrl+click opens hyperlink
-    if (GetKeyState(VK_CONTROL) & 0x8000) {
-        int cols = g_cols, nrows = g_rows;
-        if (g_cells && col >= 0 && col < cols && row >= 0 && row < nrows) {
-            uint32_t lid = g_cells[row * cols + col].link_id;
-            if (lid != 0) {
-                char uri_buf[2048];
-                int uri_len = attyx_get_link_uri(lid, uri_buf, sizeof(uri_buf));
-                if (uri_len > 0) {
-                    uri_buf[uri_len] = '\0';
-                    ShellExecuteA(NULL, "open", uri_buf, NULL, NULL, SW_SHOW);
-                }
-                g_left_down = 1;
-                return 0;
-            }
-            int dStart, dEnd;
-            char dUrl[DETECTED_URL_MAX];
-            int dLen = 0;
-            if (detectUrlAtCell(row, col, cols, &dStart, &dEnd,
-                                dUrl, DETECTED_URL_MAX, &dLen) && dLen > 0) {
-                dUrl[dLen] = '\0';
-                ShellExecuteA(NULL, "open", dUrl, NULL, NULL, SW_SHOW);
-                g_left_down = 1;
-                return 0;
-            }
-        }
-    }
+    // Ctrl-click link handling runs earlier (before mouse-reporting)
+    // so it works inside TUIs.
 
     // Shift-click extends selection
     if ((GetKeyState(VK_SHIFT) & 0x8000) && g_sel_active) {


### PR DESCRIPTION
This pull request improves the user experience when opening hyperlinks in terminal applications by ensuring that modifier-clicks (Cmd-click on macOS, Ctrl-click on Linux and Windows) on links work even inside terminal UIs (TUIs) that capture mouse events. The main change is that link-opening logic now runs before mouse event reporting, so TUIs can't intercept and block link opening. Additionally, hover detection for OSC 8 hyperlinks is improved to work even when mouse motion reporting is active.

The most important changes are:

**Modifier-click link opening improvements:**
* Refactored Cmd-click (macOS) and Ctrl-click (Linux/Windows) link handling to occur before mouse event reporting, ensuring that clicking links works inside TUIs that capture mouse events. This logic now checks for OSC 8 links and regex-detected URLs at the clicked cell and opens them directly, falling through to normal mouse handling only if no link is found. (`src/app/macos_input.m`, `src/app/linux_input.c`, `src/app/windows_mouse.c`) [[1]](diffhunk://#diff-43488430325745b55598d8c96e0cd0e5834b0676a4147815e19d62d7bff68f06R336-R378) [[2]](diffhunk://#diff-00c0fd68c8e642c93f5037c1af5bc043c3e11f9b263a8d21fa8a40d31585811dR703-R738) [[3]](diffhunk://#diff-0b801d469611c8ec3ba489138c1c7f05cd542277d27e94564c136620d3bf1f97R228-R262)
* Removed the old modifier-click link handling code that previously ran after mouse reporting, since it is now redundant. (`src/app/macos_input.m`, `src/app/linux_input.c`, `src/app/windows_mouse.c`) [[1]](diffhunk://#diff-43488430325745b55598d8c96e0cd0e5834b0676a4147815e19d62d7bff68f06L389-L422) [[2]](diffhunk://#diff-00c0fd68c8e642c93f5037c1af5bc043c3e11f9b263a8d21fa8a40d31585811dL753-R790) [[3]](diffhunk://#diff-0b801d469611c8ec3ba489138c1c7f05cd542277d27e94564c136620d3bf1f97L270-R306)

**Hyperlink hover and mouse motion improvements:**
* Updated hover detection for OSC 8 hyperlinks so that it runs even when mouse motion reporting is enabled, allowing hand cursors and underlines to appear for links inside TUIs. (`src/app/macos_input.m`, `src/app/linux_input.c`) [[1]](diffhunk://#diff-43488430325745b55598d8c96e0cd0e5834b0676a4147815e19d62d7bff68f06L818-R834) [[2]](diffhunk://#diff-00c0fd68c8e642c93f5037c1af5bc043c3e11f9b263a8d21fa8a40d31585811dL1034-R1047)
* Changed mouse motion event handling to always forward SGR motion reports when any-motion tracking is enabled, while still allowing hover-link detection to run. (`src/app/macos_input.m`, `src/app/linux_input.c`) [[1]](diffhunk://#diff-43488430325745b55598d8c96e0cd0e5834b0676a4147815e19d62d7bff68f06R901-R911) [[2]](diffhunk://#diff-00c0fd68c8e642c93f5037c1af5bc043c3e11f9b263a8d21fa8a40d31585811dL968-R982)

These changes make link opening and hover feedback more reliable and consistent across all platforms, even when running terminal UIs that use mouse input.