### PR TITLE
feat: Allow getting arbitrary number of lines via get-text command

### DIFF
--- a/skills/claude/attyx/SKILL.md
+++ b/skills/claude/attyx/SKILL.md
@@ -215,6 +215,17 @@ attyx send-keys -p "$id" "{Enter}"
 attyx send-keys -p "$id" "ihello world{Escape}:wq{Enter}"
 ```
 
+### Reading Scrollback History — `--lines` / `-n`
+By default `get-text` returns only the visible screen. To capture more (like `tail -N` over the pane's scrollback + screen), pass `--lines N` / `-n N`:
+
+```bash
+attyx get-text -n 100              # last 100 rows from focused pane
+attyx get-text -p 3 -n 500         # last 500 rows from pane 3
+attyx -s 1 get-text -p 5 -n 1000   # last 1000 rows from pane 5 in session 1
+```
+
+The count is clamped to the pane's available scrollback depth. Use this when a long-running command's output has scrolled off-screen, or when you need to inspect history beyond the current viewport.
+
 ### Reading Output — Use `--wait-stable`
 Instead of blind `sleep N && attyx get-text`, use `--wait-stable` to send keys and automatically wait for output to settle:
 
@@ -238,7 +249,8 @@ Almost all commands support `--pane` (`-p`) to target any pane by its stable ID:
 ```bash
 # IO
 attyx send-keys -p 3 "ls -la{Enter}"  # send to pane 3
-attyx get-text -p 3                   # read from pane 3
+attyx get-text -p 3                   # read visible screen from pane 3
+attyx get-text -p 3 -n 200            # last 200 rows (scrollback + screen)
 
 # Split management
 attyx split close -p 5               # close pane 5

--- a/src/app/shell_integration.zig
+++ b/src/app/shell_integration.zig
@@ -24,6 +24,7 @@ pub const Shell = enum {
     bash,
     fish,
     nushell,
+    xyron,
     posix_sh,
     powershell,
     cmd,
@@ -47,6 +48,7 @@ pub fn detectShell(shell_path: []const u8) Shell {
         std.mem.eql(u8, shell_path, "bash")) return .bash;
     if (std.mem.endsWith(u8, shell_path, "/fish") or std.mem.eql(u8, shell_path, "fish")) return .fish;
     if (std.mem.endsWith(u8, shell_path, "/nu") or std.mem.eql(u8, shell_path, "nu")) return .nushell;
+    if (std.mem.endsWith(u8, shell_path, "/xyron") or std.mem.eql(u8, shell_path, "xyron")) return .xyron;
     // Windows shells
     if (std.mem.endsWith(u8, shell_path, "\\pwsh.exe") or
         std.mem.endsWith(u8, shell_path, "\\powershell.exe") or
@@ -84,6 +86,7 @@ pub fn setup() ArgvOverride {
         .bash => setupBash(home),
         .fish => setupFish(home),
         .nushell => setupNushell(home),
+        .xyron => setupXyron(exe_dir),
         .posix_sh => setupPosixSh(home, exe_dir),
         .powershell, .cmd => .{},
     };
@@ -274,6 +277,15 @@ fn setupNushell(home: []const u8) ArgvOverride {
 
 fn setupPosixSh(_: []const u8, exe_dir: []const u8) ArgvOverride {
     // POSIX sh: best-effort direct PATH append + ENV for one-shot reporting
+    appendExeDirToPath(exe_dir);
+    return .{};
+}
+
+/// Xyron is not POSIX and uses Lua for scripting, so it can't source one of
+/// our shell init scripts. Instead, xyron itself reads __ATTYX_STARTUP_CMD,
+/// emits OSC events natively (when ATTYX=1), and inherits PATH directly.
+/// We just need to make `attyx` reachable on PATH.
+fn setupXyron(exe_dir: []const u8) ArgvOverride {
     appendExeDirToPath(exe_dir);
     return .{};
 }

--- a/src/config/cli_help.zig
+++ b/src/config/cli_help.zig
@@ -96,7 +96,7 @@ const ipc_io =
     "  " ++ d ++ "Input / Output" ++ r ++ "\n" ++
     cmd("send-keys [-p <id>] [--wait-stable] <keys>   ", "Send keystrokes to a pane") ++
     cont("                                " ++ d ++ "Named: {Enter} {Up} {Down} {Tab} {Ctrl-c} ... or \\n \\xHH" ++ r) ++
-    cmd("get-text [-p <id>] [--json]     ", "Read visible screen text from a pane") ++
+    cmd("get-text [-p <id>] [-n <N>] [--json]     ", "Read screen text (or last N rows) from a pane") ++
     "\n";
 
 const ipc_misc =

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -71,6 +71,9 @@ pub const IpcRequest = struct {
     pane_id: u32 = 0,
     /// Tab targeting by 0-based index. 0xFF = active (default).
     tab_idx: u8 = 0xFF,
+    /// get-text: number of trailing rows from scrollback+screen to capture.
+    /// 0 = visible screen (default behavior).
+    lines: u32 = 0,
 };
 
 /// Returns true if the string looks like a filesystem path rather than a plain name.
@@ -189,6 +192,12 @@ pub fn parse(args: []const [:0]const u8) ?IpcRequest {
                     if (gi + 1 >= args.len) fatal("--pane requires a pane ID");
                     gi += 1;
                     parsePaneArg(args[gi], &gt_result);
+                } else if (std.mem.eql(u8, args[gi], "--lines") or std.mem.eql(u8, args[gi], "-n")) {
+                    if (gi + 1 >= args.len) fatal("--lines requires a count");
+                    gi += 1;
+                    const n = std.fmt.parseInt(u32, args[gi], 10) catch fatal("--lines: invalid count");
+                    if (n == 0) fatal("--lines: count must be >= 1");
+                    gt_result.lines = n;
                 }
                 gi += 1;
             }

--- a/src/config/cli_ipc_help.zig
+++ b/src/config/cli_ipc_help.zig
@@ -387,22 +387,24 @@ pub const send_keys =
 // send_text removed — send-text is now an alias for send-keys (same help)
 
 pub const get_text =
-    \\Read visible text from a pane.
+    \\Read visible text (or scrollback history) from a pane.
     \\
-    \\Usage: attyx get-text [--pane <target>] [--json]
+    \\Usage: attyx get-text [--pane <target>] [--lines <N>] [--json]
     \\
-    \\Returns the current screen content of the specified pane (or the
-    \\focused pane if --pane is not given). This is what an agent uses
-    \\to "see" what's on screen.
+    \\By default, returns the current screen content of the specified pane
+    \\(or the focused pane if --pane is not given). With --lines N, returns
+    \\the last N rows from scrollback + screen — like `tail -N`.
     \\
     \\Options:
     \\  --pane, -p <id>       Target a specific pane by its stable ID instead of
     \\                        the focused one. Pane IDs are shown in 'attyx list'
     \\                        output and returned by creation commands.
+    \\  --lines, -n <N>       Return the last N rows from scrollback + visible
+    \\                        screen, instead of just the visible screen. Capped
+    \\                        at the pane's scrollback depth.
     \\
     \\Output format (plain text):
-    \\  One line per screen row. Trailing whitespace is trimmed per row.
-    \\  Empty trailing rows are omitted.
+    \\  One line per row. Trailing whitespace is trimmed per row.
     \\
     \\Output format (--json):
     \\  { "lines": ["row1", "row2", ...] }
@@ -410,7 +412,8 @@ pub const get_text =
     \\Examples:
     \\  attyx get-text                         Print screen content
     \\  attyx get-text --pane 3                Read from pane 3
-    \\  attyx get-text --pane 5 --json         Pane 5 as JSON
+    \\  attyx get-text -n 100                  Last 100 rows (scrollback + screen)
+    \\  attyx get-text -p 5 -n 500             Last 500 rows from pane 5
     \\
     \\Tip: After running a command with send-keys, wait briefly before
     \\calling get-text to give the command time to produce output.

--- a/src/ipc/client.zig
+++ b/src/ipc/client.zig
@@ -179,9 +179,20 @@ pub fn run(args: []const [:0]const u8) void {
         };
     }
 
-    // Send and receive
-    var resp_buf: [max_response]u8 = undefined;
-    const resp = sendCommand(socket_path, request, &resp_buf) catch |err| {
+    // Send and receive. For get-text with --lines, the response can be much
+    // larger than max_response (potentially MBs of scrollback) — heap-allocate.
+    var heap_resp_buf: ?[]u8 = null;
+    defer if (heap_resp_buf) |b| std.heap.page_allocator.free(b);
+    var stack_resp_buf: [max_response]u8 = undefined;
+    const resp_buf: []u8 = if (parsed.command == .get_text and parsed.lines > 0) blk: {
+        const buf = std.heap.page_allocator.alloc(u8, 8 * 1024 * 1024) catch {
+            writeStderr("error: out of memory for response buffer\n");
+            std.process.exit(1);
+        };
+        heap_resp_buf = buf;
+        break :blk buf;
+    } else stack_resp_buf[0..];
+    const resp = sendCommand(socket_path, request, resp_buf) catch |err| {
         switch (err) {
             error.ConnectionRefused => writeStderr("error: no running Attyx instance found\n"),
             else => writeStderr("error: failed to communicate with Attyx instance\n"),
@@ -383,9 +394,18 @@ fn buildRequest(buf: []u8, parsed: @import("../config/cli_ipc.zig").IpcRequest) 
         },
         .get_text => blk: {
             if (parsed.pane_id != 0) {
+                var payload: [8]u8 = undefined;
+                std.mem.writeInt(u32, payload[0..4], parsed.pane_id, .little);
+                if (parsed.lines > 0) {
+                    std.mem.writeInt(u32, payload[4..8], parsed.lines, .little);
+                    break :blk protocol.encodeMessage(buf, .get_text_pane, payload[0..8]);
+                }
+                break :blk protocol.encodeMessage(buf, .get_text_pane, payload[0..4]);
+            }
+            if (parsed.lines > 0) {
                 var payload: [4]u8 = undefined;
-                std.mem.writeInt(u32, &payload, parsed.pane_id, .little);
-                break :blk protocol.encodeMessage(buf, .get_text_pane, &payload);
+                std.mem.writeInt(u32, &payload, parsed.lines, .little);
+                break :blk protocol.encodeMessage(buf, .get_text, &payload);
             }
             break :blk protocol.encodeMessage(buf, .get_text, "");
         },

--- a/src/ipc/handler_query.zig
+++ b/src/ipc/handler_query.zig
@@ -124,7 +124,11 @@ pub fn buildSplitList(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
 
 pub fn buildGetText(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
     const pane = ctx.tab_mgr.activePane();
-    writeScreenText(cmd, pane);
+    const lines: u32 = if (cmd.payload_len >= 4)
+        std.mem.readInt(u32, cmd.payload[0..4], .little)
+    else
+        0;
+    writeScreenText(cmd, pane, lines);
 }
 
 pub fn buildGetTextPane(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
@@ -133,25 +137,40 @@ pub fn buildGetTextPane(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
         return;
     }
     const pane_id = std.mem.readInt(u32, cmd.payload[0..4], .little);
+    const lines: u32 = if (cmd.payload_len >= 8)
+        std.mem.readInt(u32, cmd.payload[4..8], .little)
+    else
+        0;
     const pane = ctx.tab_mgr.findPaneById(pane_id) orelse {
         sendError(cmd, "pane not found");
         return;
     };
-    writeScreenText(cmd, pane);
+    writeScreenText(cmd, pane, lines);
 }
 
-fn writeScreenText(cmd: *queue.IpcCommand, pane: anytype) void {
+fn writeScreenText(cmd: *queue.IpcCommand, pane: anytype, lines: u32) void {
     const ring = &pane.engine.state.ring;
-    const rows = ring.screen_rows;
     const cols = ring.cols;
 
-    // Worst case: 4 bytes per char (UTF-8) + newline per row
-    var buf: [32768]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
+    // Determine row range. lines == 0 → visible screen only.
+    // lines > 0 → last N rows from the ring (scrollback + screen).
+    const total_rows: usize = if (lines == 0) ring.screen_rows else @min(@as(usize, lines), ring.count);
+    const start_abs: usize = if (lines == 0) ring.scrollbackCount() else ring.count - total_rows;
+
+    // Allocate output buffer sized for worst-case UTF-8 output.
+    const max_row_bytes = cols * 4 + 1;
+    const buf_size = total_rows * max_row_bytes + 64;
+    const buf = pane.allocator.alloc(u8, buf_size) catch {
+        sendError(cmd, "out of memory");
+        return;
+    };
+    defer pane.allocator.free(buf);
+    var stream = std.io.fixedBufferStream(buf);
     const w = stream.writer();
 
-    for (0..rows) |r| {
-        const row_cells = ring.getScreenRow(r);
+    var i: usize = 0;
+    while (i < total_rows) : (i += 1) {
+        const row_cells = ring.getRow(start_abs + i);
         // Find last non-space cell to trim trailing whitespace
         var last: usize = cols;
         while (last > 0 and row_cells[last - 1].char == ' ') last -= 1;

--- a/src/ipc/handler_windows.zig
+++ b/src/ipc/handler_windows.zig
@@ -149,7 +149,11 @@ pub fn handle(cmd: *queue.IpcCommand, ctx: *WinCtx) void {
             sendOk(cmd, "");
         },
         .get_text => {
-            writeScreenText(cmd, ctx.tab_mgr.activePane());
+            const lines: u32 = if (cmd.payload_len >= 4)
+                std.mem.readInt(u32, cmd.payload[0..4], .little)
+            else
+                0;
+            writeScreenText(cmd, ctx.tab_mgr.activePane(), lines);
         },
         .get_text_pane => {
             if (cmd.payload_len < 4) {
@@ -157,11 +161,15 @@ pub fn handle(cmd: *queue.IpcCommand, ctx: *WinCtx) void {
                 return;
             }
             const pane_id = std.mem.readInt(u32, cmd.payload[0..4], .little);
+            const lines: u32 = if (cmd.payload_len >= 8)
+                std.mem.readInt(u32, cmd.payload[4..8], .little)
+            else
+                0;
             const pane = ctx.tab_mgr.findPaneById(pane_id) orelse {
                 sendError(cmd, "pane not found");
                 return;
             };
-            writeScreenText(cmd, pane);
+            writeScreenText(cmd, pane, lines);
         },
 
         // ── Query ──
@@ -464,15 +472,26 @@ fn buildSplitList(cmd: *queue.IpcCommand, ctx: *WinCtx) void {
     sendOk(cmd, stream.getWritten());
 }
 
-fn writeScreenText(cmd: *queue.IpcCommand, pane: *Pane) void {
+fn writeScreenText(cmd: *queue.IpcCommand, pane: *Pane, lines: u32) void {
     const ring = &pane.engine.state.ring;
-    const rows = ring.screen_rows;
     const cols = ring.cols;
-    var buf: [32768]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
+
+    const total_rows: usize = if (lines == 0) ring.screen_rows else @min(@as(usize, lines), ring.count);
+    const start_abs: usize = if (lines == 0) ring.scrollbackCount() else ring.count - total_rows;
+
+    const max_row_bytes = cols * 4 + 1;
+    const buf_size = total_rows * max_row_bytes + 64;
+    const buf = pane.allocator.alloc(u8, buf_size) catch {
+        sendError(cmd, "out of memory");
+        return;
+    };
+    defer pane.allocator.free(buf);
+    var stream = std.io.fixedBufferStream(buf);
     const w = stream.writer();
-    for (0..rows) |r| {
-        const row_cells = ring.getScreenRow(r);
+
+    var i: usize = 0;
+    while (i < total_rows) : (i += 1) {
+        const row_cells = ring.getRow(start_abs + i);
         var last: usize = cols;
         while (last > 0 and row_cells[last - 1].char == ' ') last -= 1;
         for (row_cells[0..last]) |cell| {


### PR DESCRIPTION
This pull request adds a major new feature to the `attyx get-text` command, allowing users to capture scrollback history by specifying the number of lines to retrieve, not just the visible screen. This is implemented across the CLI, documentation, help texts, and the backend, with careful handling for potentially large responses. Additionally, support for the `xyron` shell is introduced.

**New scrollback capture feature for `get-text`:**

* Added support for a `--lines N` / `-n N` argument to `attyx get-text`, enabling retrieval of the last N rows from a pane's scrollback plus visible screen, similar to `tail -N`. The count is capped at the available scrollback. This is reflected in the CLI parsing, IPC protocol, backend handlers, and documentation. [[1]](diffhunk://#diff-1a21fd2d90221378d685e6159ff4d5232d754829ea27310b24bd1d2b42ac0499R74-R76) [[2]](diffhunk://#diff-1a21fd2d90221378d685e6159ff4d5232d754829ea27310b24bd1d2b42ac0499R195-R200) [[3]](diffhunk://#diff-69681fbe021f6dfdc37c3b89377ea71563bb0d54a136666030d7d66cfd91d4a5L182-R195) [[4]](diffhunk://#diff-69681fbe021f6dfdc37c3b89377ea71563bb0d54a136666030d7d66cfd91d4a5R397-R408) [[5]](diffhunk://#diff-da6090f0d37bce4dc69134006f4f21a75533310ea3d298eaaea34860bd65b89eL127-R131) [[6]](diffhunk://#diff-da6090f0d37bce4dc69134006f4f21a75533310ea3d298eaaea34860bd65b89eR140-R173) [[7]](diffhunk://#diff-8b783cd938f77e8f753711f0f46eeed9d6c9b72c7eb097a4083829f50c9dec45L152-R172) [[8]](diffhunk://#diff-8b783cd938f77e8f753711f0f46eeed9d6c9b72c7eb097a4083829f50c9dec45L467-R494) [[9]](diffhunk://#diff-f95e7842d0fdc9ac3c66742cb5794bb003e1c940ae92807cd0224fe311bc055bR218-R228) [[10]](diffhunk://#diff-f95e7842d0fdc9ac3c66742cb5794bb003e1c940ae92807cd0224fe311bc055bL241-R253) [[11]](diffhunk://#diff-88311af82bcbfd3cd8f77e720d847f958ad68d43bb96cc05c595908b6b77fd82L99-R99) [[12]](diffhunk://#diff-fcecb6bb1f5770a3f085dfb65be85446d58be5262e38b065d207061f25396adfL390-R416)

* Updated help texts and documentation to describe the new `--lines`/`-n` option, including usage examples and clarifications in `SKILL.md` and CLI help output. [[1]](diffhunk://#diff-88311af82bcbfd3cd8f77e720d847f958ad68d43bb96cc05c595908b6b77fd82L99-R99) [[2]](diffhunk://#diff-fcecb6bb1f5770a3f085dfb65be85446d58be5262e38b065d207061f25396adfL390-R416) [[3]](diffhunk://#diff-f95e7842d0fdc9ac3c66742cb5794bb003e1c940ae92807cd0224fe311bc055bR218-R228) [[4]](diffhunk://#diff-f95e7842d0fdc9ac3c66742cb5794bb003e1c940ae92807cd0224fe311bc055bL241-R253)

* Modified the client to heap-allocate a large buffer for responses when using `--lines`, since scrollback dumps can be large (up to several MB).

**Shell integration improvements:**

* Added support for the `xyron` shell in shell detection and integration logic, with custom setup to ensure `attyx` is reachable on `PATH` (since `xyron` uses Lua scripting and can't source POSIX shell scripts). [[1]](diffhunk://#diff-5fbeeec21f7e5c8552587da604b5c713bacaf597ff9e1528796caa7b257b957cR27) [[2]](diffhunk://#diff-5fbeeec21f7e5c8552587da604b5c713bacaf597ff9e1528796caa7b257b957cR51) [[3]](diffhunk://#diff-5fbeeec21f7e5c8552587da604b5c713bacaf597ff9e1528796caa7b257b957cR89) [[4]](diffhunk://#diff-5fbeeec21f7e5c8552587da604b5c713bacaf597ff9e1528796caa7b257b957cR284-R292)

These changes together provide a more powerful and flexible way to extract terminal output from panes, and broaden shell compatibility.