### PR TITLE
fix: Tab switch flickering and lag

### DIFF
--- a/docs/server-side-engine.md
+++ b/docs/server-side-engine.md
@@ -1,0 +1,259 @@
+# Design: Server-Side VT Engine (tmux-style)
+
+## Motivation
+
+Attyx session switching is ~60–200ms because the daemon is a **byte-level**
+multiplexer — it ships raw PTY output to the client and the client's VT
+engine reprocesses those bytes to rebuild cell state. For a session with
+several altscreen TUI apps (Claude Code, vim, htop), every switch requires
+replaying tens of KB of VT sequences per pane.
+
+Tmux is instant because its server runs the engine itself: it keeps a
+rendered cell grid per pane in server memory, and switching just ships the
+grid. There's nothing to replay.
+
+This doc proposes moving the VT engine from client to daemon so attyx can
+match tmux's switch latency.
+
+## Current architecture (byte-level)
+
+```
+┌─ attyx client ────────────────────┐   ┌─ attyx daemon ────────┐
+│                                   │   │                       │
+│  render (Metal/GL)                │   │  PTY masters          │
+│       ↑                           │   │       ↓               │
+│  cells (AttyxCell buffer)         │   │  per-pane ring        │
+│       ↑                           │   │  buffer of raw bytes  │
+│  Engine per pane (src/term/)      │◀──┼──────── socket ───────┤
+│       ↑                           │   │  (pane_output msgs)   │
+│  pane_output bytes via socket     │   │                       │
+│                                   │   │                       │
+└───────────────────────────────────┘   └───────────────────────┘
+```
+
+- Daemon stores raw PTY bytes, sends them on focus.
+- Client runs `src/term/` Engine to parse bytes → cells.
+- On focus change, daemon replays the ring; client re-parses from scratch.
+
+## Proposed architecture (cell-level)
+
+```
+┌─ attyx client ────────────────┐   ┌─ attyx daemon ────────────┐
+│                               │   │                           │
+│  render (Metal/GL)            │   │  PTY masters              │
+│       ↑                       │   │       ↓                   │
+│  cells (AttyxCell buffer)     │◀──┼── socket (grid sync) ─────┤
+│       ↑                       │   │       ↑                   │
+│  grid sync (apply deltas)     │   │  Engine per pane          │
+│  input router                 │   │  (src/term/ moved here)   │
+│                               │   │       ↑                   │
+│                               │   │  PTY bytes → engine       │
+│                               │   │                           │
+└───────────────────────────────┘   └───────────────────────────┘
+```
+
+- Daemon owns the Engine per pane, feeds PTY bytes into it continuously.
+- Daemon maintains an authoritative cell grid per pane at all times.
+- Focus/session switch: daemon ships a cell snapshot (or delta since the
+  client's last-seen generation). No replay. No shadow engine. No
+  reprocessing.
+- Client is now a "thin" renderer + input router.
+
+## Protocol sketch
+
+Two new message types; `pane_output` + `replay_end` go away.
+
+### `grid_snapshot` (daemon → client)
+
+Sent on first focus and whenever the client requests a full resync.
+
+```
+pane_id: u32
+generation: u64       // monotonic per-pane counter; client tracks last-seen
+rows: u16
+cols: u16
+alt_active: u8
+cursor_row: u16
+cursor_col: u16
+cursor_visible: u8
+cursor_shape: u8
+// followed by rows*cols packed cells (same wire format as AttyxCell or similar)
+```
+
+### `grid_delta` (daemon → client)
+
+Sent every time the daemon's engine emits dirty rows (throttled to
+~60Hz per-client).
+
+```
+pane_id: u32
+generation: u64                    // new generation after this delta
+dirty_row_bitmap: [N]u64           // which rows changed
+// for each dirty row: packed row cells
+cursor_row/col/visible/shape: ...  // (include even if unchanged, it's tiny)
+```
+
+Client applies: if its last-seen generation matches `generation - 1`,
+apply dirty rows; otherwise request a full `grid_snapshot`.
+
+### Input still flows as-is
+
+`pane_input` (client → daemon, raw bytes for PTY write) stays unchanged.
+That path is already thin.
+
+## One engine codebase, two run-time locations
+
+**The engine module is not duplicated.**  `src/term/` stays exactly where
+it is — a single pure, deterministic implementation.  Both the client
+binary and the daemon binary `@import` it.
+
+- **Plain mode (no daemon):** client's PTY thread runs the engine
+  in-process, same as today.  No grid protocol kicks in.
+- **Session mode (daemon attached):** the daemon runs the engine in its
+  own process.  Client receives grid snapshots/deltas over the socket
+  and becomes a thin renderer.
+
+A given pane's engine runs in exactly one process — whichever owns the
+PTY.  Never both.  The renderer can take its cells from either source
+based on a small enum at the cell-publishing layer.
+
+**Per-pane vs. per-viewer state.**  Some state currently living in
+`TerminalState` is really per-client, not per-pane: `viewport_offset`
+(scroll position), search matches, selection, Xyron UI state.  When the
+engine moves server-side for session mode, these must stay client-side
+(each attached client can scroll independently).  The refactor needs to
+split `TerminalState` into:
+- **Authoritative engine state** (daemon-side in session mode):
+  cells, cursor, altscreen mode, saved cursor, scroll region, title,
+  mouse/cursor-keys modes, theme colors.
+- **Per-viewer UI state** (always client-side): viewport_offset, search
+  state, selection rect, Xyron integration fields.
+
+In plain mode both live in the same process so nothing changes.  In
+session mode the boundary matters.
+
+## Implementation plan
+
+1. **Prepare `src/term/` for the split.**
+   - Engine must not depend on client globals (`terminal.g_*`) or anything
+     platform-specific.  Already true per CLAUDE.md; double-check.
+   - Separate per-viewer fields (viewport_offset, etc.) out of
+     `TerminalState` into a new `ViewerState` struct owned by the client.
+   - Remove engine instances from client-side `Pane` only for
+     daemon-backed panes (local panes keep theirs).
+
+2. **Daemon owns engines.**
+   - Each `DaemonPane` gets an `Engine` alongside its existing ring buffer
+     (keep the ring buffer initially for debugging/reconstruction).
+   - PTY read path: `engine.feed(bytes)` instead of (or in addition to)
+     appending to the ring.
+
+3. **Dirty-row tracking per client.**
+   - Daemon tracks `last_sent_generation` per (client, pane) pair.
+   - After each `engine.feed`, if generation advanced, flag pane for sync
+     to each attached client that has it in `active_panes`.
+
+4. **Grid sync loop.**
+   - Every daemon poll iteration (~16ms), for each flagged (client, pane):
+     - If client's last-seen == gen-N (adjacent), send `grid_delta`.
+     - Otherwise send `grid_snapshot`.
+   - Client replies with ack? Probably not needed — daemon just tracks
+     what it sent.
+
+5. **Client becomes renderer-only.**
+   - On `grid_snapshot`: copy cells into `pane.cells_view` (new field
+     replacing `pane.engine`). Mark pane dirty for render.
+   - On `grid_delta`: apply dirty rows, update cursor globals.
+   - `switchActiveTab` no longer composes from `pane.engine` — copies
+     from `pane.cells_view` into `ctx.cells`.
+
+6. **Retire dead code.**
+   - Shadow engine (`pane.shadow_engine`) — no longer needed.
+   - `pane_output` handler in event_loop — gone.
+   - `replay_end` handler + `replay_end` protocol msg — gone.
+   - `notifyRedraw` / SIGWINCH nudge in daemon — gone. The TUI's redraws
+     flow into the daemon's engine naturally; no need to force them.
+   - `needs_engine_reinit` flag on Pane — gone.
+   - Client-side `src/term/` Engine usage — gone (replaced by cells_view).
+
+7. **Keep ring buffer?**
+   - The daemon's replay ring was useful for "new client attaches to
+     existing session" scenarios and for debugging. For new clients,
+     we can bootstrap them by sending a snapshot from the current
+     engine state. Ring becomes redundant — remove it.
+
+## Input routing
+
+Currently `attyx_handle_key` on the client translates keys to VT bytes
+and sends them via `pane_input`. That stays. The daemon's engine
+processes both the child's output AND receives input bytes — but input
+goes straight to the PTY master (write to child), not through the
+engine. Same as today.
+
+## What breaks during the refactor
+
+- **Xyron integration:** Xyron-specific overlays and completion state
+  live in the client's engine today (`engine.state.xyron_ipc_socket`
+  etc.). Either (a) keep those fields in a client-side per-pane struct
+  that's orthogonal to the engine, or (b) move those to daemon too.
+  Option (a) is cleaner — Xyron's UI decisions belong on the client.
+
+- **Per-pane viewport_offset (scrollback scroll):** Currently the engine
+  tracks this. Server-side engine must either (a) maintain per-client
+  viewport offsets (complicated) or (b) expose scrollback as a separate
+  query (`get_scrollback_range` → bytes, client re-parses for its local
+  scroll view). (b) is saner: active viewport tracking per pane, but
+  scrollback rendering becomes an explicit "give me rows N..M" RPC.
+  This is actually how tmux copy-mode works — it asks the server for
+  historical cells.
+
+- **Search (`src/app/ui/search.zig`):** Currently searches client's
+  engine. Needs to search via the daemon — add `search_pane` RPC.
+
+- **Selection/copy:** Client-side selection state is fine; the actual
+  copy reads cells from `pane.cells_view` which is up-to-date.
+
+## Performance expectations
+
+- **Tab switch within session:** already fast after the warm-panes
+  change. Server-side engine doesn't improve this much.
+- **Session switch:** 60–200ms → 5–15ms. The win.
+- **First attach / session restore:** need to ship one snapshot per
+  pane, each ~rows*cols*sizeof(Cell) = 80*30*32 = ~77KB. Localhost
+  socket = <5ms per pane.
+- **Steady-state bandwidth:** deltas are tiny (usually 1-3 dirty rows
+  per frame). Similar or less than current pane_output stream, because
+  the daemon coalesces engine-internal state transitions.
+
+## Migration strategy
+
+Can ship incrementally:
+1. Ship the engine in daemon alongside the existing byte-stream path.
+   Run both, compare cell grids for sanity.
+2. Add `grid_snapshot` / `grid_delta` protocol. Client opt-in via flag.
+3. Flip default to grid-sync. Remove byte-stream path and client engine
+   after a release of field testing.
+
+## What we already did in preparation
+
+Not really preparation, but the recent work made the client-side flow
+cleaner:
+- `scratch_cells` + atomic `@memcpy` for cell publishing — the renderer
+  already treats the cell buffer as authoritative. Swapping in a daemon-
+  delivered grid instead of a client-engine-rendered one is a drop-in.
+- Shadow engine — can be deleted once daemon owns the engine.
+- Warm-panes (`sendActiveFocusPanes` keeps all daemon panes active) —
+  already matches the server-side engine model; the daemon already
+  streams all output. The only reason we still replay is that the
+  client reboots its engine on first-time focus. Server-side engine
+  removes that.
+
+## Rough effort
+
+- Extract engine to daemon: 1 day (engine is already pure).
+- Protocol + serialization: 1 day.
+- Client renderer wiring: 1 day.
+- Search / scrollback / Xyron integration patches: 2 days.
+- Testing / debugging: 2 days.
+
+**~1 week of focused work** for a proper migration.

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -419,16 +419,23 @@ pub const DaemonPane = struct {
         self.cols = cols;
     }
 
-    /// Force a full repaint by nudging the PTY size by one column.
+    /// Force a full repaint after focus change so TUI apps re-render their
+    /// current frame into the PTY (and thus into the replay stream the client
+    /// is processing).  On POSIX we send SIGWINCH directly to the foreground
+    /// process group at the *current* dimensions — this triggers the redraw
+    /// without changing geometry, so width-responsive TUIs (Claude Code
+    /// banner, tmux status line, etc.) don't flicker between layouts during
+    /// the tab switch.  Windows has no SIGWINCH, so we keep the old col-nudge
+    /// there (host_conn.sendResize doesn't accept same-dim no-op).
     pub fn notifyRedraw(self: *DaemonPane) void {
-        const nudged = if (self.cols < std.math.maxInt(u16)) self.cols + 1 else self.cols - 1;
         if (comptime is_windows) {
             if (self.host_conn) |hc| {
+                const nudged = if (self.cols < std.math.maxInt(u16)) self.cols + 1 else self.cols - 1;
                 _ = hc.sendResize(self.rows, nudged);
                 return;
             }
         }
-        self.pty.resize(self.rows, nudged) catch {};
+        self.pty.sendSigwinch();
     }
 
     /// Non-blocking check if child process has exited.

--- a/src/app/pane.zig
+++ b/src/app/pane.zig
@@ -41,9 +41,15 @@ pub const Pane = struct {
     daemon_pane_id: ?u32 = null,
     /// Session client for sending resize to daemon (set for daemon-backed panes).
     session_client: ?*@import("session_client.zig").SessionClient = null,
-    /// When true, the engine will be reinitialized before the next data feed
-    /// (deferred reinit to prevent blank-screen gap between focus and replay).
+    /// When true, the next incoming pane_output for this pane belongs to a
+    /// daemon replay burst.  Bytes are routed into `shadow_engine` (allocated
+    /// lazily on the first replay byte) instead of the live `engine`, so the
+    /// last known visible state stays on screen during catch-up.  On the
+    /// matching `replay_end` message, `shadow_engine` is swapped into
+    /// `engine` atomically — single visual transition, no blank-gap,
+    /// no "Tab N" fallback, no stacked duplicate content.
     needs_engine_reinit: bool = false,
+    shadow_engine: ?Engine = null,
     /// Foreground process name reported by the daemon (for title fallback).
     daemon_proc_name: [64]u8 = undefined,
     daemon_proc_name_len: u8 = 0,
@@ -187,6 +193,7 @@ pub const Pane = struct {
             self.pty.deinit();
         }
         self.engine.deinit();
+        if (self.shadow_engine) |*s| s.deinit();
     }
 
     /// Non-blocking drain of stdout capture pipe into captured_stdout buffer.
@@ -225,6 +232,11 @@ pub const Pane = struct {
         self.engine.state.resize(rows, cols) catch |err| {
             logging.err("resize", "state.resize({d}x{d}) failed: {}", .{ cols, rows, err });
         };
+        // Keep shadow engine dimensions in sync so the pending swap at
+        // replay_end lands at the right size.
+        if (self.shadow_engine) |*s| {
+            s.state.resize(rows, cols) catch {};
+        }
         // Leading-edge throttle: record pending dimensions but don't reset
         // the timer. flushPtyResize() fires immediately on the first event,
         // then at most once per throttle interval during continuous resizing.

--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -45,6 +45,12 @@ const MAX_CELLS = c.ATTYX_MAX_ROWS * c.ATTYX_MAX_COLS;
 pub const PtyThreadCtx = struct {
     tab_mgr: *TabManager,
     cells: [*]c.AttyxCell,
+    // Scratch buffer used to compose the next frame off-screen during tab
+    // switches.  Composing into a side buffer and memcpy'ing into `cells`
+    // under the begin/end_cell_update guard avoids the renderer ever
+    // observing a half-cleared frame (blank flash) or a stride mismatch
+    // between engine.cols and grid_cols (text-wrap flicker).
+    scratch_cells: [*]c.AttyxCell,
     session: *SessionLog,
     allocator: std.mem.Allocator,
     no_config: bool,
@@ -71,7 +77,11 @@ pub const PtyThreadCtx = struct {
     session_client: ?*SessionClient = null,
     sessions_enabled: bool = false,
     // Track last-sent focus_panes IDs to avoid stale replay on refocus.
-    last_focus_panes: [split_layout_mod.max_panes]u32 = .{0} ** split_layout_mod.max_panes,
+    // Sized for ALL panes across ALL tabs because we keep every daemon-backed
+    // pane "warm" (claimed as focused) so the daemon streams output for them
+    // continuously and tab switches require no replay round-trip.
+    last_focus_panes: [split_layout_mod.max_panes * @import("tab_manager.zig").max_tabs]u32 =
+        .{0} ** (split_layout_mod.max_panes * @import("tab_manager.zig").max_tabs),
     last_focus_count: u8 = 0,
     // Configurable session picker icons
     session_icon_filter: []const u8 = ">",
@@ -592,7 +602,8 @@ pub fn run(
     }
 
     // Track initial focus pane IDs so PtyThreadCtx starts with correct replay tracking.
-    var initial_focus_panes: [split_layout_mod.max_panes]u32 = .{0} ** split_layout_mod.max_panes;
+    var initial_focus_panes: [split_layout_mod.max_panes * @import("tab_manager.zig").max_tabs]u32 =
+        .{0} ** (split_layout_mod.max_panes * @import("tab_manager.zig").max_tabs);
     var initial_focus_count: u8 = 0;
 
     // Session mode: try to reconstruct tabs from saved layout, else single pane fallback.
@@ -671,6 +682,10 @@ pub fn run(
     const render_cells = try allocator.alloc(c.AttyxCell, MAX_CELLS);
     @memset(render_cells, std.mem.zeroes(c.AttyxCell));
     defer allocator.free(render_cells);
+
+    const scratch_cells = try allocator.alloc(c.AttyxCell, MAX_CELLS);
+    @memset(scratch_cells, std.mem.zeroes(c.AttyxCell));
+    defer allocator.free(scratch_cells);
 
     const active_eng = &tab_mgr.activePane().engine;
     const total: usize = @as(usize, initial_pty_rows) * @as(usize, config.cols);
@@ -751,6 +766,7 @@ pub fn run(
     var ctx = PtyThreadCtx{
         .tab_mgr = &tab_mgr,
         .cells = render_cells.ptr,
+        .scratch_cells = scratch_cells.ptr,
         .session = &session,
         .allocator = allocator,
         .no_config = no_config,

--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -384,71 +384,75 @@ pub fn switchActiveTab(ctx: *PtyThreadCtx) void {
 
     updateSplitActive(ctx);
 
-    c.attyx_begin_cell_update();
+    // Compose the new frame into a scratch buffer first, then swap it into
+    // the live render buffer with a single memcpy under the begin/end_cell
+    // guard.  Composing off-buffer eliminates two flicker sources: (1) the
+    // brief blank frame when we cleared the live buffer to background before
+    // re-filling it, and (2) the stride mismatch when fillCells wrote at
+    // engine.cols while the renderer reads at g_cols.
     const layout = ctx.tab_mgr.activeLayout();
+    const grid_cols: u16 = ctx.grid_cols;
+    const grid_rows: u16 = ctx.grid_rows;
+    const scratch_total: usize = @as(usize, grid_rows) * @as(usize, grid_cols);
+    const scratch = ctx.scratch_cells[0..scratch_total];
+
+    var cursor_row: usize = 0;
+    var cursor_col: usize = 0;
+
     if (layout.pane_count > 1 and !layout.isZoomed()) {
-        const pty_rows: u16 = @intCast(@max(1, @as(i32, ctx.grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
+        const pty_rows: u16 = @intCast(@max(1, @as(i32, grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
         split_render.fillCellsSplit(
-            @ptrCast(ctx.cells),
+            @ptrCast(ctx.scratch_cells),
             layout,
             pty_rows,
-            ctx.grid_cols,
+            grid_cols,
             &ctx.active_theme,
         );
         const rect = layout.pool[layout.focused].rect;
         const eng = &pane.engine;
         const vp_cur = @min(eng.state.viewport_offset, eng.state.ring.scrollbackCount());
-        c.attyx_set_cursor(
-            @intCast(eng.state.cursor.row + vp_cur + rect.row + @as(usize, @intCast(terminal.g_grid_top_offset))),
-            @intCast(eng.state.cursor.col + rect.col),
-        );
-        c.attyx_mark_all_dirty();
+        cursor_row = eng.state.cursor.row + vp_cur + rect.row + @as(usize, @intCast(terminal.g_grid_top_offset));
+        cursor_col = eng.state.cursor.col + rect.col;
     } else {
-        const buf_total: usize = @as(usize, ctx.grid_rows) * @as(usize, ctx.grid_cols);
-        const bg = ctx.active_theme.background;
-        for (0..buf_total) |i| {
-            ctx.cells[i] = .{
-                .character = ' ',
-                .combining = .{ 0, 0 },
-                .fg_r = bg.r,
-                .fg_g = bg.g,
-                .fg_b = bg.b,
-                .bg_r = bg.r,
-                .bg_g = bg.g,
-                .bg_b = bg.b,
-                .flags = 4,
-                .link_id = 0,
-            };
-        }
+        const bg_cell = publish.bgCell(&ctx.active_theme);
+        @memset(scratch, bg_cell);
         const eng = &pane.engine;
-        const total = eng.state.ring.screen_rows * eng.state.ring.cols;
-        publish.fillCells(ctx.cells[0..total], eng, total, &ctx.active_theme, null);
+        publish.fillCellsStride(scratch, eng, &ctx.active_theme, grid_cols, null);
         const vp_cur = @min(eng.state.viewport_offset, eng.state.ring.scrollbackCount());
-        c.attyx_set_cursor(
-            @intCast(eng.state.cursor.row + vp_cur + @as(usize, @intCast(terminal.g_grid_top_offset))),
-            @intCast(eng.state.cursor.col),
-        );
-        c.attyx_mark_all_dirty();
+        cursor_row = eng.state.cursor.row + vp_cur + @as(usize, @intCast(terminal.g_grid_top_offset));
+        cursor_col = eng.state.cursor.col;
         eng.state.dirty.clear();
     }
+
+    // Generate overlays/tab bar/statusbar BEFORE the cell-update window so
+    // the renderer doesn't observe partially-published overlay buffers
+    // alongside the new cells.
     publish.publishImagePlacements(ctx);
     publish.publishState(ctx);
     c.g_viewport_offset = @intCast(publish.ctxEngine(ctx).state.viewport_offset);
     publish.generateTabBar(ctx);
-    // Tick statusbar widgets immediately so cwd/git refresh for the new
-    // pane before we generate the overlay — avoids a flash of stale data.
-    if (ctx.statusbar) |sb| if (sb.config.enabled) {
-        _ = sb.tick(std.time.timestamp(), publish.ctxPty(ctx).master, publish.ctxEngine(ctx).state.working_directory);
-    };
+    // NOTE: the statusbar tick used to run here to refresh cwd/git widgets
+    // for the new pane before painting the overlay.  Profiling showed it
+    // forking subprocesses (git status, etc.) and adding 50–70ms of input
+    // latency to every tab switch.  The periodic event-loop tick refreshes
+    // the same widgets on the very next iteration (~16ms), so the worst
+    // case is one frame of stale data — invisible in practice and
+    // dramatically better than the prior synchronous block.
     publish.generateStatusbar(ctx);
     publish.publishNativeTabTitles(ctx);
     publish.publishOverlays(ctx);
+
+    // Atomic swap: between begin/end_cell_update the renderer either sees
+    // the prior tab's frame or the next tab's frame in full, never the
+    // intermediate cleared-to-bg state.
+    c.attyx_begin_cell_update();
+    @memcpy(ctx.cells[0..scratch_total], scratch);
+    c.attyx_set_cursor(@intCast(cursor_row), @intCast(cursor_col));
+    c.attyx_mark_all_dirty();
     // Tell the renderer to rebuild all vertex buffers from scratch on the
-    // next frame.  Dirty-bit-based incremental updates can miss content when
-    // switching tabs because the entire cell buffer has changed identity
-    // (different pane), not just a few rows.  Must be set BEFORE
-    // end_cell_update so the renderer sees it on the same frame that
-    // observes the new cursor position (suppresses cursor trail).
+    // next frame.  Must be set BEFORE end_cell_update so the renderer sees
+    // it on the same frame that observes the new cursor position
+    // (suppresses cursor trail).
     c.g_renderer_full_redraw = 1;
     c.attyx_end_cell_update();
     c.attyx_mark_all_dirty();

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -76,6 +76,10 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         ctx.session_finder_show_hidden,
     );
 
+    // Self-pipe for waking the poll loop on UI events.  Must be initialized
+    // before any code path that calls input.wake().
+    input.initWakePipe();
+
     // Apply initial grid offsets (statusbar/tab bar) and resize PTY
     publish.updateGridOffsets(ctx);
     publish.generateStatusbar(ctx);
@@ -637,6 +641,17 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
             }
         }
 
+        // Wake pipe — lets UI actions (tab switch, IPC, etc.) interrupt the
+        // poll immediately rather than waiting for the 16ms timer tick.
+        // Tracked separately so the PTY-drain loops below can skip it
+        // (fd_panes[wake_fd_idx] is intentionally not populated).
+        const wake_fd_idx: ?usize = if (input.g_wake_read_fd >= 0) blk: {
+            const idx = nfds;
+            fds[nfds] = .{ .fd = input.g_wake_read_fd, .events = POLLIN, .revents = 0 };
+            nfds += 1;
+            break :blk idx;
+        } else null;
+
         // Drain any buffered paste data before polling — this interleaves
         // writing paste input with reading shell output, preventing deadlock
         // when the kernel PTY buffer fills in both directions.
@@ -646,6 +661,8 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         // drain it promptly instead of waiting the full 16ms.
         const poll_timeout: i32 = if (input.hasPendingPaste()) 1 else 16;
         _ = posix.poll(fds[0..nfds], poll_timeout) catch break;
+        // Drain the wake pipe so it doesn't stay readable and burn CPU.
+        input.drainWake();
 
         if (ctx.tab_mgr.count == 0) continue :outer;
         const active_focused_pane = ctx.tab_mgr.activePane();
@@ -678,35 +695,47 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                 switch (msg) {
                     .pane_output => |out| {
                         if (findPaneByDaemonId(ctx, out.pane_id)) |result| {
-                            // Deferred engine reinit: if the daemon is replaying
-                            // scrollback for a newly-focused pane, reinit the
-                            // engine NOW (right before feeding data) to prevent
-                            // blank-screen gap and duplicate content.
+                            // Replay routing: when the daemon is replaying
+                            // scrollback for a newly-focused pane, feed the
+                            // bytes into a shadow engine instead of the live
+                            // one.  The live engine keeps rendering the last
+                            // known frame (no blank-pane gap, no "Tab N"
+                            // fallback title) while the shadow catches up
+                            // invisibly.  On `replay_end` we swap shadow →
+                            // live in one atomic transition.
                             if (result.pane.needs_engine_reinit) {
-                                const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);
-                                const cols: u16 = @intCast(result.pane.engine.state.ring.cols);
-                                const new_engine = @import("attyx").Engine.init(
-                                    result.pane.allocator,
-                                    rows,
-                                    cols,
-                                    ctx.applied_scrollback_lines,
-                                ) catch continue;
-                                result.pane.engine.deinit();
-                                result.pane.engine = new_engine;
-                                result.pane.engine.state.theme_colors = publish.themeToEngineColors(&ctx.active_theme);
-                                result.pane.needs_engine_reinit = false;
+                                if (result.pane.shadow_engine == null) {
+                                    const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);
+                                    const cols: u16 = @intCast(result.pane.engine.state.ring.cols);
+                                    const shadow = @import("attyx").Engine.init(
+                                        result.pane.allocator,
+                                        rows,
+                                        cols,
+                                        ctx.applied_scrollback_lines,
+                                    ) catch continue;
+                                    result.pane.shadow_engine = shadow;
+                                    result.pane.shadow_engine.?.state.theme_colors = publish.themeToEngineColors(&ctx.active_theme);
+                                }
+                                result.pane.shadow_engine.?.feed(out.data);
+                                _ = result.pane.shadow_engine.?.state.drainResponse();
+                                // Do NOT set got_data — live engine is
+                                // unchanged, the periodic publish should
+                                // keep showing the old frame.  Do NOT
+                                // appendOutput — replay bytes are historical,
+                                // not new output.
+                            } else {
+                                if (result.pane == active_focused_pane) {
+                                    ctx.session.appendOutput(out.data);
+                                    ctx.throughput.add(out.data.len);
+                                }
+                                if (result.tab_idx == ctx.tab_mgr.active) got_data = true;
+                                result.pane.engine.feed(out.data);
+                                // Discard engine responses — the daemon intercepts
+                                // all queries (DA1, DECRPM, kitty keyboard, OSC
+                                // color queries, etc.) and responds directly to
+                                // avoid round-trip latency and duplicate responses.
+                                _ = result.pane.engine.state.drainResponse();
                             }
-                            if (result.pane == active_focused_pane) {
-                                ctx.session.appendOutput(out.data);
-                                ctx.throughput.add(out.data.len);
-                            }
-                            if (result.tab_idx == ctx.tab_mgr.active) got_data = true;
-                            result.pane.engine.feed(out.data);
-                            // Discard engine responses — the daemon intercepts
-                            // all queries (DA1, DECRPM, kitty keyboard, OSC
-                            // color queries, etc.) and responds directly to
-                            // avoid round-trip latency and duplicate responses.
-                            _ = result.pane.engine.state.drainResponse();
                         }
                     },
                     .pane_died => |died| {
@@ -786,16 +815,34 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                         }
                     },
                     .replay_end => |pane_id| {
-                        // The daemon already nudged the PTY size (cols+1)
-                        // before sending replay_end. Restore the correct
-                        // size so the app gets a second SIGWINCH at the
-                        // right dimensions — the round-trip delay ensures
-                        // the first SIGWINCH was processed.
                         if (findPaneByDaemonId(ctx, pane_id)) |result| {
-                            const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);
-                            const cols: u16 = @intCast(result.pane.engine.state.ring.cols);
-                            if (ctx.session_client) |scc| {
-                                scc.sendPaneResize(pane_id, rows, cols) catch {};
+                            // Atomic swap: shadow engine (with fully
+                            // replayed state) replaces the live engine in
+                            // one step.  Mark all rows dirty and force a
+                            // full redraw so the renderer lands on the new
+                            // frame on its very next tick — single clean
+                            // transition, no intermediate states visible.
+                            if (result.pane.shadow_engine) |shadow| {
+                                var old_engine = result.pane.engine;
+                                result.pane.engine = shadow;
+                                result.pane.shadow_engine = null;
+                                old_engine.deinit();
+                                result.pane.needs_engine_reinit = false;
+                                result.pane.engine.state.dirty.markAll(result.pane.engine.state.ring.screen_rows);
+                                if (result.tab_idx == ctx.tab_mgr.active) {
+                                    got_data = true;
+                                    actions.g_force_full_redraw = true;
+                                }
+                            }
+                            // Windows still col-nudges to force repaint;
+                            // restore dims here.  POSIX uses SIGWINCH at
+                            // current dims so no restore needed.
+                            if (@import("builtin").os.tag == .windows) {
+                                const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);
+                                const cols: u16 = @intCast(result.pane.engine.state.ring.cols);
+                                if (ctx.session_client) |scc| {
+                                    scc.sendPaneResize(pane_id, rows, cols) catch {};
+                                }
                             }
                         }
                     },
@@ -814,6 +861,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
             for (local_start..nfds) |i| {
                 if (fd_tab_idx[i] == 0xFF) continue; // popup handled separately
                 if (i == xyron_event_fd_idx) continue; // xyron IPC handled separately
+                if (wake_fd_idx) |w| if (i == w) continue; // wake pipe — drained above
                 if (fds[i].revents & POLLIN == 0) continue;
                 const p = fd_panes[i];
                 while (true) {
@@ -1037,17 +1085,27 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         }
 
         if (need_update_final) {
-            c.attyx_begin_cell_update();
             const layout = ctx.tab_mgr.activeLayout();
             if (layout.pane_count > 1 and !layout.isZoomed()) {
                 const pty_rows: u16 = @intCast(@max(1, @as(i32, ctx.grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
+                // Compose the split layout into the scratch buffer first, then
+                // memcpy into the live buffer under the cell-update guard.
+                // fillCellsSplit clears the entire grid to bg before re-filling
+                // each pane region — doing that on the live buffer leaves a
+                // window where the renderer can observe a blank/partial frame
+                // even with the gen guard, because mark_all_dirty + the
+                // multiple non-atomic global writes (g_pane_rect_*) span the
+                // begin/end window.
+                const scratch_total: usize = @as(usize, ctx.grid_rows) * @as(usize, ctx.grid_cols);
                 split_render.fillCellsSplit(
-                    @ptrCast(ctx.cells),
+                    @ptrCast(ctx.scratch_cells),
                     layout,
                     pty_rows,
                     ctx.grid_cols,
                     &ctx.active_theme,
                 );
+                c.attyx_begin_cell_update();
+                @memcpy(ctx.cells[0..scratch_total], ctx.scratch_cells[0..scratch_total]);
                 const rect = layout.pool[layout.focused].rect;
                 terminal.g_pane_rect_row = @intCast(rect.row);
                 terminal.g_pane_rect_col = @intCast(rect.col);
@@ -1073,10 +1131,25 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                 // the engine processes many screenfuls between publishes.
                 const full_redraw = viewport_changed or search_vp_changed or actions.g_force_full_redraw or (throttled_frames > 0);
                 if (full_redraw) {
+                    // Compose into scratch with grid_cols stride and atomically
+                    // swap into the live buffer.  This avoids two flicker
+                    // sources on full redraws: (1) eng.cols != grid_cols stride
+                    // mismatch in fillCells (text-wrap appearance), and (2) any
+                    // window where the renderer can land on a partially-written
+                    // frame.  For sparse dirty-row updates the direct write is
+                    // fine — only changed rows are touched and stride matches.
                     eng.state.dirty.markAll(eng.state.ring.screen_rows);
+                    const scratch_total: usize = @as(usize, ctx.grid_rows) * @as(usize, ctx.grid_cols);
+                    const bg_cell = publish.bgCell(&ctx.active_theme);
+                    @memset(ctx.scratch_cells[0..scratch_total], bg_cell);
+                    publish.fillCellsStride(ctx.scratch_cells[0..scratch_total], eng, &ctx.active_theme, ctx.grid_cols, null);
+                    c.attyx_begin_cell_update();
+                    @memcpy(ctx.cells[0..scratch_total], ctx.scratch_cells[0..scratch_total]);
+                } else {
+                    c.attyx_begin_cell_update();
+                    const total = eng.state.ring.screen_rows * eng.state.ring.cols;
+                    publish.fillCells(ctx.cells[0..total], eng, total, &ctx.active_theme, &eng.state.dirty);
                 }
-                const total = eng.state.ring.screen_rows * eng.state.ring.cols;
-                publish.fillCells(ctx.cells[0..total], eng, total, &ctx.active_theme, &eng.state.dirty);
 
                 const vp_cur = @min(eng.state.viewport_offset, eng.state.ring.scrollbackCount());
                 c.attyx_set_cursor(

--- a/src/app/ui/input.zig
+++ b/src/app/ui/input.zig
@@ -8,6 +8,46 @@ const terminal = @import("../terminal.zig");
 const c = terminal.c;
 
 // ---------------------------------------------------------------------------
+// Event-loop wake-up pipe
+// ---------------------------------------------------------------------------
+// The PTY thread sleeps in posix.poll for up to 16ms per iteration.  UI
+// actions posted from the main thread (tab switches, IPC commands, overlay
+// toggles) are plain atomics that don't wake the poll — so they wait for the
+// next timer tick to be serviced.  Writing a byte to this pipe makes the
+// poll return immediately, giving ~0ms actuation latency for keypresses.
+pub var g_wake_read_fd: std.posix.fd_t = -1;
+pub var g_wake_write_fd: std.posix.fd_t = -1;
+
+/// Initialize the wake pipe.  Called once at startup by the PTY thread.
+pub fn initWakePipe() void {
+    const fds = std.posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true }) catch {
+        logging.err("wake-pipe", "pipe2 failed; UI actions will wait for poll timeout", .{});
+        return;
+    };
+    g_wake_read_fd = fds[0];
+    g_wake_write_fd = fds[1];
+}
+
+/// Wake the PTY thread from posix.poll.  Safe to call from any thread.
+/// A single byte is written; the poll on the other end returns immediately.
+pub fn wake() void {
+    if (g_wake_write_fd < 0) return;
+    const byte: [1]u8 = .{1};
+    _ = std.posix.write(g_wake_write_fd, &byte) catch {};
+}
+
+/// Drain any accumulated wake bytes.  Called after poll returns so the pipe
+/// doesn't stay readable and burn CPU on subsequent polls.
+pub fn drainWake() void {
+    if (g_wake_read_fd < 0) return;
+    var scratch: [64]u8 = undefined;
+    while (true) {
+        const n = std.posix.read(g_wake_read_fd, &scratch) catch return;
+        if (n == 0 or n < scratch.len) return;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Overlay interaction atomics
 // ---------------------------------------------------------------------------
 
@@ -162,6 +202,7 @@ pub var g_tab_click_index: i32 = -1;
 
 pub fn tabAction(action: c_int) void {
     @atomicStore(i32, &g_tab_action_request, action, .seq_cst);
+    wake();
 }
 
 pub fn tabBarClick(col: c_int, grid_cols: c_int) void {
@@ -172,6 +213,7 @@ pub fn tabBarClick(col: c_int, grid_cols: c_int) void {
         @intCast(@max(1, grid_cols)),
     ) orelse return;
     @atomicStore(i32, &g_tab_click_index, @as(i32, idx), .seq_cst);
+    wake();
 }
 
 const statusbar_mod = @import("../statusbar.zig");
@@ -188,6 +230,7 @@ pub fn statusbarTabClick(col: c_int, grid_cols: c_int) void {
         remaining,
     ) orelse return;
     @atomicStore(i32, &g_tab_click_index, @as(i32, idx), .seq_cst);
+    wake();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/ui/publish.zig
+++ b/src/app/ui/publish.zig
@@ -592,10 +592,27 @@ pub fn cellToAttyxCell(cell: attyx.Cell, theme: *const Theme) c.AttyxCell {
 const DirtyRows = attyx.DirtyRows;
 
 pub fn fillCells(cells: []c.AttyxCell, eng: *Engine, _: usize, theme: *const Theme, dirty: ?*const DirtyRows) void {
+    fillCellsStride(cells, eng, theme, @intCast(eng.state.ring.cols), dirty);
+}
+
+/// Write the engine's visible viewport into `cells` using `stride` as the
+/// row stride.  Callers that compose into the live render buffer must pass
+/// `g_cols` (== ctx.grid_cols) so the renderer's row indexing matches.
+/// Cells past `eng.cols` in each row are left untouched — the caller is
+/// responsible for pre-clearing them to the desired background.
+pub fn fillCellsStride(
+    cells: []c.AttyxCell,
+    eng: *Engine,
+    theme: *const Theme,
+    stride: u16,
+    dirty: ?*const DirtyRows,
+) void {
     const vp = eng.state.viewport_offset;
     const cols = eng.state.ring.cols;
     const rows = eng.state.ring.screen_rows;
     const wrapped: *volatile [c.ATTYX_MAX_ROWS]u8 = @ptrCast(&c.g_row_wrapped);
+    const stride_usize: usize = stride;
+    const cols_to_copy = @min(@as(usize, cols), stride_usize);
 
     for (0..rows) |row| {
         const row_cells = eng.state.ring.viewportRow(vp, row);
@@ -603,10 +620,27 @@ pub fn fillCells(cells: []c.AttyxCell, eng: *Engine, _: usize, theme: *const The
         if (dirty) |d| {
             if (!d.isDirty(row)) continue;
         }
-        for (0..cols) |col| {
-            cells[row * cols + col] = cellToAttyxCell(row_cells[col], theme);
+        const base = row * stride_usize;
+        for (0..cols_to_copy) |col| {
+            cells[base + col] = cellToAttyxCell(row_cells[col], theme);
         }
     }
+}
+
+pub fn bgCell(theme: *const Theme) c.AttyxCell {
+    const bg = theme.background;
+    return .{
+        .character = ' ',
+        .combining = .{ 0, 0 },
+        .fg_r = bg.r,
+        .fg_g = bg.g,
+        .fg_b = bg.b,
+        .bg_r = bg.r,
+        .bg_g = bg.g,
+        .bg_b = bg.b,
+        .flags = 4,
+        .link_id = 0,
+    };
 }
 
 /// Check if statusbar is active and enabled.

--- a/src/app/ui/session_actions.zig
+++ b/src/app/ui/session_actions.zig
@@ -34,40 +34,71 @@ pub fn saveSessionLayout(ctx: *PtyThreadCtx) void {
 /// Send focus_panes for all daemon-backed panes in the active tab.
 /// Reinitializes engines for panes that weren't in the previous focus set,
 /// since the daemon will replay their scrollback into the engine.
+/// Tell the daemon which panes we want pane_output messages for.  We claim
+/// ALL daemon-backed panes across ALL tabs as "active" so the daemon keeps
+/// streaming output to us continuously, including for panes the user can't
+/// currently see.  The cost is a little extra socket bandwidth for inactive
+/// panes; the win is huge: tab switches don't need a focus_panes round-trip
+/// or a scrollback replay because every pane's engine is already up-to-date.
+///
+/// The pane set only changes when the user creates or closes panes/tabs, so
+/// most calls are no-ops (we de-dup against the previous set).  Replay still
+/// fires for genuinely new panes (first time the daemon sees them in our
+/// active set) — which is correct, since those engines really are blank.
 pub fn sendActiveFocusPanes(ctx: *PtyThreadCtx) void {
     const sc = ctx.session_client orelse return;
-    const layout = ctx.tab_mgr.activeLayout();
-    var pane_ids: [split_layout_mod.max_panes]u32 = undefined;
+    var pane_ids: [split_layout_mod.max_panes * @import("../tab_manager.zig").max_tabs]u32 = undefined;
     var count: usize = 0;
-    var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
-    const lc = layout.collectLeaves(&leaves);
-    for (leaves[0..lc]) |leaf| {
-        if (leaf.pane.daemon_pane_id) |dpid| {
-            pane_ids[count] = dpid;
-            count += 1;
 
-            // If this pane wasn't in the previous focus set, the daemon will
-            // replay its scrollback. Reinit the engine so replay doesn't
-            // stack on top of stale content from a prior focus cycle.
-            var was_focused = false;
-            for (ctx.last_focus_panes[0..ctx.last_focus_count]) |old_id| {
-                if (old_id == dpid) {
-                    was_focused = true;
-                    break;
+    // Collect daemon-backed panes from every tab (not just the active one).
+    for (ctx.tab_mgr.tabs[0..ctx.tab_mgr.count]) |*maybe_layout| {
+        if (maybe_layout.*) |*lay| {
+            var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
+            const lc = lay.collectLeaves(&leaves);
+            for (leaves[0..lc]) |leaf| {
+                if (leaf.pane.daemon_pane_id) |dpid| {
+                    if (count >= pane_ids.len) break;
+                    pane_ids[count] = dpid;
+                    count += 1;
+
+                    // Arm shadow-replay routing only if this pane is brand
+                    // new to us (not in the prior focus set).  Existing
+                    // panes stay warm — their engines already have the
+                    // current state, and the daemon won't trigger replay
+                    // because they're not "newly active".
+                    var was_focused = false;
+                    for (ctx.last_focus_panes[0..ctx.last_focus_count]) |old_id| {
+                        if (old_id == dpid) {
+                            was_focused = true;
+                            break;
+                        }
+                    }
+                    if (!was_focused) {
+                        if (leaf.pane.shadow_engine) |*s| {
+                            s.deinit();
+                            leaf.pane.shadow_engine = null;
+                        }
+                        leaf.pane.needs_engine_reinit = true;
+                    }
                 }
-            }
-            if (!was_focused) {
-                // Defer the engine reinit until the first replay byte
-                // arrives (handled in event_loop.zig). This keeps the
-                // old engine content visible during the tab switch,
-                // avoiding a blank flash before the daemon replay
-                // populates the altscreen/content.
-                leaf.pane.needs_engine_reinit = true;
             }
         }
     }
 
-    // Update tracking
+    // Skip the IPC round-trip entirely if the pane set hasn't changed.
+    var same_set = (count == ctx.last_focus_count);
+    if (same_set) {
+        outer: for (pane_ids[0..count]) |new_id| {
+            for (ctx.last_focus_panes[0..ctx.last_focus_count]) |old_id| {
+                if (new_id == old_id) continue :outer;
+            }
+            same_set = false;
+            break;
+        }
+    }
+    if (same_set) return;
+
+    // Pane set changed — update tracking and tell the daemon.
     for (0..count) |i| {
         ctx.last_focus_panes[i] = pane_ids[i];
     }

--- a/src/app/ui/session_actions.zig
+++ b/src/app/ui/session_actions.zig
@@ -186,13 +186,13 @@ pub fn doSessionSwitch(ctx: *PtyThreadCtx, session_id: u32) void {
     // Force full redraw so the new session's content appears immediately.
     actions.g_force_full_redraw = true;
     c.attyx_mark_all_dirty();
-    // Reset cached cwd pointers so tick detects the new pane's cwd and
-    // refreshes immediately — avoids a flash of stale/empty widgets.
+    // Reset cached cwd/git state so the next periodic tick picks up the new
+    // session's values.  Skip the synchronous tick that used to run here —
+    // profiling showed it forking subprocesses (git status, etc.) and
+    // adding 50–70ms of input latency, same as on tab switch.  The worst
+    // case is one frame of stale widgets (~16ms) — invisible.
     if (ctx.statusbar) |sb| {
         sb.resetWidgets();
-        if (sb.config.enabled) {
-            _ = sb.tick(std.time.timestamp(), publish.ctxPty(ctx).master, publish.ctxEngine(ctx).state.working_directory);
-        }
     }
     publish.generateTabBar(ctx);
     publish.generateStatusbar(ctx);
@@ -287,11 +287,10 @@ pub fn handleLayoutSync(ctx: *PtyThreadCtx, layout_data: []const u8) void {
 
     actions.g_force_full_redraw = true;
     c.attyx_mark_all_dirty();
+    // Reset cached widget state; next periodic tick refreshes (avoids the
+    // 50–70ms synchronous git/cwd fork/exec on this code path too).
     if (ctx.statusbar) |sb| {
         sb.resetWidgets();
-        if (sb.config.enabled) {
-            _ = sb.tick(std.time.timestamp(), publish.ctxPty(ctx).master, publish.ctxEngine(ctx).state.working_directory);
-        }
     }
     publish.generateTabBar(ctx);
     publish.generateStatusbar(ctx);


### PR DESCRIPTION
This pull request introduces several architectural and implementation improvements to reduce session/tab switch latency and improve rendering smoothness, especially when switching between TUI panes. The main focus is on eliminating visual flicker, preparing for a server-side VT engine, and improving buffer management. The most important changes are grouped below:

---

**Rendering and Flicker Elimination**
* `src/app/ui/actions.zig`, `src/app/terminal.zig`: Added a `scratch_cells` buffer and updated tab switching logic to compose frames off-screen before a single atomic memcpy into the live render buffer. This prevents blank frames and stride mismatches, eliminating flicker during tab switches. [[1]](diffhunk://#diff-d4052522f312f8a9175368a0f72bd92c0c2b9187cc4a08b1b878595585909578L387-R455) [[2]](diffhunk://#diff-3d35e2992ec754677ef5f08c931557a9bbe6e525ff048b5cbc06055d7be7f341R48-R53) [[3]](diffhunk://#diff-3d35e2992ec754677ef5f08c931557a9bbe6e525ff048b5cbc06055d7be7f341R686-R689) [[4]](diffhunk://#diff-3d35e2992ec754677ef5f08c931557a9bbe6e525ff048b5cbc06055d7be7f341R769)
* [`src/app/ui/actions.zig`](diffhunk://#diff-d4052522f312f8a9175368a0f72bd92c0c2b9187cc4a08b1b878595585909578L387-R455): Status bar widget updates are now deferred to the event loop tick, removing synchronous blocking (e.g., git status calls) during tab switches, which previously caused 50–70ms latency.

**Buffer and State Management**
* [`src/app/terminal.zig`](diffhunk://#diff-3d35e2992ec754677ef5f08c931557a9bbe6e525ff048b5cbc06055d7be7f341L74-R84): The `last_focus_panes` array is expanded to cover all panes across all tabs, supporting the "warm-panes" model that keeps all daemon-backed panes active and ready for instant switching. [[1]](diffhunk://#diff-3d35e2992ec754677ef5f08c931557a9bbe6e525ff048b5cbc06055d7be7f341L74-R84) [[2]](diffhunk://#diff-3d35e2992ec754677ef5f08c931557a9bbe6e525ff048b5cbc06055d7be7f341L595-R606)
* [`src/app/pane.zig`](diffhunk://#diff-127b383c63c0dce440e149f5d6a48e13e27d11b8cac18832defd04755af3625dL44-R52): The `shadow_engine` logic is clarified and maintained, ensuring that during replay bursts, the visible state remains stable until the new engine state is ready, preventing visual glitches. Shadow engine dimensions are now kept in sync with the main engine. [[1]](diffhunk://#diff-127b383c63c0dce440e149f5d6a48e13e27d11b8cac18832defd04755af3625dL44-R52) [[2]](diffhunk://#diff-127b383c63c0dce440e149f5d6a48e13e27d11b8cac18832defd04755af3625dR235-R239) [[3]](diffhunk://#diff-127b383c63c0dce440e149f5d6a48e13e27d11b8cac18832defd04755af3625dR196)

**Daemon Protocol and Redraw Handling**
* [`src/app/daemon/pane.zig`](diffhunk://#diff-e1e6190873829ab4fae202f869a563e551dd6462905585d443ce07052598ef28L422-R438): On POSIX, `notifyRedraw` now sends a SIGWINCH to the foreground process group at the current dimensions (instead of nudging the PTY size), triggering a redraw without geometry flicker. On Windows, the nudge is retained.

**Documentation and Design**
* [`docs/server-side-engine.md`](diffhunk://#diff-5eb9ae07924d47e3a9327110d50324d3897d9977fff0e1b00035cb3f9a62af84R1-R259): Added a comprehensive design document for migrating the VT engine to the server-side (daemon), detailing motivation, protocol changes, state management, migration strategy, and expected performance improvements.