### PR TITLE
feat: Server-side rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,60 @@ All tests must run in headless mode. No rendering required for core tests.
 - Keep descriptions concise and practical — a user reading these should immediately understand what changed and how it affects them.
 - Always include PR links for each fix or feature (e.g. `(#178)`). Link to the specific PR that introduced the change.
 
+# Behavioral guidelines
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -492,14 +492,31 @@ pub const DaemonClient = struct {
     /// the generation hasn't advanced (used by handleFocusPanes to prime
     /// a newly-active slot).
     pub fn sendGridSnapshot(self: *DaemonClient, pane: *DaemonPane, force: bool) void {
-        const eng = pane.engine orelse return;
-        const slot = self.findActivePaneSlot(pane.id) orelse return;
+        const eng = pane.engine orelse {
+            std.log.scoped(.grid).info("sendGridSnapshot: pane {d} has no engine", .{pane.id});
+            return;
+        };
+        const slot = self.findActivePaneSlot(pane.id) orelse {
+            std.log.scoped(.grid).info("sendGridSnapshot: pane {d} not in active set", .{pane.id});
+            return;
+        };
         const gen = pane.engine_generation;
         if (!force and self.active_pane_last_gen[slot] == gen) return;
 
         const rows = pane.rows;
         const cols = pane.cols;
-        if (rows == 0 or cols == 0) return;
+        if (rows == 0 or cols == 0) {
+            std.log.scoped(.grid).warn("sendGridSnapshot: pane {d} has zero dims ({d}x{d})", .{ pane.id, rows, cols });
+            return;
+        }
+        std.log.scoped(.grid).info("sendGridSnapshot: pane {d} gen={d} force={} {d}x{d}", .{ pane.id, gen, force, rows, cols });
+        // Dump first row non-space cells to verify engine state.
+        var non_space: u16 = 0;
+        for (0..cols) |c2| {
+            const cell = eng.state.ring.getScreenCell(0, c2);
+            if (cell.char != ' ' and cell.char != 0) non_space += 1;
+        }
+        std.log.scoped(.grid).info("  row0 non-space cells: {d}, cursor=({d},{d})", .{ non_space, eng.state.cursor.row, eng.state.cursor.col });
 
         // Chunk size limit: keep message payload under ~32KB so it fits
         // the 64KB client read buffer with headroom.

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -595,6 +595,18 @@ pub const DaemonClient = struct {
         self.sendRaw(m);
     }
 
+    /// Send a PaneTitle notification (grid-sync mode).
+    /// Propagates engine.state.title (OSC 0/2) to the client so tab titles
+    /// refresh — the client's engine is passive in grid-sync and never
+    /// sees the OSC bytes directly.
+    pub fn sendPaneTitle(self: *DaemonClient, pane_id: u32, title: []const u8) void {
+        var buf: [protocol.header_size + 4 + 2 + 1024]u8 = undefined;
+        var payload: [4 + 2 + 1024]u8 = undefined;
+        const p = protocol.encodePaneTitle(&payload, pane_id, title) catch return;
+        const m = protocol.encodeMessage(&buf, .pane_title, p) catch return;
+        self.sendRaw(m);
+    }
+
     /// Send a PaneFgCwd notification.
     pub fn sendPaneFgCwd(self: *DaemonClient, pane_id: u32, cwd: []const u8) void {
         var buf: [protocol.header_size + 4 + 2 + 512]u8 = undefined;

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -534,14 +534,18 @@ pub const DaemonClient = struct {
                 .final_chunk = final,
             }) catch return;
 
-            // Pack cells directly into the scratch buffer.
+            // Pack cells into the scratch buffer via memcpy — the wire
+            // framing (5-byte msg header + 28-byte snapshot header = 33)
+            // puts the cell region at an unaligned offset, so pointer
+            // casts are unsafe on arm64.
             const cells_off = payload_off + grid_sync.snapshot_header_size;
-            const cells_ptr: [*]grid_sync.PackedCell = @ptrCast(@alignCast(scratch_buf[cells_off..].ptr));
+            const cell_bytes_len = @as(usize, this_rows) * row_bytes;
+            const cell_buf = scratch_buf[cells_off .. cells_off + cell_bytes_len];
             var out_idx: usize = 0;
             for (start..start + this_rows) |row| {
                 for (0..cols) |col| {
                     const cell = eng.state.ring.getScreenCell(row, col);
-                    cells_ptr[out_idx] = grid_sync.packCell(cell);
+                    grid_sync.writePackedCell(cell_buf, out_idx, grid_sync.packCell(cell));
                     out_idx += 1;
                 }
             }

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -691,6 +691,71 @@ pub const DaemonClient = struct {
         self.sendScrollbackRange(pane, start, take);
     }
 
+    /// Reply to a `get_scrollback_range` RPC: ship up to `request_count`
+    /// rows OLDER than the client's current oldest (`client_has` rows
+    /// behind the daemon's newest). Wire type is `scrollback_range` —
+    /// wire format matches `scrollback_chunk` but client semantics are
+    /// PREPEND (rows are older than anything currently in the client's
+    /// ring). Rows are sent NEWEST-first so the client can prependRow
+    /// each in sequence and end up with the batch in chronological order.
+    pub fn sendScrollbackRangeResponse(self: *DaemonClient, pane: *DaemonPane, client_has: u32, request_count: u32) void {
+        const eng = pane.engine orelse return;
+        const sb_count = eng.state.ring.scrollbackCount();
+        if (sb_count == 0 or request_count == 0) return;
+        // Client's oldest-known abs on daemon = sb_count - client_has.
+        // Clamp if client reports more than daemon has (stale view).
+        const client_oldest_abs: usize = if (client_has >= sb_count) 0 else sb_count - @as(usize, client_has);
+        if (client_oldest_abs == 0) return; // nothing older available
+        const want: usize = @min(@as(usize, request_count), client_oldest_abs);
+        const start_abs: usize = client_oldest_abs - want;
+
+        const cols: u16 = @intCast(eng.state.ring.cols);
+        if (cols == 0) return;
+
+        const max_chunk_payload: usize = 32 * 1024;
+        const row_bytes: usize = @as(usize, cols) * @sizeOf(grid_sync.PackedCell);
+        const rows_per_chunk_usize: usize = @max(1, (max_chunk_payload - grid_sync.scrollback_header_size) / row_bytes);
+        const rows_per_chunk: u16 = @intCast(@min(rows_per_chunk_usize, want));
+
+        var scratch_buf: [max_chunk_payload + protocol.header_size]u8 align(4) = undefined;
+
+        // Walk NEWEST-first: first chunk contains the newest of the range
+        // (closest to the client's existing oldest row).
+        var sent: usize = 0;
+        while (sent < want) {
+            const this_rows_usize = @min(@as(usize, rows_per_chunk), want - sent);
+            const this_rows: u16 = @intCast(this_rows_usize);
+            const remaining: u32 = @intCast(want - sent - this_rows);
+            const payload_len: u32 = @intCast(grid_sync.scrollback_header_size + this_rows_usize * row_bytes);
+            protocol.encodeHeader(scratch_buf[0..protocol.header_size], .scrollback_range, payload_len);
+            const payload_off = protocol.header_size;
+            _ = grid_sync.encodeScrollbackHeader(scratch_buf[payload_off..], .{
+                .pane_id = pane.id,
+                .cols = cols,
+                .row_count = this_rows,
+                .total_remaining = remaining,
+            }) catch return;
+            const cells_off = payload_off + grid_sync.scrollback_header_size;
+            const cell_buf = scratch_buf[cells_off .. cells_off + this_rows_usize * row_bytes];
+            var out_idx: usize = 0;
+            // Newest-first: abs = (client_oldest_abs - 1) - sent - i.
+            var i: usize = 0;
+            while (i < this_rows_usize) : (i += 1) {
+                const abs = client_oldest_abs - 1 - sent - i;
+                if (abs < start_abs) break;
+                const row = eng.state.ring.getRow(abs);
+                for (0..cols) |c_idx| {
+                    grid_sync.writePackedCell(cell_buf, out_idx, grid_sync.packCell(row[c_idx]));
+                    out_idx += 1;
+                }
+            }
+            const total_len = protocol.header_size + @as(usize, payload_len);
+            self.sendRaw(scratch_buf[0..total_len]);
+            if (self.dead) return;
+            sent += this_rows_usize;
+        }
+    }
+
     /// Send a PaneTitle notification (grid-sync mode).
     /// Propagates engine.state.title (OSC 0/2) to the client so tab titles
     /// refresh — the client's engine is passive in grid-sync and never

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const is_windows = builtin.os.tag == .windows;
 const protocol = @import("protocol.zig");
+const grid_sync = @import("grid_sync.zig");
 const DaemonSession = @import("session.zig").DaemonSession;
 const DaemonPane = @import("pane.zig").DaemonPane;
 
@@ -30,6 +31,16 @@ pub const DaemonClient = struct {
     /// V2: active panes set (panes the client is currently displaying)
     active_panes: [32]u32 = .{0} ** 32,
     active_pane_count: u8 = 0,
+    /// Last engine_generation shipped to this client per active pane,
+    /// parallel-indexed with `active_panes`. 0 means "nothing sent yet" →
+    /// next emission will be a full snapshot. Reset when the slot is
+    /// reassigned to a different pane_id in handleFocusPanes.
+    active_pane_last_gen: [32]u64 = .{0} ** 32,
+    /// Capability bits advertised by this client in its hello payload.
+    /// 0 for legacy clients that didn't send caps. Daemon uses this to
+    /// decide whether it can ship grid_snapshot/grid_delta or must fall
+    /// back to the legacy byte-stream (pane_output) path.
+    peer_caps: u32 = 0,
 
     pub fn init(fd: std.posix.fd_t) DaemonClient {
         return .{ .socket_fd = fd };
@@ -462,6 +473,88 @@ pub const DaemonClient = struct {
         }
     }
 
+    /// True if this client negotiated grid-sync mode in its hello caps.
+    pub fn hasGridSync(self: *const DaemonClient) bool {
+        return self.peer_caps & protocol.Capabilities.GRID_SYNC != 0;
+    }
+
+    /// Find the index of pane_id in active_panes, or null.
+    pub fn findActivePaneSlot(self: *const DaemonClient, pane_id: u32) ?usize {
+        for (self.active_panes[0..self.active_pane_count], 0..) |id, i| {
+            if (id == pane_id) return i;
+        }
+        return null;
+    }
+
+    /// Ship the pane's current engine cell grid to this client as one or
+    /// more grid_snapshot chunks. No-op if the pane has no engine.
+    /// Updates active_pane_last_gen on success. `force` sends even if
+    /// the generation hasn't advanced (used by handleFocusPanes to prime
+    /// a newly-active slot).
+    pub fn sendGridSnapshot(self: *DaemonClient, pane: *DaemonPane, force: bool) void {
+        const eng = pane.engine orelse return;
+        const slot = self.findActivePaneSlot(pane.id) orelse return;
+        const gen = pane.engine_generation;
+        if (!force and self.active_pane_last_gen[slot] == gen) return;
+
+        const rows = pane.rows;
+        const cols = pane.cols;
+        if (rows == 0 or cols == 0) return;
+
+        // Chunk size limit: keep message payload under ~32KB so it fits
+        // the 64KB client read buffer with headroom.
+        const max_chunk_payload: usize = 32 * 1024;
+        const row_bytes: usize = @as(usize, cols) * @sizeOf(grid_sync.PackedCell);
+        if (row_bytes == 0) return;
+        const rows_per_chunk_usize: usize = @max(1, (max_chunk_payload - grid_sync.snapshot_header_size) / row_bytes);
+        const rows_per_chunk: u16 = @intCast(@min(rows_per_chunk_usize, rows));
+
+        var scratch_buf: [max_chunk_payload + protocol.header_size]u8 align(4) = undefined;
+
+        var start: u16 = 0;
+        while (start < rows) {
+            const this_rows = @min(rows_per_chunk, rows - start);
+            const final = (start + this_rows) >= rows;
+            const payload_len: u32 = @intCast(grid_sync.snapshot_header_size + @as(usize, this_rows) * row_bytes);
+            protocol.encodeHeader(scratch_buf[0..protocol.header_size], .grid_snapshot, payload_len);
+
+            const payload_off = protocol.header_size;
+            _ = grid_sync.encodeSnapshotHeader(scratch_buf[payload_off..], .{
+                .pane_id = pane.id,
+                .generation = gen,
+                .rows = rows,
+                .cols = cols,
+                .cursor_row = @intCast(@min(eng.state.cursor.row, std.math.maxInt(u16))),
+                .cursor_col = @intCast(@min(eng.state.cursor.col, std.math.maxInt(u16))),
+                .cursor_visible = eng.state.cursor_visible,
+                .cursor_shape = @intFromEnum(eng.state.cursor_shape),
+                .alt_active = eng.state.alt_active,
+                .start_row = start,
+                .row_count = this_rows,
+                .final_chunk = final,
+            }) catch return;
+
+            // Pack cells directly into the scratch buffer.
+            const cells_off = payload_off + grid_sync.snapshot_header_size;
+            const cells_ptr: [*]grid_sync.PackedCell = @ptrCast(@alignCast(scratch_buf[cells_off..].ptr));
+            var out_idx: usize = 0;
+            for (start..start + this_rows) |row| {
+                for (0..cols) |col| {
+                    const cell = eng.state.ring.getScreenCell(row, col);
+                    cells_ptr[out_idx] = grid_sync.packCell(cell);
+                    out_idx += 1;
+                }
+            }
+
+            const total_len = protocol.header_size + @as(usize, payload_len);
+            self.sendRaw(scratch_buf[0..total_len]);
+            if (self.dead) return;
+            start += this_rows;
+        }
+
+        self.active_pane_last_gen[slot] = gen;
+    }
+
     /// Send a ReplayEnd notification for a pane, signaling that scrollback
     /// replay is complete and real-time data follows.
     pub fn sendReplayEnd(self: *DaemonClient, pane_id: u32) void {
@@ -490,10 +583,10 @@ pub const DaemonClient = struct {
         self.sendRaw(m);
     }
 
-    /// Send a HelloAck response with daemon's version string.
-    pub fn sendHelloAck(self: *DaemonClient, version: []const u8) void {
+    /// Send a HelloAck response with daemon's version string and capability bits.
+    pub fn sendHelloAck(self: *DaemonClient, version: []const u8, caps: u32) void {
         var payload: [256]u8 = undefined;
-        const p = protocol.encodeHello(&payload, version) catch return;
+        const p = protocol.encodeHello(&payload, version, caps) catch return;
         var buf: [protocol.header_size + 256]u8 = undefined;
         const m = protocol.encodeMessage(&buf, .hello_ack, p) catch return;
         self.sendRaw(m);

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -36,6 +36,11 @@ pub const DaemonClient = struct {
     /// next emission will be a full snapshot. Reset when the slot is
     /// reassigned to a different pane_id in handleFocusPanes.
     active_pane_last_gen: [32]u64 = .{0} ** 32,
+    /// Scrollback row count we last observed when sending a snapshot to
+    /// this client per active pane slot. Used to compute an incremental
+    /// `scrollback_delta` so the client can grow its own ring as the
+    /// daemon's engine scrolls rows off-screen.
+    active_pane_last_sb: [32]u32 = .{0} ** 32,
     /// Capability bits advertised by this client in its hello payload.
     /// 0 for legacy clients that didn't send caps. Daemon uses this to
     /// decide whether it can ship grid_snapshot/grid_delta or must fall
@@ -493,11 +498,11 @@ pub const DaemonClient = struct {
     /// a newly-active slot).
     pub fn sendGridSnapshot(self: *DaemonClient, pane: *DaemonPane, force: bool) void {
         const eng = pane.engine orelse {
-            std.log.scoped(.grid).info("sendGridSnapshot: pane {d} has no engine", .{pane.id});
+            std.log.scoped(.grid).debug("sendGridSnapshot: pane {d} has no engine", .{pane.id});
             return;
         };
         const slot = self.findActivePaneSlot(pane.id) orelse {
-            std.log.scoped(.grid).info("sendGridSnapshot: pane {d} not in active set", .{pane.id});
+            std.log.scoped(.grid).debug("sendGridSnapshot: pane {d} not in active set", .{pane.id});
             return;
         };
         const gen = pane.engine_generation;
@@ -505,18 +510,27 @@ pub const DaemonClient = struct {
 
         const rows = pane.rows;
         const cols = pane.cols;
-        if (rows == 0 or cols == 0) {
-            std.log.scoped(.grid).warn("sendGridSnapshot: pane {d} has zero dims ({d}x{d})", .{ pane.id, rows, cols });
-            return;
+        if (rows == 0 or cols == 0) return;
+        std.log.scoped(.grid).debug("sendGridSnapshot: pane {d} gen={d} force={} {d}x{d}", .{ pane.id, gen, force, rows, cols });
+
+        // Scrollback delta = rows that have been pushed into scrollback on
+        // the daemon since our last snapshot to this client. We ship those
+        // rows EXPLICITLY as scrollback_chunk messages before the snapshot
+        // so the client can append them to its own scrollback — relying on
+        // the client's own top-of-screen rows matching what scrolled off
+        // is unreliable when many scrolls happen in one fan-out tick.
+        const current_sb: u32 = @intCast(eng.state.ring.scrollbackCount());
+        const last_sb = self.active_pane_last_sb[slot];
+        const delta_usize: usize = if (current_sb > last_sb) current_sb - last_sb else 0;
+        if (delta_usize > 0) {
+            // The newly-scrolled rows live at abs [last_sb, current_sb) —
+            // they are the OLDEST scrollback_count - last_sb portion of
+            // the window that didn't exist the last time we synced.
+            self.sendScrollbackRange(pane, last_sb, delta_usize);
         }
-        std.log.scoped(.grid).info("sendGridSnapshot: pane {d} gen={d} force={} {d}x{d}", .{ pane.id, gen, force, rows, cols });
-        // Dump first row non-space cells to verify engine state.
-        var non_space: u16 = 0;
-        for (0..cols) |c2| {
-            const cell = eng.state.ring.getScreenCell(0, c2);
-            if (cell.char != ' ' and cell.char != 0) non_space += 1;
-        }
-        std.log.scoped(.grid).info("  row0 non-space cells: {d}, cursor=({d},{d})", .{ non_space, eng.state.cursor.row, eng.state.cursor.col });
+        // Snapshot header still carries a (now legacy) scrollback_delta
+        // field for wire-compat; client ignores it.
+        const scrollback_delta: u16 = @intCast(@min(delta_usize, std.math.maxInt(u16)));
 
         // Chunk size limit: keep message payload under ~32KB so it fits
         // the 64KB client read buffer with headroom.
@@ -549,6 +563,10 @@ pub const DaemonClient = struct {
                 .start_row = start,
                 .row_count = this_rows,
                 .final_chunk = final,
+                // Only the first chunk carries the scrollback_delta; later
+                // chunks in the same snapshot ship 0 so the client doesn't
+                // double-shift.
+                .scrollback_delta = if (start == 0) scrollback_delta else 0,
             }) catch return;
 
             // Pack cells into the scratch buffer via memcpy — the wire
@@ -574,6 +592,7 @@ pub const DaemonClient = struct {
         }
 
         self.active_pane_last_gen[slot] = gen;
+        self.active_pane_last_sb[slot] = current_sb;
     }
 
     /// Send a ReplayEnd notification for a pane, signaling that scrollback
@@ -595,17 +614,28 @@ pub const DaemonClient = struct {
         self.sendRaw(m);
     }
 
-    /// Ship the pane's current scrollback to this grid-sync client as one
-    /// or more scrollback_chunk messages. Rows are sent NEWEST-first so
-    /// the client can prepend each row into its ring in sequence. Capped
-    /// at `max_rows` total to bound initial-focus bandwidth. No-op if the
-    /// pane has no engine or no scrollback.
-    pub fn sendScrollbackChunks(self: *DaemonClient, pane: *DaemonPane, max_rows: usize) void {
+    /// Pre-seed the per-slot `last_sb` to the pane's current scrollback count,
+    /// so the next sendGridSnapshot sees delta=0 and doesn't ask the client
+    /// to shiftScreenUp — the one-shot scrollback_chunk hydration will fill
+    /// those rows explicitly. Called exactly once per focus event before
+    /// the initial snapshot + scrollback burst.
+    pub fn primeScrollbackBaseline(self: *DaemonClient, pane: *DaemonPane) void {
+        const eng = pane.engine orelse return;
+        const slot = self.findActivePaneSlot(pane.id) orelse return;
+        const current_sb: u32 = @intCast(eng.state.ring.scrollbackCount());
+        self.active_pane_last_sb[slot] = current_sb;
+    }
+
+    /// Ship rows `[start_abs, start_abs+count)` from the daemon pane's
+    /// scrollback to this client as scrollback_chunk messages, oldest-first.
+    /// Client APPENDS each row to its scrollback in order, so batch order
+    /// equals chronological order.
+    pub fn sendScrollbackRange(self: *DaemonClient, pane: *DaemonPane, start_abs: usize, count: usize) void {
         const eng = pane.engine orelse return;
         const sb_count = eng.state.ring.scrollbackCount();
-        std.log.scoped(.grid).info("sendScrollbackChunks: pane {d} scrollbackCount={d} max={d}", .{ pane.id, sb_count, max_rows });
-        if (sb_count == 0) return;
-        const rows_to_send = @min(sb_count, max_rows);
+        if (count == 0 or start_abs >= sb_count) return;
+        const end_abs = @min(start_abs + count, sb_count);
+        const rows_to_send = end_abs - start_abs;
         const cols: u16 = @intCast(eng.state.ring.cols);
         if (cols == 0) return;
 
@@ -616,7 +646,6 @@ pub const DaemonClient = struct {
 
         var scratch_buf: [max_chunk_payload + protocol.header_size]u8 align(4) = undefined;
 
-        // Walk newest-first: abs starts at (sb_count - 1), decrements by chunk.
         var sent: usize = 0;
         while (sent < rows_to_send) {
             const this_rows_usize = @min(@as(usize, rows_per_chunk), rows_to_send - sent);
@@ -634,10 +663,10 @@ pub const DaemonClient = struct {
             const cells_off = payload_off + grid_sync.scrollback_header_size;
             const cell_buf = scratch_buf[cells_off .. cells_off + this_rows_usize * row_bytes];
             var out_idx: usize = 0;
-            // Newest-first: abs = (sb_count - 1) - sent - i
+            // Oldest-first within the chunk: abs = start_abs + sent + i.
             var i: usize = 0;
             while (i < this_rows_usize) : (i += 1) {
-                const abs = sb_count - 1 - sent - i;
+                const abs = start_abs + sent + i;
                 const row = eng.state.ring.getRow(abs);
                 for (0..cols) |c_idx| {
                     grid_sync.writePackedCell(cell_buf, out_idx, grid_sync.packCell(row[c_idx]));
@@ -649,6 +678,17 @@ pub const DaemonClient = struct {
             if (self.dead) return;
             sent += this_rows_usize;
         }
+    }
+
+    /// Convenience wrapper: on initial focus, ship the newest `max_rows`
+    /// of the pane's scrollback so the client's scrollback starts hydrated.
+    pub fn sendScrollbackChunks(self: *DaemonClient, pane: *DaemonPane, max_rows: usize) void {
+        const eng = pane.engine orelse return;
+        const sb_count = eng.state.ring.scrollbackCount();
+        if (sb_count == 0) return;
+        const take = @min(sb_count, max_rows);
+        const start = sb_count - take;
+        self.sendScrollbackRange(pane, start, take);
     }
 
     /// Send a PaneTitle notification (grid-sync mode).

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -595,6 +595,62 @@ pub const DaemonClient = struct {
         self.sendRaw(m);
     }
 
+    /// Ship the pane's current scrollback to this grid-sync client as one
+    /// or more scrollback_chunk messages. Rows are sent NEWEST-first so
+    /// the client can prepend each row into its ring in sequence. Capped
+    /// at `max_rows` total to bound initial-focus bandwidth. No-op if the
+    /// pane has no engine or no scrollback.
+    pub fn sendScrollbackChunks(self: *DaemonClient, pane: *DaemonPane, max_rows: usize) void {
+        const eng = pane.engine orelse return;
+        const sb_count = eng.state.ring.scrollbackCount();
+        std.log.scoped(.grid).info("sendScrollbackChunks: pane {d} scrollbackCount={d} max={d}", .{ pane.id, sb_count, max_rows });
+        if (sb_count == 0) return;
+        const rows_to_send = @min(sb_count, max_rows);
+        const cols: u16 = @intCast(eng.state.ring.cols);
+        if (cols == 0) return;
+
+        const max_chunk_payload: usize = 32 * 1024;
+        const row_bytes: usize = @as(usize, cols) * @sizeOf(grid_sync.PackedCell);
+        const rows_per_chunk_usize: usize = @max(1, (max_chunk_payload - grid_sync.scrollback_header_size) / row_bytes);
+        const rows_per_chunk: u16 = @intCast(@min(rows_per_chunk_usize, rows_to_send));
+
+        var scratch_buf: [max_chunk_payload + protocol.header_size]u8 align(4) = undefined;
+
+        // Walk newest-first: abs starts at (sb_count - 1), decrements by chunk.
+        var sent: usize = 0;
+        while (sent < rows_to_send) {
+            const this_rows_usize = @min(@as(usize, rows_per_chunk), rows_to_send - sent);
+            const this_rows: u16 = @intCast(this_rows_usize);
+            const remaining: u32 = @intCast(rows_to_send - sent - this_rows);
+            const payload_len: u32 = @intCast(grid_sync.scrollback_header_size + this_rows_usize * row_bytes);
+            protocol.encodeHeader(scratch_buf[0..protocol.header_size], .scrollback_chunk, payload_len);
+            const payload_off = protocol.header_size;
+            _ = grid_sync.encodeScrollbackHeader(scratch_buf[payload_off..], .{
+                .pane_id = pane.id,
+                .cols = cols,
+                .row_count = this_rows,
+                .total_remaining = remaining,
+            }) catch return;
+            const cells_off = payload_off + grid_sync.scrollback_header_size;
+            const cell_buf = scratch_buf[cells_off .. cells_off + this_rows_usize * row_bytes];
+            var out_idx: usize = 0;
+            // Newest-first: abs = (sb_count - 1) - sent - i
+            var i: usize = 0;
+            while (i < this_rows_usize) : (i += 1) {
+                const abs = sb_count - 1 - sent - i;
+                const row = eng.state.ring.getRow(abs);
+                for (0..cols) |c_idx| {
+                    grid_sync.writePackedCell(cell_buf, out_idx, grid_sync.packCell(row[c_idx]));
+                    out_idx += 1;
+                }
+            }
+            const total_len = protocol.header_size + @as(usize, payload_len);
+            self.sendRaw(scratch_buf[0..total_len]);
+            if (self.dead) return;
+            sent += this_rows_usize;
+        }
+    }
+
     /// Send a PaneTitle notification (grid-sync mode).
     /// Propagates engine.state.title (OSC 0/2) to the client so tab titles
     /// refresh — the client's engine is passive in grid-sync and never

--- a/src/app/daemon/cwd_test.zig
+++ b/src/app/daemon/cwd_test.zig
@@ -124,11 +124,15 @@ test "daemon: session created with cwd spawns shell in that directory" {
     const v2 = try protocol.decodeAttachedV2(attached);
     const pane_id = v2.pane_ids[0];
 
+    // Pane is deferred-spawn until first pane_resize activates it.
+    const init_rp = try protocol.encodePaneResize(&buf, pane_id, 24, 80);
+    try client.send(.pane_resize, init_rp);
+
     const fp = try protocol.encodeFocusPanes(&buf, &.{pane_id});
     try client.send(.focus_panes, fp);
 
     // Wait for shell startup, drain initial output
-    posix.nanosleep(0, 200_000_000);
+    posix.nanosleep(0, 400_000_000);
     _ = client.tryParse(.pane_output);
     client.read_len = 0;
 
@@ -162,10 +166,14 @@ test "daemon: session with home cwd spawns in home" {
     const v2 = try protocol.decodeAttachedV2(attached);
     const pane_id = v2.pane_ids[0];
 
+    // Pane is deferred-spawn until first pane_resize activates it.
+    const init_rp = try protocol.encodePaneResize(&buf, pane_id, 24, 80);
+    try client.send(.pane_resize, init_rp);
+
     const fp = try protocol.encodeFocusPanes(&buf, &.{pane_id});
     try client.send(.focus_panes, fp);
 
-    posix.nanosleep(0, 200_000_000);
+    posix.nanosleep(0, 400_000_000);
     _ = client.tryParse(.pane_output);
     client.read_len = 0;
 
@@ -243,10 +251,14 @@ test "daemon: two sessions with different cwds" {
         const v2 = try protocol.decodeAttachedV2(attached);
         const pane_id = v2.pane_ids[0];
 
+        // Pane is deferred-spawn until first pane_resize activates it.
+        const init_rp = try protocol.encodePaneResize(&buf, pane_id, 24, 80);
+        try client.send(.pane_resize, init_rp);
+
         const fp = try protocol.encodeFocusPanes(&buf, &.{pane_id});
         try client.send(.focus_panes, fp);
 
-        posix.nanosleep(0, 200_000_000);
+        posix.nanosleep(0, 400_000_000);
         _ = client.tryParse(.pane_output);
         client.read_len = 0;
 
@@ -257,9 +269,19 @@ test "daemon: two sessions with different cwds" {
         try testing.expect(found);
     }
 
-    // Detach, then attach to session 2, verify different cwd
+    // Detach, then attach to session 2, verify different cwd.
+    // Drain pending session-1 output post-detach by reading from the
+    // socket until quiet — otherwise stale pane_output messages can
+    // outpace the .attached response in the kernel recv buffer.
     try client.send(.detach, &.{});
-    posix.nanosleep(0, 50_000_000);
+    posix.nanosleep(0, 200_000_000);
+    drain_loop: for (0..10) |_| {
+        var fds = [1]posix.pollfd{.{ .fd = client.fd, .events = 0x0001, .revents = 0 }};
+        _ = posix.poll(&fds, 50) catch break :drain_loop;
+        if (fds[0].revents & 0x0001 == 0) break :drain_loop;
+        var dbuf: [4096]u8 = undefined;
+        _ = posix.read(client.fd, &dbuf) catch break :drain_loop;
+    }
     client.read_len = 0;
 
     {
@@ -269,10 +291,14 @@ test "daemon: two sessions with different cwds" {
         const v2 = try protocol.decodeAttachedV2(attached);
         const pane_id = v2.pane_ids[0];
 
+        // Pane is deferred-spawn until first pane_resize activates it.
+        const init_rp = try protocol.encodePaneResize(&buf, pane_id, 24, 80);
+        try client.send(.pane_resize, init_rp);
+
         const fp = try protocol.encodeFocusPanes(&buf, &.{pane_id});
         try client.send(.focus_panes, fp);
 
-        posix.nanosleep(0, 200_000_000);
+        posix.nanosleep(0, 400_000_000);
         _ = client.tryParse(.pane_output);
         client.read_len = 0;
 

--- a/src/app/daemon/daemon.zig
+++ b/src/app/daemon/daemon.zig
@@ -249,11 +249,22 @@ pub fn run(allocator: std.mem.Allocator, restore_path: ?[]const u8) !void {
                                 coalesced += n;
                             }
                             if (coalesced == 0) break;
+                            // Grid-sync title change propagation (OSC 0/2):
+                            // the client's engine is passive in grid-sync mode,
+                            // so title updates have to be shipped explicitly.
+                            const title_dirty = if (pane.engine) |eng_ptr| eng_ptr.state.title_changed else false;
+                            if (title_dirty) {
+                                if (pane.engine) |eng_ptr| eng_ptr.state.title_changed = false;
+                            }
                             for (&clients) |*cslot| {
                                 if (cslot.*) |*cl| {
                                     if (cl.attached_session == s.id and cl.isPaneActive(pane.id)) {
                                         if (cl.hasGridSync() and pane.engine != null) {
                                             cl.sendGridSnapshot(pane, false);
+                                            if (title_dirty) {
+                                                const t = pane.engine.?.state.title orelse "";
+                                                cl.sendPaneTitle(pane.id, t);
+                                            }
                                         } else {
                                             cl.sendPaneOutput(pane.id, pty_buf[0..coalesced]);
                                         }

--- a/src/app/daemon/daemon.zig
+++ b/src/app/daemon/daemon.zig
@@ -252,7 +252,11 @@ pub fn run(allocator: std.mem.Allocator, restore_path: ?[]const u8) !void {
                             for (&clients) |*cslot| {
                                 if (cslot.*) |*cl| {
                                     if (cl.attached_session == s.id and cl.isPaneActive(pane.id)) {
-                                        cl.sendPaneOutput(pane.id, pty_buf[0..coalesced]);
+                                        if (cl.hasGridSync() and pane.engine != null) {
+                                            cl.sendGridSnapshot(pane, false);
+                                        } else {
+                                            cl.sendPaneOutput(pane.id, pty_buf[0..coalesced]);
+                                        }
                                     }
                                 }
                             }

--- a/src/app/daemon/daemon.zig
+++ b/src/app/daemon/daemon.zig
@@ -194,7 +194,9 @@ pub fn run(allocator: std.mem.Allocator, restore_path: ?[]const u8) !void {
             if (slot.*) |*s| {
                 for (&s.panes, 0..) |*pslot, pi| {
                     if (pslot.*) |*p| {
-                        if (p.alive) {
+                        // Skip deferred-spawn panes (master == -1 until
+                        // first resize triggers the actual fork/exec).
+                        if (p.alive and p.pty.master >= 0) {
                             fds[nfds] = .{ .fd = p.pty.master, .events = 0x0001, .revents = 0 };
                             pty_fd_map[pty_fd_count] = .{ .session_idx = si, .pane_idx = pi };
                             pty_fd_count += 1;
@@ -525,6 +527,7 @@ fn deleteVersionFile() void {
 }
 
 fn setNonBlocking(fd: posix.fd_t) void {
+    if (fd < 0) return; // deferred-spawn pane: PTY not yet active
     const F_GETFL: i32 = 3;
     const F_SETFL: i32 = 4;
     const flags = std.posix.fcntl(fd, F_GETFL, 0) catch return;

--- a/src/app/daemon/grid_sync.zig
+++ b/src/app/daemon/grid_sync.zig
@@ -1,0 +1,516 @@
+// Attyx — Grid sync wire format (server-side VT engine)
+//
+// When both peers advertise Capabilities.GRID_SYNC the daemon ships cell
+// grids instead of raw PTY bytes. Two messages carry the state:
+//
+//   grid_snapshot — full screen (sent on first focus or gap recovery)
+//   grid_delta    — dirty rows only (sent every ~60Hz while bytes flow)
+//
+// Cells travel in `PackedCell` (32 bytes, extern struct, stable layout).
+// Themes are NOT baked in — the client resolves Color → RGB using its
+// own theme at publish time. That keeps multi-client + per-client theming
+// cleanly separable.
+
+const std = @import("std");
+const attyx = @import("attyx");
+
+const Cell = attyx.Cell;
+const Color = attyx.Color;
+const Style = attyx.Style;
+
+// ── PackedColor: wire-stable Color encoding ──
+
+/// Tag identifying which variant of `Color` a PackedColor holds.
+pub const color_tag_default: u8 = 0;
+pub const color_tag_ansi: u8 = 1;
+pub const color_tag_palette: u8 = 2;
+pub const color_tag_rgb: u8 = 3;
+
+/// 32-bit encoded Color. `tag` picks the variant; `value` payload:
+///   default  → 0
+///   ansi     → 0x0000_00XX (XX = ANSI index 0–15)
+///   palette  → 0x0000_00XX (XX = 256-color palette index)
+///   rgb      → 0x00_RRGGBB (r,g,b in low three bytes)
+pub const PackedColor = packed struct(u32) {
+    value: u24,
+    tag: u8,
+};
+
+pub fn packColor(c: Color) PackedColor {
+    return switch (c) {
+        .default => .{ .tag = color_tag_default, .value = 0 },
+        .ansi => |i| .{ .tag = color_tag_ansi, .value = i },
+        .palette => |i| .{ .tag = color_tag_palette, .value = i },
+        .rgb => |rgb| .{
+            .tag = color_tag_rgb,
+            .value = @as(u24, rgb.r) |
+                (@as(u24, rgb.g) << 8) |
+                (@as(u24, rgb.b) << 16),
+        },
+    };
+}
+
+pub fn unpackColor(p: PackedColor) Color {
+    return switch (p.tag) {
+        color_tag_ansi => .{ .ansi = @intCast(p.value & 0xFF) },
+        color_tag_palette => .{ .palette = @intCast(p.value & 0xFF) },
+        color_tag_rgb => .{ .rgb = .{
+            .r = @intCast(p.value & 0xFF),
+            .g = @intCast((p.value >> 8) & 0xFF),
+            .b = @intCast((p.value >> 16) & 0xFF),
+        } },
+        else => .default,
+    };
+}
+
+// ── PackedCell: wire-stable Cell ──
+
+pub const style_flag_bold: u8 = 1 << 0;
+pub const style_flag_dim: u8 = 1 << 1;
+pub const style_flag_italic: u8 = 1 << 2;
+pub const style_flag_underline: u8 = 1 << 3;
+pub const style_flag_reverse: u8 = 1 << 4;
+pub const style_flag_strikethrough: u8 = 1 << 5;
+
+pub const PackedCell = extern struct {
+    char: u32 = 0x20,
+    combining: [2]u32 = .{ 0, 0 },
+    fg: u32 = 0,
+    bg: u32 = 0,
+    style_flags: u8 = 0,
+    _pad: [3]u8 = .{ 0, 0, 0 },
+    link_id: u32 = 0,
+};
+
+comptime {
+    // Wire format must be stable across builds.
+    if (@sizeOf(PackedCell) != 28) @compileError("PackedCell size changed; wire format would break");
+}
+
+pub fn packCell(cell: Cell) PackedCell {
+    var flags: u8 = 0;
+    if (cell.style.bold) flags |= style_flag_bold;
+    if (cell.style.dim) flags |= style_flag_dim;
+    if (cell.style.italic) flags |= style_flag_italic;
+    if (cell.style.underline) flags |= style_flag_underline;
+    if (cell.style.reverse) flags |= style_flag_reverse;
+    if (cell.style.strikethrough) flags |= style_flag_strikethrough;
+    return .{
+        .char = cell.char,
+        .combining = .{ cell.combining[0], cell.combining[1] },
+        .fg = @bitCast(packColor(cell.style.fg)),
+        .bg = @bitCast(packColor(cell.style.bg)),
+        .style_flags = flags,
+        .link_id = cell.link_id,
+    };
+}
+
+pub fn unpackCell(p: PackedCell) Cell {
+    const fg_packed: PackedColor = @bitCast(p.fg);
+    const bg_packed: PackedColor = @bitCast(p.bg);
+    return .{
+        .char = @intCast(p.char & 0x1FFFFF),
+        .combining = .{
+            @intCast(p.combining[0] & 0x1FFFFF),
+            @intCast(p.combining[1] & 0x1FFFFF),
+        },
+        .style = .{
+            .fg = unpackColor(fg_packed),
+            .bg = unpackColor(bg_packed),
+            .bold = p.style_flags & style_flag_bold != 0,
+            .dim = p.style_flags & style_flag_dim != 0,
+            .italic = p.style_flags & style_flag_italic != 0,
+            .underline = p.style_flags & style_flag_underline != 0,
+            .reverse = p.style_flags & style_flag_reverse != 0,
+            .strikethrough = p.style_flags & style_flag_strikethrough != 0,
+        },
+        .link_id = p.link_id,
+    };
+}
+
+// ── grid_snapshot ──
+
+pub const cursor_visible_flag: u8 = 1 << 0;
+pub const alt_active_flag: u8 = 1 << 1;
+pub const final_chunk_flag: u8 = 1 << 2;
+
+/// grid_snapshot header. Each message carries a CONTIGUOUS row range
+/// `[start_row, start_row + row_count)` of the pane grid. Large panes
+/// require multiple messages (bounded by the 64KB wire framing). The
+/// final message in a snapshot sets `final_chunk_flag`; all messages
+/// share the same `generation`.
+pub const SnapshotHeader = extern struct {
+    pane_id: u32,
+    generation_lo: u32,
+    generation_hi: u32,
+    rows: u16, // total rows in pane
+    cols: u16, // cols in pane
+    cursor_row: u16,
+    cursor_col: u16,
+    flags: u8, // bit0=cursor_visible, bit1=alt_active, bit2=final_chunk
+    cursor_shape: u8,
+    start_row: u16,
+    row_count: u16, // rows in this message's cell block
+};
+
+comptime {
+    if (@sizeOf(SnapshotHeader) != 28) @compileError("SnapshotHeader size changed");
+}
+
+pub const snapshot_header_size = @sizeOf(SnapshotHeader);
+
+pub const SnapshotInfo = struct {
+    pane_id: u32,
+    generation: u64,
+    rows: u16,
+    cols: u16,
+    cursor_row: u16,
+    cursor_col: u16,
+    cursor_visible: bool,
+    cursor_shape: u8,
+    alt_active: bool,
+    start_row: u16,
+    row_count: u16,
+    final_chunk: bool,
+};
+
+pub fn encodedSnapshotChunkSize(cols: u16, row_count: u16) usize {
+    return snapshot_header_size + @as(usize, row_count) * @as(usize, cols) * @sizeOf(PackedCell);
+}
+
+/// Encode header into buf; returns header size. Caller appends cells.
+pub fn encodeSnapshotHeader(buf: []u8, info: SnapshotInfo) !usize {
+    if (buf.len < snapshot_header_size) return error.BufferTooSmall;
+    var flags: u8 = 0;
+    if (info.cursor_visible) flags |= cursor_visible_flag;
+    if (info.alt_active) flags |= alt_active_flag;
+    if (info.final_chunk) flags |= final_chunk_flag;
+    const hdr: SnapshotHeader = .{
+        .pane_id = info.pane_id,
+        .generation_lo = @truncate(info.generation),
+        .generation_hi = @truncate(info.generation >> 32),
+        .rows = info.rows,
+        .cols = info.cols,
+        .cursor_row = info.cursor_row,
+        .cursor_col = info.cursor_col,
+        .flags = flags,
+        .cursor_shape = info.cursor_shape,
+        .start_row = info.start_row,
+        .row_count = info.row_count,
+    };
+    @memcpy(buf[0..snapshot_header_size], std.mem.asBytes(&hdr));
+    return snapshot_header_size;
+}
+
+pub fn decodeSnapshotHeader(payload: []const u8) !SnapshotInfo {
+    if (payload.len < snapshot_header_size) return error.PayloadTooShort;
+    var hdr: SnapshotHeader = undefined;
+    @memcpy(std.mem.asBytes(&hdr), payload[0..snapshot_header_size]);
+    const gen: u64 = @as(u64, hdr.generation_lo) |
+        (@as(u64, hdr.generation_hi) << 32);
+    return .{
+        .pane_id = hdr.pane_id,
+        .generation = gen,
+        .rows = hdr.rows,
+        .cols = hdr.cols,
+        .cursor_row = hdr.cursor_row,
+        .cursor_col = hdr.cursor_col,
+        .cursor_visible = hdr.flags & cursor_visible_flag != 0,
+        .cursor_shape = hdr.cursor_shape,
+        .alt_active = hdr.flags & alt_active_flag != 0,
+        .start_row = hdr.start_row,
+        .row_count = hdr.row_count,
+        .final_chunk = hdr.flags & final_chunk_flag != 0,
+    };
+}
+
+/// Returns the PackedCell slice embedded in a snapshot chunk payload
+/// (row_count × cols cells starting at start_row).
+pub fn snapshotCells(payload: []const u8, info: SnapshotInfo) ![]const PackedCell {
+    const need = @as(usize, info.row_count) * @as(usize, info.cols);
+    const bytes = payload[snapshot_header_size..];
+    if (bytes.len < need * @sizeOf(PackedCell)) return error.PayloadTooShort;
+    const ptr: [*]const PackedCell = @ptrCast(@alignCast(bytes.ptr));
+    return ptr[0..need];
+}
+
+// ── grid_delta ──
+//
+// Wire: DeltaHeader (fixed), then per-dirty-row {row_index:u16, PackedCell*cols}.
+
+pub const DeltaHeader = extern struct {
+    pane_id: u32,
+    generation_lo: u32,
+    generation_hi: u32,
+    cols: u16,
+    cursor_row: u16,
+    cursor_col: u16,
+    dirty_row_count: u16,
+    flags: u8,
+    cursor_shape: u8,
+    _pad: [2]u8 = .{ 0, 0 },
+};
+
+comptime {
+    if (@sizeOf(DeltaHeader) != 24) @compileError("DeltaHeader size changed");
+}
+
+pub const delta_header_size = @sizeOf(DeltaHeader);
+
+pub const DeltaInfo = struct {
+    pane_id: u32,
+    generation: u64,
+    cols: u16,
+    cursor_row: u16,
+    cursor_col: u16,
+    cursor_visible: bool,
+    cursor_shape: u8,
+    dirty_row_count: u16,
+};
+
+/// Per-row entry: row_index:u16, _pad:u16 (keeps PackedCells 4-byte aligned),
+/// then cols * PackedCell.
+const delta_row_prefix: usize = 4;
+
+pub fn encodedDeltaSize(cols: u16, dirty_rows: u16) usize {
+    const per_row: usize = delta_row_prefix + @as(usize, cols) * @sizeOf(PackedCell);
+    return delta_header_size + @as(usize, dirty_rows) * per_row;
+}
+
+pub fn encodeDeltaHeader(buf: []u8, info: DeltaInfo) !usize {
+    if (buf.len < delta_header_size) return error.BufferTooSmall;
+    var flags: u8 = 0;
+    if (info.cursor_visible) flags |= cursor_visible_flag;
+    const hdr: DeltaHeader = .{
+        .pane_id = info.pane_id,
+        .generation_lo = @truncate(info.generation),
+        .generation_hi = @truncate(info.generation >> 32),
+        .cols = info.cols,
+        .cursor_row = info.cursor_row,
+        .cursor_col = info.cursor_col,
+        .dirty_row_count = info.dirty_row_count,
+        .flags = flags,
+        .cursor_shape = info.cursor_shape,
+    };
+    @memcpy(buf[0..delta_header_size], std.mem.asBytes(&hdr));
+    return delta_header_size;
+}
+
+pub fn decodeDeltaHeader(payload: []const u8) !DeltaInfo {
+    if (payload.len < delta_header_size) return error.PayloadTooShort;
+    var hdr: DeltaHeader = undefined;
+    @memcpy(std.mem.asBytes(&hdr), payload[0..delta_header_size]);
+    const gen: u64 = @as(u64, hdr.generation_lo) |
+        (@as(u64, hdr.generation_hi) << 32);
+    return .{
+        .pane_id = hdr.pane_id,
+        .generation = gen,
+        .cols = hdr.cols,
+        .cursor_row = hdr.cursor_row,
+        .cursor_col = hdr.cursor_col,
+        .cursor_visible = hdr.flags & cursor_visible_flag != 0,
+        .cursor_shape = hdr.cursor_shape,
+        .dirty_row_count = hdr.dirty_row_count,
+    };
+}
+
+/// Iterate dirty rows in a delta payload. Each call returns the next
+/// (row_index, cells) pair, or null when exhausted.
+pub const DeltaRowIter = struct {
+    payload: []const u8,
+    info: DeltaInfo,
+    offset: usize,
+    seen: u16,
+
+    pub const Entry = struct { row_index: u16, cells: []const PackedCell };
+
+    pub fn next(self: *DeltaRowIter) !?Entry {
+        if (self.seen >= self.info.dirty_row_count) return null;
+        if (self.offset + delta_row_prefix > self.payload.len) return error.PayloadTooShort;
+        const row_index = std.mem.readInt(u16, self.payload[self.offset..][0..2], .little);
+        self.offset += delta_row_prefix;
+        const cells_bytes = @as(usize, self.info.cols) * @sizeOf(PackedCell);
+        if (self.offset + cells_bytes > self.payload.len) return error.PayloadTooShort;
+        const ptr: [*]const PackedCell = @ptrCast(@alignCast(self.payload[self.offset..].ptr));
+        const cells = ptr[0..self.info.cols];
+        self.offset += cells_bytes;
+        self.seen += 1;
+        return .{ .row_index = row_index, .cells = cells };
+    }
+};
+
+pub fn deltaRowIter(payload: []const u8, info: DeltaInfo) DeltaRowIter {
+    return .{
+        .payload = payload,
+        .info = info,
+        .offset = delta_header_size,
+        .seen = 0,
+    };
+}
+
+// ── Tests ──
+
+test "PackedColor round-trip" {
+    const cases = [_]Color{
+        .default,
+        .{ .ansi = 3 },
+        .{ .palette = 217 },
+        .{ .rgb = .{ .r = 10, .g = 200, .b = 255 } },
+    };
+    for (cases) |c| {
+        const p = packColor(c);
+        const back = unpackColor(p);
+        try std.testing.expectEqual(std.meta.activeTag(c), std.meta.activeTag(back));
+        switch (c) {
+            .default => {},
+            .ansi => |i| try std.testing.expectEqual(i, back.ansi),
+            .palette => |i| try std.testing.expectEqual(i, back.palette),
+            .rgb => |rgb| try std.testing.expectEqual(rgb, back.rgb),
+        }
+    }
+}
+
+test "PackedCell round-trip preserves style and link" {
+    const original: Cell = .{
+        .char = '漢',
+        .combining = .{ 0x0301, 0 },
+        .style = .{
+            .fg = .{ .rgb = .{ .r = 1, .g = 2, .b = 3 } },
+            .bg = .{ .palette = 42 },
+            .bold = true,
+            .italic = true,
+            .underline = true,
+            .strikethrough = true,
+        },
+        .link_id = 7,
+    };
+    const p = packCell(original);
+    const back = unpackCell(p);
+    try std.testing.expectEqual(original.char, back.char);
+    try std.testing.expectEqual(original.combining[0], back.combining[0]);
+    try std.testing.expectEqual(@as(u32, 7), back.link_id);
+    try std.testing.expect(back.style.bold);
+    try std.testing.expect(back.style.italic);
+    try std.testing.expect(back.style.underline);
+    try std.testing.expect(back.style.strikethrough);
+    try std.testing.expect(!back.style.dim);
+    try std.testing.expect(!back.style.reverse);
+    try std.testing.expectEqual(@as(u8, 42), back.style.bg.palette);
+    try std.testing.expectEqual(@as(u8, 1), back.style.fg.rgb.r);
+}
+
+test "snapshot header round-trip" {
+    var buf: [snapshot_header_size]u8 = undefined;
+    const info: SnapshotInfo = .{
+        .pane_id = 42,
+        .generation = 0x0123_4567_89AB_CDEF,
+        .rows = 30,
+        .cols = 80,
+        .cursor_row = 5,
+        .cursor_col = 12,
+        .cursor_visible = true,
+        .cursor_shape = 2,
+        .alt_active = true,
+        .start_row = 0,
+        .row_count = 30,
+        .final_chunk = true,
+    };
+    _ = try encodeSnapshotHeader(&buf, info);
+    const back = try decodeSnapshotHeader(&buf);
+    try std.testing.expectEqual(info.pane_id, back.pane_id);
+    try std.testing.expectEqual(info.generation, back.generation);
+    try std.testing.expectEqual(info.rows, back.rows);
+    try std.testing.expectEqual(info.cols, back.cols);
+    try std.testing.expectEqual(info.cursor_row, back.cursor_row);
+    try std.testing.expectEqual(info.cursor_col, back.cursor_col);
+    try std.testing.expect(back.cursor_visible);
+    try std.testing.expect(back.alt_active);
+    try std.testing.expect(back.final_chunk);
+    try std.testing.expectEqual(@as(u16, 0), back.start_row);
+    try std.testing.expectEqual(@as(u16, 30), back.row_count);
+    try std.testing.expectEqual(info.cursor_shape, back.cursor_shape);
+}
+
+test "snapshot header chunking: non-final" {
+    var buf: [snapshot_header_size]u8 = undefined;
+    const info: SnapshotInfo = .{
+        .pane_id = 1,
+        .generation = 1,
+        .rows = 50,
+        .cols = 80,
+        .cursor_row = 0,
+        .cursor_col = 0,
+        .cursor_visible = false,
+        .cursor_shape = 0,
+        .alt_active = false,
+        .start_row = 20,
+        .row_count = 15,
+        .final_chunk = false,
+    };
+    _ = try encodeSnapshotHeader(&buf, info);
+    const back = try decodeSnapshotHeader(&buf);
+    try std.testing.expectEqual(@as(u16, 20), back.start_row);
+    try std.testing.expectEqual(@as(u16, 15), back.row_count);
+    try std.testing.expect(!back.final_chunk);
+}
+
+test "delta header + row iter round-trip" {
+    const cols: u16 = 4;
+    const dirty: u16 = 2;
+    const sz = encodedDeltaSize(cols, dirty);
+    const alloc = std.testing.allocator;
+    const buf = try alloc.alloc(u8, sz);
+    defer alloc.free(buf);
+
+    const info: DeltaInfo = .{
+        .pane_id = 9,
+        .generation = 7,
+        .cols = cols,
+        .cursor_row = 1,
+        .cursor_col = 2,
+        .cursor_visible = true,
+        .cursor_shape = 0,
+        .dirty_row_count = dirty,
+    };
+    var off = try encodeDeltaHeader(buf, info);
+
+    // Row 0: 'A' 'B' 'C' 'D'
+    std.mem.writeInt(u16, buf[off..][0..2], 0, .little);
+    std.mem.writeInt(u16, buf[off + 2 ..][0..2], 0, .little); // padding
+    off += delta_row_prefix;
+    const row0_cells: [*]PackedCell = @ptrCast(@alignCast(buf[off..].ptr));
+    row0_cells[0] = packCell(.{ .char = 'A' });
+    row0_cells[1] = packCell(.{ .char = 'B' });
+    row0_cells[2] = packCell(.{ .char = 'C' });
+    row0_cells[3] = packCell(.{ .char = 'D' });
+    off += @as(usize, cols) * @sizeOf(PackedCell);
+
+    // Row 5: 'W' 'X' 'Y' 'Z'
+    std.mem.writeInt(u16, buf[off..][0..2], 5, .little);
+    std.mem.writeInt(u16, buf[off + 2 ..][0..2], 0, .little); // padding
+    off += delta_row_prefix;
+    const row5_cells: [*]PackedCell = @ptrCast(@alignCast(buf[off..].ptr));
+    row5_cells[0] = packCell(.{ .char = 'W' });
+    row5_cells[1] = packCell(.{ .char = 'X' });
+    row5_cells[2] = packCell(.{ .char = 'Y' });
+    row5_cells[3] = packCell(.{ .char = 'Z' });
+
+    const hdr_back = try decodeDeltaHeader(buf);
+    try std.testing.expectEqual(info.pane_id, hdr_back.pane_id);
+    try std.testing.expectEqual(info.generation, hdr_back.generation);
+    try std.testing.expectEqual(info.dirty_row_count, hdr_back.dirty_row_count);
+
+    var it = deltaRowIter(buf, hdr_back);
+    const e0 = (try it.next()).?;
+    try std.testing.expectEqual(@as(u16, 0), e0.row_index);
+    try std.testing.expectEqual(@as(u32, 'A'), e0.cells[0].char);
+    try std.testing.expectEqual(@as(u32, 'D'), e0.cells[3].char);
+
+    const e1 = (try it.next()).?;
+    try std.testing.expectEqual(@as(u16, 5), e1.row_index);
+    try std.testing.expectEqual(@as(u32, 'W'), e1.cells[0].char);
+    try std.testing.expectEqual(@as(u32, 'Z'), e1.cells[3].char);
+
+    try std.testing.expect((try it.next()) == null);
+}
+

--- a/src/app/daemon/grid_sync.zig
+++ b/src/app/daemon/grid_sync.zig
@@ -224,14 +224,31 @@ pub fn decodeSnapshotHeader(payload: []const u8) !SnapshotInfo {
     };
 }
 
-/// Returns the PackedCell slice embedded in a snapshot chunk payload
-/// (row_count × cols cells starting at start_row).
-pub fn snapshotCells(payload: []const u8, info: SnapshotInfo) ![]const PackedCell {
+/// Returns the raw cell bytes embedded in a snapshot chunk payload
+/// (row_count × cols × @sizeOf(PackedCell) bytes). Callers read
+/// individual cells with `readPackedCell(bytes, idx)` — the bytes are
+/// not generally 4-byte aligned (msg frame header pushes the payload
+/// offset off alignment), so a direct pointer cast is unsafe.
+pub fn snapshotCellBytes(payload: []const u8, info: SnapshotInfo) ![]const u8 {
     const need = @as(usize, info.row_count) * @as(usize, info.cols);
     const bytes = payload[snapshot_header_size..];
-    if (bytes.len < need * @sizeOf(PackedCell)) return error.PayloadTooShort;
-    const ptr: [*]const PackedCell = @ptrCast(@alignCast(bytes.ptr));
-    return ptr[0..need];
+    const want = need * @sizeOf(PackedCell);
+    if (bytes.len < want) return error.PayloadTooShort;
+    return bytes[0..want];
+}
+
+/// Read PackedCell at logical index `idx` from a flat cell byte slice.
+pub fn readPackedCell(cell_bytes: []const u8, idx: usize) PackedCell {
+    var out: PackedCell = .{};
+    const off = idx * @sizeOf(PackedCell);
+    @memcpy(std.mem.asBytes(&out), cell_bytes[off..][0..@sizeOf(PackedCell)]);
+    return out;
+}
+
+/// Write a PackedCell at logical index `idx` into a flat cell byte slice.
+pub fn writePackedCell(cell_bytes: []u8, idx: usize, cell: PackedCell) void {
+    const off = idx * @sizeOf(PackedCell);
+    @memcpy(cell_bytes[off..][0..@sizeOf(PackedCell)], std.mem.asBytes(&cell));
 }
 
 // ── grid_delta ──
@@ -322,7 +339,7 @@ pub const DeltaRowIter = struct {
     offset: usize,
     seen: u16,
 
-    pub const Entry = struct { row_index: u16, cells: []const PackedCell };
+    pub const Entry = struct { row_index: u16, cell_bytes: []const u8 };
 
     pub fn next(self: *DeltaRowIter) !?Entry {
         if (self.seen >= self.info.dirty_row_count) return null;
@@ -331,11 +348,10 @@ pub const DeltaRowIter = struct {
         self.offset += delta_row_prefix;
         const cells_bytes = @as(usize, self.info.cols) * @sizeOf(PackedCell);
         if (self.offset + cells_bytes > self.payload.len) return error.PayloadTooShort;
-        const ptr: [*]const PackedCell = @ptrCast(@alignCast(self.payload[self.offset..].ptr));
-        const cells = ptr[0..self.info.cols];
+        const slice = self.payload[self.offset .. self.offset + cells_bytes];
         self.offset += cells_bytes;
         self.seen += 1;
-        return .{ .row_index = row_index, .cells = cells };
+        return .{ .row_index = row_index, .cell_bytes = slice };
     }
 };
 
@@ -478,22 +494,20 @@ test "delta header + row iter round-trip" {
     std.mem.writeInt(u16, buf[off..][0..2], 0, .little);
     std.mem.writeInt(u16, buf[off + 2 ..][0..2], 0, .little); // padding
     off += delta_row_prefix;
-    const row0_cells: [*]PackedCell = @ptrCast(@alignCast(buf[off..].ptr));
-    row0_cells[0] = packCell(.{ .char = 'A' });
-    row0_cells[1] = packCell(.{ .char = 'B' });
-    row0_cells[2] = packCell(.{ .char = 'C' });
-    row0_cells[3] = packCell(.{ .char = 'D' });
+    writePackedCell(buf[off..], 0, packCell(.{ .char = 'A' }));
+    writePackedCell(buf[off..], 1, packCell(.{ .char = 'B' }));
+    writePackedCell(buf[off..], 2, packCell(.{ .char = 'C' }));
+    writePackedCell(buf[off..], 3, packCell(.{ .char = 'D' }));
     off += @as(usize, cols) * @sizeOf(PackedCell);
 
     // Row 5: 'W' 'X' 'Y' 'Z'
     std.mem.writeInt(u16, buf[off..][0..2], 5, .little);
     std.mem.writeInt(u16, buf[off + 2 ..][0..2], 0, .little); // padding
     off += delta_row_prefix;
-    const row5_cells: [*]PackedCell = @ptrCast(@alignCast(buf[off..].ptr));
-    row5_cells[0] = packCell(.{ .char = 'W' });
-    row5_cells[1] = packCell(.{ .char = 'X' });
-    row5_cells[2] = packCell(.{ .char = 'Y' });
-    row5_cells[3] = packCell(.{ .char = 'Z' });
+    writePackedCell(buf[off..], 0, packCell(.{ .char = 'W' }));
+    writePackedCell(buf[off..], 1, packCell(.{ .char = 'X' }));
+    writePackedCell(buf[off..], 2, packCell(.{ .char = 'Y' }));
+    writePackedCell(buf[off..], 3, packCell(.{ .char = 'Z' }));
 
     const hdr_back = try decodeDeltaHeader(buf);
     try std.testing.expectEqual(info.pane_id, hdr_back.pane_id);
@@ -503,13 +517,13 @@ test "delta header + row iter round-trip" {
     var it = deltaRowIter(buf, hdr_back);
     const e0 = (try it.next()).?;
     try std.testing.expectEqual(@as(u16, 0), e0.row_index);
-    try std.testing.expectEqual(@as(u32, 'A'), e0.cells[0].char);
-    try std.testing.expectEqual(@as(u32, 'D'), e0.cells[3].char);
+    try std.testing.expectEqual(@as(u32, 'A'), readPackedCell(e0.cell_bytes, 0).char);
+    try std.testing.expectEqual(@as(u32, 'D'), readPackedCell(e0.cell_bytes, 3).char);
 
     const e1 = (try it.next()).?;
     try std.testing.expectEqual(@as(u16, 5), e1.row_index);
-    try std.testing.expectEqual(@as(u32, 'W'), e1.cells[0].char);
-    try std.testing.expectEqual(@as(u32, 'Z'), e1.cells[3].char);
+    try std.testing.expectEqual(@as(u32, 'W'), readPackedCell(e1.cell_bytes, 0).char);
+    try std.testing.expectEqual(@as(u32, 'Z'), readPackedCell(e1.cell_bytes, 3).char);
 
     try std.testing.expect((try it.next()) == null);
 }

--- a/src/app/daemon/grid_sync.zig
+++ b/src/app/daemon/grid_sync.zig
@@ -151,10 +151,18 @@ pub const SnapshotHeader = extern struct {
     cursor_shape: u8,
     start_row: u16,
     row_count: u16, // rows in this message's cell block
+    /// Scrollback rows that have been produced on the daemon since the
+    /// last snapshot shipped to this client. On the first chunk of a new
+    /// snapshot (start_row == 0) the client applies `shiftScreenUp(delta)`
+    /// before writing cells — that promotes the client's previous top
+    /// screen rows into scrollback, mirroring what happened on the daemon.
+    /// Subsequent chunks in the same snapshot carry delta=0.
+    scrollback_delta: u16,
+    _pad: u16 = 0,
 };
 
 comptime {
-    if (@sizeOf(SnapshotHeader) != 28) @compileError("SnapshotHeader size changed");
+    if (@sizeOf(SnapshotHeader) != 32) @compileError("SnapshotHeader size changed");
 }
 
 pub const snapshot_header_size = @sizeOf(SnapshotHeader);
@@ -172,6 +180,7 @@ pub const SnapshotInfo = struct {
     start_row: u16,
     row_count: u16,
     final_chunk: bool,
+    scrollback_delta: u16,
 };
 
 pub fn encodedSnapshotChunkSize(cols: u16, row_count: u16) usize {
@@ -197,6 +206,7 @@ pub fn encodeSnapshotHeader(buf: []u8, info: SnapshotInfo) !usize {
         .cursor_shape = info.cursor_shape,
         .start_row = info.start_row,
         .row_count = info.row_count,
+        .scrollback_delta = info.scrollback_delta,
     };
     @memcpy(buf[0..snapshot_header_size], std.mem.asBytes(&hdr));
     return snapshot_header_size;
@@ -221,6 +231,7 @@ pub fn decodeSnapshotHeader(payload: []const u8) !SnapshotInfo {
         .start_row = hdr.start_row,
         .row_count = hdr.row_count,
         .final_chunk = hdr.flags & final_chunk_flag != 0,
+        .scrollback_delta = hdr.scrollback_delta,
     };
 }
 
@@ -493,6 +504,7 @@ test "snapshot header round-trip" {
         .start_row = 0,
         .row_count = 30,
         .final_chunk = true,
+        .scrollback_delta = 0,
     };
     _ = try encodeSnapshotHeader(&buf, info);
     const back = try decodeSnapshotHeader(&buf);
@@ -525,6 +537,7 @@ test "snapshot header chunking: non-final" {
         .start_row = 20,
         .row_count = 15,
         .final_chunk = false,
+        .scrollback_delta = 3,
     };
     _ = try encodeSnapshotHeader(&buf, info);
     const back = try decodeSnapshotHeader(&buf);

--- a/src/app/daemon/grid_sync.zig
+++ b/src/app/daemon/grid_sync.zig
@@ -325,6 +325,36 @@ pub fn scrollbackCellBytes(payload: []const u8, info: ScrollbackInfo) ![]const u
     return bytes[0..want];
 }
 
+// ── get_scrollback_range (C→D RPC) ──
+//
+// Client reports how many scrollback rows it currently holds and asks
+// for up to N older rows. Daemon responds with up to N rows drawn from
+// the portion of its ring that precedes the client's oldest row —
+// newest-first, so the client can `prependRow` each into place.
+
+pub const GetScrollbackRangeMsg = struct {
+    pane_id: u32,
+    client_has: u32,
+    request_count: u32,
+};
+
+pub fn encodeGetScrollbackRange(buf: []u8, msg: GetScrollbackRangeMsg) ![]u8 {
+    if (buf.len < 12) return error.BufferTooSmall;
+    std.mem.writeInt(u32, buf[0..4], msg.pane_id, .little);
+    std.mem.writeInt(u32, buf[4..8], msg.client_has, .little);
+    std.mem.writeInt(u32, buf[8..12], msg.request_count, .little);
+    return buf[0..12];
+}
+
+pub fn decodeGetScrollbackRange(payload: []const u8) !GetScrollbackRangeMsg {
+    if (payload.len < 12) return error.PayloadTooShort;
+    return .{
+        .pane_id = std.mem.readInt(u32, payload[0..4], .little),
+        .client_has = std.mem.readInt(u32, payload[4..8], .little),
+        .request_count = std.mem.readInt(u32, payload[8..12], .little),
+    };
+}
+
 // ── grid_delta ──
 //
 // Wire: DeltaHeader (fixed), then per-dirty-row {row_index:u16, PackedCell*cols}.

--- a/src/app/daemon/grid_sync.zig
+++ b/src/app/daemon/grid_sync.zig
@@ -251,6 +251,69 @@ pub fn writePackedCell(cell_bytes: []u8, idx: usize, cell: PackedCell) void {
     @memcpy(cell_bytes[off..][0..@sizeOf(PackedCell)], std.mem.asBytes(&cell));
 }
 
+// ── scrollback_chunk ──
+//
+// Wire: ScrollbackHeader (fixed) + row_count × cols × PackedCell.
+// Rows in the chunk are ordered NEWEST-FIRST so the client can prepend
+// each row into its ring in sequence (first-received becomes the newest
+// scrollback line, last-received becomes the oldest).
+
+pub const ScrollbackHeader = extern struct {
+    pane_id: u32,
+    cols: u16,
+    row_count: u16, // rows in this chunk
+    total_remaining: u32, // scrollback rows still pending after this chunk (for progress)
+};
+
+comptime {
+    if (@sizeOf(ScrollbackHeader) != 12) @compileError("ScrollbackHeader size changed");
+}
+
+pub const scrollback_header_size = @sizeOf(ScrollbackHeader);
+
+pub const ScrollbackInfo = struct {
+    pane_id: u32,
+    cols: u16,
+    row_count: u16,
+    total_remaining: u32,
+};
+
+pub fn encodedScrollbackSize(cols: u16, row_count: u16) usize {
+    return scrollback_header_size + @as(usize, row_count) * @as(usize, cols) * @sizeOf(PackedCell);
+}
+
+pub fn encodeScrollbackHeader(buf: []u8, info: ScrollbackInfo) !usize {
+    if (buf.len < scrollback_header_size) return error.BufferTooSmall;
+    const hdr: ScrollbackHeader = .{
+        .pane_id = info.pane_id,
+        .cols = info.cols,
+        .row_count = info.row_count,
+        .total_remaining = info.total_remaining,
+    };
+    @memcpy(buf[0..scrollback_header_size], std.mem.asBytes(&hdr));
+    return scrollback_header_size;
+}
+
+pub fn decodeScrollbackHeader(payload: []const u8) !ScrollbackInfo {
+    if (payload.len < scrollback_header_size) return error.PayloadTooShort;
+    var hdr: ScrollbackHeader = undefined;
+    @memcpy(std.mem.asBytes(&hdr), payload[0..scrollback_header_size]);
+    return .{
+        .pane_id = hdr.pane_id,
+        .cols = hdr.cols,
+        .row_count = hdr.row_count,
+        .total_remaining = hdr.total_remaining,
+    };
+}
+
+pub fn scrollbackCellBytes(payload: []const u8, info: ScrollbackInfo) ![]const u8 {
+    const need = @as(usize, info.row_count) * @as(usize, info.cols);
+    const bytes = payload[scrollback_header_size..];
+    const want = need * @sizeOf(PackedCell);
+    if (bytes.len < want) return error.PayloadTooShort;
+    return bytes[0..want];
+}
+
 // ── grid_delta ──
 //
 // Wire: DeltaHeader (fixed), then per-dirty-row {row_index:u16, PackedCell*cols}.

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -328,6 +328,13 @@ fn handleFocusPanes(
         }
         if (!was_active) {
             if (session.findPane(new_id)) |pane| {
+                // Skip drain/snapshot for deferred panes: the PTY hasn't
+                // been spawned yet (master == -1) and there's no engine
+                // to ship. The first pane_resize will activate the spawn,
+                // and the regular daemon poll loop will ship the snapshot
+                // once shell output starts flowing.
+                const pty_inactive = if (comptime is_windows) false else (pane.pty.master < 0);
+                if (pane.deferred != null or pty_inactive) continue;
                 // Drain any buffered PTY output into the ring buffer.
                 // On Windows, Pty.read blocks (INFINITE wait), so use
                 // peekAvail + read to only drain what's available.
@@ -557,6 +564,7 @@ fn findSession(sessions: *[max_sessions]?DaemonSession, id: u32) ?*DaemonSession
 
 fn setNonBlocking(fd: std.posix.fd_t) void {
     if (comptime is_windows) return; // Windows handles don't use fcntl
+    if (fd < 0) return; // deferred-spawn pane: PTY not yet active
     const F_GETFL: i32 = 3;
     const F_SETFL: i32 = 4;
     const platform = @import("../../platform/platform.zig");

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -5,6 +5,7 @@ const attyx = @import("attyx");
 const protocol = @import("protocol.zig");
 const DaemonSession = @import("session.zig").DaemonSession;
 const DaemonClient = @import("client.zig").DaemonClient;
+const DaemonPane = @import("pane.zig").DaemonPane;
 const RingBuffer = @import("ring_buffer.zig").RingBuffer;
 const layout_codec = @import("../layout_codec.zig");
 const state_persist = @import("state_persist.zig");
@@ -363,6 +364,19 @@ fn handleFocusPanes(
                     // see the OSC 0/2 bytes).
                     if (pane.engine.?.state.title) |t| {
                         cl.sendPaneTitle(pane.id, t);
+                    }
+                    // And the current OSC 7 cwd so actions like "new tab
+                    // from this pane's cwd" work immediately. Prefer the
+                    // cached fg_cwd (populated by the periodic tick — which
+                    // may have fired before the client's focus_panes was
+                    // processed and thus missed this client) over the live
+                    // engine URI, falling back to parsing the engine URI.
+                    if (pane.fg_cwd_len > 0) {
+                        cl.sendPaneFgCwd(pane.id, pane.fg_cwd[0..pane.fg_cwd_len]);
+                    } else if (pane.engine.?.state.working_directory) |uri| {
+                        if (DaemonPane.parseCwdUriPublic(uri)) |path| {
+                            cl.sendPaneFgCwd(pane.id, path);
+                        }
                     }
                 } else {
                     cl.sendPaneReplay(pane);

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -45,6 +45,7 @@ pub fn handleMessage(
         .pane_resize => handlePaneResize(cl, msg.payload, sessions),
         .save_layout => handleSaveLayout(cl, msg.payload, sessions, clients),
         .set_theme_colors => handleSetThemeColors(cl, msg.payload, sessions),
+        .get_scrollback_range => handleGetScrollbackRange(cl, msg.payload, sessions),
 
         // Ignore server→client messages
         else => {},
@@ -408,6 +409,23 @@ fn handleSetThemeColors(
             pane.theme_cursor_set = msg.cursor_set;
         }
     }
+}
+
+/// Grid-sync: client requests older scrollback rows than it currently
+/// holds. Daemon replies with a `scrollback_range` burst (newest-first,
+/// intended for prepend on the client). Silently ignored if the client
+/// isn't grid-sync, the pane doesn't exist, or the daemon has no older
+/// rows to offer.
+fn handleGetScrollbackRange(
+    cl: *DaemonClient,
+    payload: []const u8,
+    sessions: *[max_sessions]?DaemonSession,
+) void {
+    if (!cl.hasGridSync()) return;
+    const msg = protocol.grid_sync.decodeGetScrollbackRange(payload) catch return;
+    const session = getAttachedSession(cl, sessions) orelse return;
+    const pane = session.findPane(msg.pane_id) orelse return;
+    cl.sendScrollbackRangeResponse(pane, msg.client_has, msg.request_count);
 }
 
 fn handlePaneInput(

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -344,6 +344,11 @@ fn handleFocusPanes(
                     // No byte replay, no SIGWINCH nudge — the engine
                     // already holds the TUI's current screen.
                     cl.sendGridSnapshot(pane, true);
+                    // Hydrate scrollback on first focus so scrolling up
+                    // actually shows history. Capped to keep the initial
+                    // burst bounded; Phase 3 adds an on-demand RPC for
+                    // deeper scrollback.
+                    cl.sendScrollbackChunks(pane, 1024);
                     // Also ship the current title so the client's tab bar
                     // picks it up on first focus (engine is passive, won't
                     // see the OSC 0/2 bytes).

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -198,12 +198,13 @@ fn handleRename(
 
 fn handleHello(cl: *DaemonClient, payload: []const u8, upgrade_requested: *bool) void {
     const daemon_version = attyx.version;
-    const client_version = protocol.decodeHello(payload) catch {
-        cl.sendHelloAck(daemon_version);
+    const hello = protocol.decodeHello(payload) catch {
+        cl.sendHelloAck(daemon_version, protocol.CAPABILITIES);
         return;
     };
-    cl.sendHelloAck(daemon_version);
-    if (!std.mem.eql(u8, client_version, daemon_version)) {
+    cl.peer_caps = hello.caps;
+    cl.sendHelloAck(daemon_version, protocol.CAPABILITIES);
+    if (!std.mem.eql(u8, hello.version, daemon_version)) {
         upgrade_requested.* = true;
     }
 }
@@ -291,10 +292,17 @@ fn handleFocusPanes(
     const old_count = cl.active_pane_count;
     const old_panes = cl.active_panes;
 
-    // Update active panes set
+    // Update active panes set. Reset last-sent generations for any
+    // slot that changed pane_id so the next emission ships a full
+    // snapshot (generation 0 = "nothing sent yet").
     cl.active_pane_count = msg.count;
     for (0..msg.count) |i| {
+        const prev_id = if (i < old_count) old_panes[i] else 0;
         cl.active_panes[i] = msg.pane_ids[i];
+        if (cl.active_panes[i] != prev_id) cl.active_pane_last_gen[i] = 0;
+    }
+    for (msg.count..cl.active_pane_last_gen.len) |i| {
+        cl.active_pane_last_gen[i] = 0;
     }
 
     // Drain pending PTY data for newly-active panes before replaying.
@@ -331,13 +339,20 @@ fn handleFocusPanes(
                         if (n == 0) break;
                     }
                 }
-                cl.sendPaneReplay(pane);
-                // Nudge the PTY size so TUI apps get a SIGWINCH and
-                // fully repaint. The client restores the correct size
-                // on replay_end, and the round-trip delay ensures the
-                // app processes this first SIGWINCH before the second.
-                pane.notifyRedraw();
-                cl.sendReplayEnd(new_id);
+                if (cl.hasGridSync() and pane.engine != null) {
+                    // Grid-sync path: ship one authoritative snapshot.
+                    // No byte replay, no SIGWINCH nudge — the engine
+                    // already holds the TUI's current screen.
+                    cl.sendGridSnapshot(pane, true);
+                } else {
+                    cl.sendPaneReplay(pane);
+                    // Nudge the PTY size so TUI apps get a SIGWINCH and
+                    // fully repaint. The client restores the correct size
+                    // on replay_end, and the round-trip delay ensures the
+                    // app processes this first SIGWINCH before the second.
+                    pane.notifyRedraw();
+                    cl.sendReplayEnd(new_id);
+                }
             }
         }
     }

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -344,6 +344,12 @@ fn handleFocusPanes(
                     // No byte replay, no SIGWINCH nudge — the engine
                     // already holds the TUI's current screen.
                     cl.sendGridSnapshot(pane, true);
+                    // Also ship the current title so the client's tab bar
+                    // picks it up on first focus (engine is passive, won't
+                    // see the OSC 0/2 bytes).
+                    if (pane.engine.?.state.title) |t| {
+                        cl.sendPaneTitle(pane.id, t);
+                    }
                 } else {
                     cl.sendPaneReplay(pane);
                     // Nudge the PTY size so TUI apps get a SIGWINCH and

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -299,10 +299,14 @@ fn handleFocusPanes(
     for (0..msg.count) |i| {
         const prev_id = if (i < old_count) old_panes[i] else 0;
         cl.active_panes[i] = msg.pane_ids[i];
-        if (cl.active_panes[i] != prev_id) cl.active_pane_last_gen[i] = 0;
+        if (cl.active_panes[i] != prev_id) {
+            cl.active_pane_last_gen[i] = 0;
+            cl.active_pane_last_sb[i] = 0;
+        }
     }
     for (msg.count..cl.active_pane_last_gen.len) |i| {
         cl.active_pane_last_gen[i] = 0;
+        cl.active_pane_last_sb[i] = 0;
     }
 
     // Drain pending PTY data for newly-active panes before replaying.
@@ -343,11 +347,16 @@ fn handleFocusPanes(
                     // Grid-sync path: ship one authoritative snapshot.
                     // No byte replay, no SIGWINCH nudge — the engine
                     // already holds the TUI's current screen.
+                    //
+                    // Prime the scrollback baseline BEFORE the snapshot so
+                    // the snapshot's scrollback_delta is 0. The explicit
+                    // scrollback_chunks burst below populates the history
+                    // cells; if we let delta fire too we'd double-count.
+                    cl.primeScrollbackBaseline(pane);
                     cl.sendGridSnapshot(pane, true);
                     // Hydrate scrollback on first focus so scrolling up
                     // actually shows history. Capped to keep the initial
-                    // burst bounded; Phase 3 adds an on-demand RPC for
-                    // deeper scrollback.
+                    // burst bounded.
                     cl.sendScrollbackChunks(pane, 1024);
                     // Also ship the current title so the client's tab bar
                     // picks it up on first focus (engine is passive, won't

--- a/src/app/daemon/migration_stress_test.zig
+++ b/src/app/daemon/migration_stress_test.zig
@@ -472,12 +472,12 @@ test "truncated data after first session recovers partial" {
     // Clean up allocated ring buffers
     for (&sessions) |*slot| {
         if (slot.*) |*s| for (&s.panes) |*pslot| {
-            if (pslot.*) |*p| p.replay.deinit();
+            if (pslot.*) |*p| p.freeTransferableState();
         };
     }
     for (&out_sessions) |*slot| {
         if (slot.*) |*s| for (&s.panes) |*pslot| {
-            if (pslot.*) |*p| p.replay.deinit();
+            if (pslot.*) |*p| p.freeTransferableState();
         };
     }
 }
@@ -543,7 +543,7 @@ test "stale recovery preserves session metadata" {
         if (slot.*) |*rs| {
             for (&rs.panes) |*pslot| {
                 if (pslot.*) |*p| {
-                    p.replay.deinit();
+                    p.freeTransferableState();
                     pslot.* = null;
                 }
             }
@@ -563,7 +563,7 @@ test "stale recovery preserves session metadata" {
     try testing.expectEqual(@as(u32, 100), next_pid);
 
     // Clean up original
-    sessions[0].?.panes[0].?.replay.deinit();
+    sessions[0].?.panes[0].?.freeTransferableState();
 }
 
 test "stale recovery with many sessions preserves all metadata" {
@@ -608,7 +608,7 @@ test "stale recovery with many sessions preserves all metadata" {
         if (slot.*) |*rs| {
             for (&rs.panes) |*pslot| {
                 if (pslot.*) |*p| {
-                    p.replay.deinit();
+                    p.freeTransferableState();
                     pslot.* = null;
                 }
             }
@@ -631,7 +631,7 @@ test "stale recovery with many sessions preserves all metadata" {
     // Clean up original ring buffers
     for (&sessions) |*slot| {
         if (slot.*) |*s| for (&s.panes) |*pslot| {
-            if (pslot.*) |*p| p.replay.deinit();
+            if (pslot.*) |*p| p.freeTransferableState();
         };
     }
 }
@@ -692,8 +692,8 @@ test "large ring buffer data survives migration" {
     }
 
     // Cleanup
-    sessions[0].?.panes[0].?.replay.deinit();
-    out[0].?.panes[0].?.replay.deinit();
+    sessions[0].?.panes[0].?.freeTransferableState();
+    out[0].?.panes[0].?.freeTransferableState();
 }
 
 // ── OSC state preservation ──
@@ -742,8 +742,8 @@ test "OSC 7 CWD and OSC 7337 PATH survive migration" {
     try testing.expectEqualStrings(path, rp.osc7337_path[0..rp.osc7337_path_len]);
 
     // Cleanup
-    sessions[0].?.panes[0].?.replay.deinit();
-    out[0].?.panes[0].?.replay.deinit();
+    sessions[0].?.panes[0].?.freeTransferableState();
+    out[0].?.panes[0].?.freeTransferableState();
 }
 
 // ── Concurrent client operations during migration ──
@@ -898,10 +898,10 @@ test "pane cursor_visible and alt_screen survive migration" {
 
     // Cleanup
     for (&sessions) |*slot| if (slot.*) |*ss| for (&ss.panes) |*pslot| {
-        if (pslot.*) |*p| p.replay.deinit();
+        if (pslot.*) |*p| p.freeTransferableState();
     };
     for (&out) |*slot| if (slot.*) |*ss| for (&ss.panes) |*pslot| {
-        if (pslot.*) |*p| p.replay.deinit();
+        if (pslot.*) |*p| p.freeTransferableState();
     };
 }
 
@@ -946,8 +946,8 @@ test "session CWD and shell survive migration" {
     try testing.expectEqualStrings("/bin/zsh", rs.shell[0..rs.shell_len]);
 
     // Cleanup
-    sessions[0].?.panes[0].?.replay.deinit();
-    out[0].?.panes[0].?.replay.deinit();
+    sessions[0].?.panes[0].?.freeTransferableState();
+    out[0].?.panes[0].?.freeTransferableState();
 }
 
 // ── Running process survives migration ──
@@ -1147,6 +1147,6 @@ test "layout data survives migration" {
     try testing.expectEqualStrings(layout, rs.layout_data[0..rs.layout_len]);
 
     // Cleanup
-    sessions[0].?.panes[0].?.replay.deinit();
-    out[0].?.panes[0].?.replay.deinit();
+    sessions[0].?.panes[0].?.freeTransferableState();
+    out[0].?.panes[0].?.freeTransferableState();
 }

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -297,8 +297,12 @@ pub const DaemonPane = struct {
     /// First-resize activation for a deferred pane: fork+exec the PTY at
     /// the supplied dims, allocate the engine to match, and free the
     /// stashed spawn params. POSIX-only — Windows panes never set
-    /// `deferred`.
+    /// `deferred` (spawnDeferred falls through to the immediate-spawn
+    /// host-pipe path on Windows). The early return on Windows lets
+    /// Zig prune the POSIX-only `Pty.spawn(opts)` call below at
+    /// comptime — the Windows `Pty.spawn` takes a different signature.
     fn activateDeferred(self: *DaemonPane, rows: u16, cols: u16) !void {
+        if (comptime is_windows) return error.DeferredSpawnUnsupportedOnWindows;
         const def = self.deferred orelse return;
         const allocator = self.replay.allocator;
 

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -8,6 +8,15 @@ const platform = @import("../../platform/platform.zig");
 const HostConnection = if (is_windows) @import("host_pipe.zig").HostConnection else void;
 const host_pipe = if (is_windows) @import("host_pipe.zig") else struct {};
 const attyx = if (is_windows) @import("attyx") else struct {};
+const attyx_lib = @import("attyx");
+const Engine = attyx_lib.Engine;
+
+/// Scrollback lines the daemon-side engine retains. Per-pane cost is
+/// roughly `daemon_engine_scrollback_lines * cols * @sizeOf(Cell)`.
+/// 2048 × 80 × 32B ≈ 5 MB per pane — enough for the visible screen
+/// plus a buffer; scrollback beyond this is served via the ring buffer
+/// + RPC.
+pub const daemon_engine_scrollback_lines: usize = 2048;
 
 const win32_sleep = if (is_windows) struct {
     extern "kernel32" fn Sleep(dwMilliseconds: std.os.windows.DWORD) callconv(.winapi) void;
@@ -55,6 +64,17 @@ pub const DaemonPane = struct {
     theme_cursor: [3]u8 = .{ 220, 220, 220 },
     theme_cursor_set: bool = false,
 
+    /// Authoritative VT engine (heap-allocated so DaemonPane stays slim
+    /// — `var sessions: [32]?DaemonSession` lives on the stack, and an
+    /// inline Engine here blows the stack). PTY bytes get fed here on
+    /// every read; grid-sync clients pull cells/cursor from engine.state.
+    /// Runs in parallel with the ring buffer (which the byte-stream path
+    /// and hot-upgrade handoff still depend on). Null until initialised.
+    engine: ?*Engine = null,
+    /// Monotonic counter bumped when engine.feed dirties any row.
+    engine_generation: u64 = 0,
+
+
     /// Restore a pane from deserialized state (inherited PTY fd across exec).
     /// POSIX only — Windows hot-upgrade builds panes directly in upgrade_windows.zig.
     pub const fromRestored = if (!is_windows) fromRestoredImpl else @compileError("fromRestored not available on Windows");
@@ -91,7 +111,39 @@ pub const DaemonPane = struct {
         pane.proc_name_len = nlen;
         // Restore ring buffer contents
         if (ring_data.len > 0) pane.replay.write(ring_data);
+        // Hot-upgrade handoff: rebuild engine from the inherited ring.
+        // Ring holds raw VT bytes, so feeding them reconstructs the
+        // pre-upgrade screen state (minus any bytes older than the ring).
+        if (allocEngine(allocator, rows, cols)) |eng| {
+            pane.engine = eng;
+            const slices = pane.replay.readSlices();
+            if (slices.first.len > 0) eng.feed(slices.first);
+            if (slices.second.len > 0) eng.feed(slices.second);
+            pane.engine_generation = 1;
+        }
         return pane;
+    }
+
+    /// Heap-allocate and init an Engine. Returns null on degenerate
+    /// dimensions or OOM — callers silently fall back to the byte-stream
+    /// path. Engine requires at least a 1×1 grid.
+    fn allocEngine(allocator: std.mem.Allocator, rows: u16, cols: u16) ?*Engine {
+        if (rows == 0 or cols == 0) return null;
+        const eng = allocator.create(Engine) catch return null;
+        eng.* = Engine.init(allocator, rows, cols, daemon_engine_scrollback_lines) catch {
+            allocator.destroy(eng);
+            return null;
+        };
+        return eng;
+    }
+
+    fn freeEngine(self: *DaemonPane) void {
+        if (self.engine) |eng| {
+            const alloc = eng.state.ring.allocator;
+            eng.deinit();
+            alloc.destroy(eng);
+            self.engine = null;
+        }
     }
 
     pub fn spawn(
@@ -157,6 +209,7 @@ pub const DaemonPane = struct {
             pane.stdout_allocator = allocator;
         }
 
+        pane.engine = allocEngine(allocator, rows, cols);
         return pane;
     }
 
@@ -192,7 +245,7 @@ pub const DaemonPane = struct {
         }
         conn.host_pid = host_pid;
 
-        return DaemonPane{
+        var pane = DaemonPane{
             .id = id,
             .pty = Pty.initInactive(),
             .host_conn = conn,
@@ -200,6 +253,8 @@ pub const DaemonPane = struct {
             .rows = rows,
             .cols = cols,
         };
+        pane.engine = allocEngine(allocator, rows, cols);
+        return pane;
     }
 
     fn deriveShellType(shell_str: []const u8) []const u8 {
@@ -210,6 +265,16 @@ pub const DaemonPane = struct {
         if (std.mem.indexOf(u8, shell_str, "powershell") != null) return "pwsh";
         if (std.mem.indexOf(u8, shell_str, "cmd") != null) return "cmd";
         return "auto";
+    }
+
+    /// Feed bytes into the daemon-side engine and bump generation if any
+    /// row gets dirtied. Safe to call with no engine (no-op).
+    fn feedEngine(self: *DaemonPane, data: []const u8) void {
+        const eng = self.engine orelse return;
+        eng.feed(data);
+        if (eng.state.dirty.any()) {
+            self.engine_generation +%= 1;
+        }
     }
 
     /// Process data already in the output buffer (from host pipe frames).
@@ -225,6 +290,7 @@ pub const DaemonPane = struct {
             self.trackModes(data);
             self.trackOsc(data);
             self.interceptQueries(data);
+            self.feedEngine(data);
         }
     }
 
@@ -245,6 +311,7 @@ pub const DaemonPane = struct {
             self.trackModes(slice);
             self.trackOsc(slice);
             self.interceptQueries(slice);
+            self.feedEngine(slice);
         }
         return n;
     }
@@ -266,6 +333,7 @@ pub const DaemonPane = struct {
             self.trackModes(data);
             self.trackOsc(data);
             self.interceptQueries(data);
+            self.feedEngine(data);
         }
         return n;
     }
@@ -411,12 +479,16 @@ pub const DaemonPane = struct {
                 if (!hc.sendResize(rows, cols)) return error.ResizeFailed;
                 self.rows = rows;
                 self.cols = cols;
+                if (rows > 0 and cols > 0) if (self.engine) |eng| eng.state.resize(rows, cols) catch {};
+                self.engine_generation +%= 1;
                 return;
             }
         }
         try self.pty.resize(rows, cols);
         self.rows = rows;
         self.cols = cols;
+        if (self.engine) |eng| eng.state.resize(rows, cols) catch {};
+        self.engine_generation +%= 1;
     }
 
     /// Force a full repaint after focus change so TUI apps re-render their
@@ -521,6 +593,15 @@ pub const DaemonPane = struct {
         return &[_]u8{};
     }
 
+    /// Release everything except the PTY/host connection. Used during
+    /// hot-upgrade handoff (old process) where the PTY fd is inherited
+    /// by the new daemon, but the ring and engine allocations belong to
+    /// this process and must be freed before handoff.
+    pub fn freeTransferableState(self: *DaemonPane) void {
+        self.replay.deinit();
+        self.freeEngine();
+    }
+
     pub fn deinit(self: *DaemonPane) void {
         self.deinitHost();
         if (self.captured_stdout) |cs| {
@@ -529,6 +610,7 @@ pub const DaemonPane = struct {
                 alloc.destroy(cs);
             }
         }
+        self.freeEngine();
         self.pty.deinit();
         self.replay.deinit();
         self.* = undefined;

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -22,6 +22,23 @@ const win32_sleep = if (is_windows) struct {
     extern "kernel32" fn Sleep(dwMilliseconds: std.os.windows.DWORD) callconv(.winapi) void;
 } else struct {};
 
+/// Heap-stored params for a pane whose PTY hasn't been spawned yet.
+/// Used so the daemon can defer the actual fork/exec until the client
+/// supplies real window dimensions — preventing the shell's first prompt
+/// from being rendered (and grid-synced) at config defaults (80×24).
+/// Kept off the DaemonPane to avoid bloating the by-value pane struct
+/// (`[32]?DaemonSession × max_panes_per_session` lives on the stack
+/// during hot-upgrade).
+pub const DeferredSpawnParams = struct {
+    cwd_z_buf: [4097]u8 = undefined,
+    cwd_len: u16 = 0,
+    shell_z_buf: [257]u8 = undefined,
+    shell_len: u16 = 0,
+    cmd_z_buf: [4097]u8 = undefined,
+    cmd_len: u16 = 0,
+    capture_stdout: bool = false,
+};
+
 
 /// A daemon-managed pane wrapping a PTY process and replay buffer.
 /// Multiple DaemonPanes live inside a DaemonSession.
@@ -73,6 +90,13 @@ pub const DaemonPane = struct {
     engine: ?*Engine = null,
     /// Monotonic counter bumped when engine.feed dirties any row.
     engine_generation: u64 = 0,
+
+    /// Pending spawn params. When set, the PTY is inactive and the engine
+    /// is null — the actual fork/exec runs on the first `resize()` call,
+    /// using the resize dims so the shell's first prompt renders at the
+    /// real window size. Heap-allocated so the by-value pane stays small.
+    /// Cleared (and freed) once the spawn is activated.
+    deferred: ?*DeferredSpawnParams = null,
 
 
     /// Restore a pane from deserialized state (inherited PTY fd across exec).
@@ -211,6 +235,124 @@ pub const DaemonPane = struct {
 
         pane.engine = allocEngine(allocator, rows, cols);
         return pane;
+    }
+
+    /// Spawn a pane in deferred mode: PTY is inactive, engine is null,
+    /// and the spawn params are stashed in a heap-allocated struct. The
+    /// real fork/exec runs on the first `resize()` call, using the resize
+    /// dims so the shell's first prompt renders at the actual window size
+    /// rather than the config defaults (which would bake 80-col newlines
+    /// into the grid that grid-sync then ships unchanged).
+    ///
+    /// Windows currently keeps the immediate-spawn path (host pipe READY
+    /// frame already gates against output before connect).
+    pub fn spawnDeferred(
+        allocator: std.mem.Allocator,
+        id: u32,
+        rows: u16,
+        cols: u16,
+        replay_capacity: usize,
+        cwd: ?[*:0]const u8,
+        shell: ?[*:0]const u8,
+        cmd: ?[*:0]const u8,
+        capture_stdout: bool,
+    ) !DaemonPane {
+        if (comptime is_windows) {
+            return spawn(allocator, id, rows, cols, replay_capacity, cwd, shell, cmd, capture_stdout);
+        }
+        const def = try allocator.create(DeferredSpawnParams);
+        def.* = .{};
+        if (cwd) |c| {
+            const slice = std.mem.sliceTo(c, 0);
+            const len: u16 = @intCast(@min(slice.len, def.cwd_z_buf.len - 1));
+            @memcpy(def.cwd_z_buf[0..len], slice[0..len]);
+            def.cwd_z_buf[len] = 0;
+            def.cwd_len = len;
+        }
+        if (shell) |s| {
+            const slice = std.mem.sliceTo(s, 0);
+            const len: u16 = @intCast(@min(slice.len, def.shell_z_buf.len - 1));
+            @memcpy(def.shell_z_buf[0..len], slice[0..len]);
+            def.shell_z_buf[len] = 0;
+            def.shell_len = len;
+        }
+        if (cmd) |c| {
+            const slice = std.mem.sliceTo(c, 0);
+            const len: u16 = @intCast(@min(slice.len, def.cmd_z_buf.len - 1));
+            @memcpy(def.cmd_z_buf[0..len], slice[0..len]);
+            def.cmd_z_buf[len] = 0;
+            def.cmd_len = len;
+        }
+        def.capture_stdout = capture_stdout;
+        return DaemonPane{
+            .id = id,
+            .pty = Pty.initInactive(),
+            .replay = try RingBuffer.init(allocator, replay_capacity),
+            .rows = rows,
+            .cols = cols,
+            .deferred = def,
+        };
+    }
+
+    /// First-resize activation for a deferred pane: fork+exec the PTY at
+    /// the supplied dims, allocate the engine to match, and free the
+    /// stashed spawn params. POSIX-only — Windows panes never set
+    /// `deferred`.
+    fn activateDeferred(self: *DaemonPane, rows: u16, cols: u16) !void {
+        const def = self.deferred orelse return;
+        const allocator = self.replay.allocator;
+
+        const cwd: ?[*:0]const u8 = if (def.cwd_len > 0) @ptrCast(&def.cwd_z_buf) else null;
+        const shell: ?[*:0]const u8 = if (def.shell_len > 0) @ptrCast(&def.shell_z_buf) else null;
+        const cmd: ?[*:0]const u8 = if (def.cmd_len > 0) @ptrCast(&def.cmd_z_buf) else null;
+
+        // Same shell-string→argv split as `spawn()`. Local buffers are
+        // fine here: Pty.spawn fork+exec copies argv into the child
+        // before returning, so the slices need only outlive this call.
+        var shell_argv: [4][:0]const u8 = undefined;
+        var shell_argc: usize = 0;
+        var shell_split_buf: [257]u8 = undefined;
+        const argv: ?[]const [:0]const u8 = if (shell) |s| blk: {
+            const shell_str = std.mem.sliceTo(s, 0);
+            if (shell_str.len == 0) break :blk null;
+            @memcpy(shell_split_buf[0..shell_str.len], shell_str);
+            var pos: usize = 0;
+            while (pos < shell_str.len and shell_argc < shell_argv.len) {
+                while (pos < shell_str.len and shell_split_buf[pos] == ' ') pos += 1;
+                if (pos >= shell_str.len) break;
+                const start = pos;
+                while (pos < shell_str.len and shell_split_buf[pos] != ' ') pos += 1;
+                shell_split_buf[pos] = 0;
+                shell_argv[shell_argc] = shell_split_buf[start..pos :0];
+                shell_argc += 1;
+                if (pos < shell_str.len) pos += 1;
+            }
+            if (shell_argc > 0) break :blk shell_argv[0..shell_argc] else break :blk null;
+        } else null;
+
+        self.pty = try Pty.spawn(.{
+            .rows = rows,
+            .cols = cols,
+            .cwd = cwd,
+            .argv = argv,
+            .startup_cmd = cmd,
+            .capture_stdout = def.capture_stdout,
+        });
+
+        if (def.capture_stdout) {
+            const cs = allocator.create(std.ArrayList(u8)) catch null;
+            if (cs) |c| c.* = .empty;
+            self.captured_stdout = cs;
+            self.stdout_allocator = allocator;
+        }
+
+        self.engine = allocEngine(allocator, rows, cols);
+        self.rows = rows;
+        self.cols = cols;
+        self.engine_generation = 1;
+
+        allocator.destroy(def);
+        self.deferred = null;
     }
 
     /// Windows: spawn a host process and connect to it via named pipe.
@@ -472,8 +614,13 @@ pub const DaemonPane = struct {
         }
     }
 
-    /// Resize the PTY.
+    /// Resize the PTY. For deferred panes (POSIX), the first resize call
+    /// is what triggers the actual fork/exec — the shell starts at the
+    /// supplied dims and never sees a config-default 80×24 phase.
     pub fn resize(self: *DaemonPane, rows: u16, cols: u16) !void {
+        if (self.deferred != null) {
+            return self.activateDeferred(rows, cols);
+        }
         if (comptime is_windows) {
             if (self.host_conn) |hc| {
                 if (!hc.sendResize(rows, cols)) return error.ResizeFailed;
@@ -635,6 +782,10 @@ pub const DaemonPane = struct {
     /// by the new daemon, but the ring and engine allocations belong to
     /// this process and must be freed before handoff.
     pub fn freeTransferableState(self: *DaemonPane) void {
+        if (self.deferred) |def| {
+            self.replay.allocator.destroy(def);
+            self.deferred = null;
+        }
         self.replay.deinit();
         self.freeEngine();
     }
@@ -646,6 +797,10 @@ pub const DaemonPane = struct {
                 cs.deinit(alloc);
                 alloc.destroy(cs);
             }
+        }
+        if (self.deferred) |def| {
+            self.replay.allocator.destroy(def);
+            self.deferred = null;
         }
         self.freeEngine();
         self.pty.deinit();

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -549,7 +549,27 @@ pub const DaemonPane = struct {
     }
 
     /// Check if the foreground process CWD changed. Returns the new CWD if changed, null otherwise.
+    /// Prefers the engine's OSC 7 working_directory (also set by xyron's
+    /// OSC 7339 cwd_changed event) — for xyron-wrapped shells, the
+    /// platform's getForegroundCwd returns xyron's own launch dir rather
+    /// than the user's shell cwd. Falls back to platform lookup for plain
+    /// shells (zsh/bash) that don't emit OSC 7.
     pub fn checkFgCwdChanged(self: *DaemonPane) ?[]const u8 {
+        // Prefer engine's OSC-reported cwd.
+        if (self.engine) |eng| {
+            if (eng.state.working_directory) |uri| {
+                if (parseCwdUri(uri)) |path| {
+                    const len: u16 = @intCast(@min(path.len, 512));
+                    if (len == self.fg_cwd_len and std.mem.eql(u8, self.fg_cwd[0..len], path[0..len])) {
+                        return null; // unchanged
+                    }
+                    @memcpy(self.fg_cwd[0..len], path[0..len]);
+                    self.fg_cwd_len = len;
+                    return self.fg_cwd[0..len];
+                }
+            }
+        }
+
         var buf: [std.fs.max_path_bytes]u8 = undefined;
         const cwd = if (comptime is_windows)
             @as(?[]const u8, null)
@@ -564,6 +584,23 @@ pub const DaemonPane = struct {
         @memcpy(self.fg_cwd[0..len], resolved[0..len]);
         self.fg_cwd_len = len;
         return self.fg_cwd[0..len];
+    }
+
+    /// Strip a `file://[host]` prefix to get the path component.
+    /// Returns a slice of `uri` (caller doesn't free).
+    fn parseCwdUri(uri: []const u8) ?[]const u8 {
+        return parseCwdUriPublic(uri);
+    }
+
+    /// Public variant so other daemon modules can reuse this parser.
+    pub fn parseCwdUriPublic(uri: []const u8) ?[]const u8 {
+        const prefix = "file://";
+        if (!std.mem.startsWith(u8, uri, prefix)) return null;
+        const after_scheme = uri[prefix.len..];
+        const slash_idx = std.mem.indexOfScalar(u8, after_scheme, '/') orelse return null;
+        const path = after_scheme[slash_idx..];
+        if (path.len == 0) return null;
+        return path;
     }
 
     const pane_queries = @import("pane_queries.zig");

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -1,8 +1,18 @@
 const std = @import("std");
 
+/// Grid-sync wire format (PackedCell + snapshot/delta headers).
+/// Phase 1: reserved message types only. Phase 2 wires callers.
+pub const grid_sync = @import("grid_sync.zig");
+
+// Force grid_sync tests into the test binary even though no code path
+// references its decls yet (Phase 1 reserves the types only).
+comptime {
+    _ = grid_sync;
+}
+
 /// Session protocol message types.
-/// Client → Daemon: 0x01–0x0D
-/// Daemon → Client: 0x81–0x89
+/// Client → Daemon: 0x01–0x1F
+/// Daemon → Client: 0x81–0x9F
 pub const MessageType = enum(u8) {
     // Client → Daemon (session management)
     create = 0x01,
@@ -22,6 +32,11 @@ pub const MessageType = enum(u8) {
     hello = 0x0F,
     set_theme_colors = 0x10,
 
+    // Client → Daemon (grid-sync, server-side engine). Reserved in Phase 1;
+    // encoders/decoders land with the daemon-side engine in Phase 2.
+    get_scrollback_range = 0x13,
+    search_pane = 0x14,
+
     // Daemon → Client
     created = 0x81,
     session_list = 0x82,
@@ -35,6 +50,13 @@ pub const MessageType = enum(u8) {
     layout_sync = 0x8C,
     hello_ack = 0x8D,
     pane_fg_cwd = 0x8E,
+
+    // Daemon → Client (grid-sync). Reserved in Phase 1; payload format
+    // (PackedCell layout, dirty-row bitmap, etc.) defined in Phase 2.
+    grid_snapshot = 0x91,
+    grid_delta = 0x92,
+    scrollback_range = 0x93,
+    search_result = 0x94,
 };
 
 pub const header_size: usize = 5; // 4-byte payload length + 1-byte message type
@@ -598,23 +620,56 @@ pub fn decodePaneFgCwd(payload: []const u8) !PaneFgCwdMsg {
     return .{ .pane_id = pane_id, .cwd = payload[6 .. 6 + cwd_len] };
 }
 
-// ── Hello / HelloAck (version handshake) ──
+// ── Hello / HelloAck (version handshake + capability negotiation) ──
 
-/// Encode Hello or HelloAck payload: version_len:u8, version:[N]u8
-pub fn encodeHello(buf: []u8, version: []const u8) ![]u8 {
+/// Capability bits advertised in Hello / HelloAck. Missing bits = 0.
+/// Both sides AND their bitfields to determine the negotiated mode.
+pub const Capabilities = struct {
+    /// Daemon owns the VT engine and ships cell grids (grid_snapshot /
+    /// grid_delta) instead of raw PTY bytes. When both peers advertise
+    /// this, the connection runs in grid-sync mode. Otherwise we fall
+    /// back to the legacy byte-stream path (pane_output / replay_end).
+    pub const GRID_SYNC: u32 = 1 << 0;
+};
+
+/// Capabilities advertised by this build. Both client and daemon speak
+/// grid-sync; mixed-version handshakes fall back to byte-stream
+/// automatically (legacy peer sends caps=0, intersection is 0).
+pub const CAPABILITIES: u32 = Capabilities.GRID_SYNC;
+
+pub const HelloMsg = struct {
+    version: []const u8,
+    caps: u32,
+};
+
+/// Encode Hello or HelloAck payload: version_len:u8, version:[N]u8, caps:u32
+///
+/// Older peers sent just `version_len + version`. Decoders that receive
+/// a trailing caps field from a newer peer simply ignored it (the old
+/// decoder only validated a minimum length). New decoders returning
+/// a HelloMsg default caps=0 when the trailing u32 is absent, so both
+/// directions stay wire-compatible.
+pub fn encodeHello(buf: []u8, version: []const u8, caps: u32) ![]u8 {
     const vlen: u8 = @intCast(@min(version.len, 255));
-    const total: usize = 1 + vlen;
+    const total: usize = 1 + vlen + 4;
     if (buf.len < total) return error.BufferTooSmall;
     buf[0] = vlen;
     @memcpy(buf[1 .. 1 + vlen], version[0..vlen]);
+    std.mem.writeInt(u32, buf[1 + vlen ..][0..4], caps, .little);
     return buf[0..total];
 }
 
-pub fn decodeHello(payload: []const u8) ![]const u8 {
+pub fn decodeHello(payload: []const u8) !HelloMsg {
     if (payload.len < 1) return error.PayloadTooShort;
     const vlen = payload[0];
     if (payload.len < 1 + @as(usize, vlen)) return error.PayloadTooShort;
-    return payload[1 .. 1 + vlen];
+    const version = payload[1 .. 1 + vlen];
+    const caps_off = 1 + @as(usize, vlen);
+    const caps: u32 = if (payload.len >= caps_off + 4)
+        std.mem.readInt(u32, payload[caps_off..][0..4], .little)
+    else
+        0;
+    return .{ .version = version, .caps = caps };
 }
 
 // ── Theme colors ──
@@ -798,7 +853,27 @@ test "rename round-trip" {
 
 test "hello round-trip" {
     var buf: [128]u8 = undefined;
-    const payload = try encodeHello(&buf, "0.2.10");
-    const version = try decodeHello(payload);
-    try std.testing.expectEqualStrings("0.2.10", version);
+    const payload = try encodeHello(&buf, "0.2.10", 0);
+    const msg = try decodeHello(payload);
+    try std.testing.expectEqualStrings("0.2.10", msg.version);
+    try std.testing.expectEqual(@as(u32, 0), msg.caps);
+}
+
+test "hello caps round-trip" {
+    var buf: [128]u8 = undefined;
+    const payload = try encodeHello(&buf, "0.3.15", Capabilities.GRID_SYNC);
+    const msg = try decodeHello(payload);
+    try std.testing.expectEqualStrings("0.3.15", msg.version);
+    try std.testing.expectEqual(Capabilities.GRID_SYNC, msg.caps);
+}
+
+test "hello decode accepts legacy payload without caps" {
+    // Legacy peers sent just vlen + version. Decoder should default caps=0.
+    var buf: [128]u8 = undefined;
+    const v = "legacy";
+    buf[0] = v.len;
+    @memcpy(buf[1 .. 1 + v.len], v);
+    const msg = try decodeHello(buf[0 .. 1 + v.len]);
+    try std.testing.expectEqualStrings("legacy", msg.version);
+    try std.testing.expectEqual(@as(u32, 0), msg.caps);
 }

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -666,7 +666,15 @@ pub const Capabilities = struct {
 /// Capabilities advertised by this build. Both client and daemon speak
 /// grid-sync; mixed-version handshakes fall back to byte-stream
 /// automatically (legacy peer sends caps=0, intersection is 0).
-pub const CAPABILITIES: u32 = Capabilities.GRID_SYNC;
+/// Capabilities advertised by this build. Grid-sync receivers live in
+/// the POSIX event loop (`event_loop.zig`); the Windows event loop
+/// (`event_loop_windows.zig`, `win_daemon.zig`) hasn't been ported yet,
+/// so Windows builds advertise caps=0 and stay on byte-stream. Daemon
+/// still speaks grid-sync to non-Windows clients.
+pub const CAPABILITIES: u32 = if (@import("builtin").os.tag == .windows)
+    0
+else
+    Capabilities.GRID_SYNC;
 
 pub const HelloMsg = struct {
     version: []const u8,

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -57,6 +57,10 @@ pub const MessageType = enum(u8) {
     grid_delta = 0x92,
     scrollback_range = 0x93,
     search_result = 0x94,
+    /// Grid-sync: daemon pushes engine.state.title updates (OSC 0/2).
+    /// Client's engine is passive in grid-sync, so titles have to be
+    /// propagated explicitly — otherwise tab titles never refresh.
+    pane_title = 0x95,
 };
 
 pub const header_size: usize = 5; // 4-byte payload length + 1-byte message type
@@ -595,6 +599,29 @@ pub fn decodePaneProcName(payload: []const u8) !PaneProcNameMsg {
     const name_len = payload[4];
     if (payload.len < 5 + @as(usize, name_len)) return error.PayloadTooShort;
     return .{ .pane_id = pane_id, .name = payload[5 .. 5 + name_len] };
+}
+
+// ── PaneTitle (grid-sync OSC 0/2 propagation) ──
+
+/// Encode PaneTitle payload: pane_id:u32, title_len:u16, title:[N]u8
+pub fn encodePaneTitle(buf: []u8, pane_id: u32, title: []const u8) ![]u8 {
+    const title_len: u16 = @intCast(@min(title.len, 1024));
+    const total: usize = 4 + 2 + title_len;
+    if (buf.len < total) return error.BufferTooSmall;
+    std.mem.writeInt(u32, buf[0..4], pane_id, .little);
+    std.mem.writeInt(u16, buf[4..6], title_len, .little);
+    @memcpy(buf[6 .. 6 + title_len], title[0..title_len]);
+    return buf[0..total];
+}
+
+pub const PaneTitleMsg = struct { pane_id: u32, title: []const u8 };
+
+pub fn decodePaneTitle(payload: []const u8) !PaneTitleMsg {
+    if (payload.len < 6) return error.PayloadTooShort;
+    const pane_id = std.mem.readInt(u32, payload[0..4], .little);
+    const title_len = std.mem.readInt(u16, payload[4..6], .little);
+    if (payload.len < 6 + @as(usize, title_len)) return error.PayloadTooShort;
+    return .{ .pane_id = pane_id, .title = payload[6 .. 6 + title_len] };
 }
 
 // ── PaneFgCwd ──

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -61,6 +61,10 @@ pub const MessageType = enum(u8) {
     /// Client's engine is passive in grid-sync, so titles have to be
     /// propagated explicitly — otherwise tab titles never refresh.
     pane_title = 0x95,
+    /// Grid-sync: daemon ships a chunk of scrollback rows (newest-first)
+    /// so the client's engine ring can be hydrated and normal scrollback
+    /// rendering works. Sent on focus; one or more messages per pane.
+    scrollback_chunk = 0x96,
 };
 
 pub const header_size: usize = 5; // 4-byte payload length + 1-byte message type

--- a/src/app/daemon/session.zig
+++ b/src/app/daemon/session.zig
@@ -68,7 +68,11 @@ pub const DaemonSession = struct {
             session.shell_len = @intCast(slen);
         }
 
-        session.panes[0] = try DaemonPane.spawn(allocator, initial_pane_id, rows, cols, replay_capacity, cwd, shell, null, false);
+        // Defer the actual fork/exec until the client supplies real
+        // window dims (via the first pane_resize). The shell's first
+        // prompt then renders at the actual width — no 80-col-wrapped
+        // grid getting shipped via grid-sync.
+        session.panes[0] = try DaemonPane.spawnDeferred(allocator, initial_pane_id, rows, cols, replay_capacity, cwd, shell, null, false);
         session.pane_count = 1;
         return session;
     }
@@ -160,6 +164,11 @@ pub const DaemonSession = struct {
         self.rows = rows;
         self.cols = cols;
         const pane = self.firstPane() orelse return error.NoPanes;
+        // Skip deferred panes: their first activation must happen via an
+        // explicit pane_resize message carrying the real window dims, not
+        // via attach-time defaults (which would re-introduce the cold-
+        // launch wrap by spawning the shell at 80×24).
+        if (pane.deferred != null) return;
         try pane.resize(rows, cols);
     }
 

--- a/src/app/daemon/session_lifecycle_test.zig
+++ b/src/app/daemon/session_lifecycle_test.zig
@@ -198,11 +198,11 @@ test "hello handshake works across daemon restart" {
 
     // Get version from original daemon
     var c1 = try TestClient.connect(env.path());
-    const hp = try protocol.encodeHello(&buf, "0.0.1");
+    const hp = try protocol.encodeHello(&buf, "0.0.1", 0);
     try c1.send(.hello, hp);
     const ack1 = try c1.expect(.hello_ack, 5000);
-    const v1 = try protocol.decodeHello(ack1);
-    try testing.expect(v1.len > 0);
+    const h1 = try protocol.decodeHello(ack1);
+    try testing.expect(h1.version.len > 0);
     c1.deinit();
 
     // Restart daemon
@@ -211,12 +211,12 @@ test "hello handshake works across daemon restart" {
     // New connection, hello still works
     var c2 = try TestClient.connect(env.path());
     defer c2.deinit();
-    const hp2 = try protocol.encodeHello(&buf, "0.0.1");
+    const hp2 = try protocol.encodeHello(&buf, "0.0.1", 0);
     try c2.send(.hello, hp2);
     const ack2 = try c2.expect(.hello_ack, 5000);
-    const v2 = try protocol.decodeHello(ack2);
+    const h2 = try protocol.decodeHello(ack2);
     // Same compiled binary, so version should match
-    try testing.expectEqualStrings(v1, v2);
+    try testing.expectEqualStrings(h1.version, h2.version);
 }
 
 // ── Edge cases ──

--- a/src/app/daemon/session_test.zig
+++ b/src/app/daemon/session_test.zig
@@ -254,6 +254,10 @@ test "pane input reaches PTY and produces output" {
     const v2 = try protocol.decodeAttachedV2(attached);
     const pane_id = v2.pane_ids[0];
 
+    // Pane is deferred-spawn until first pane_resize activates it.
+    const init_rp = try protocol.encodePaneResize(&buf, pane_id, 24, 80);
+    try client.send(.pane_resize, init_rp);
+
     const fp = try protocol.encodeFocusPanes(&buf, &.{pane_id});
     try client.send(.focus_panes, fp);
 
@@ -290,7 +294,10 @@ test "pane resize updates dimensions via stty" {
     defer client.deinit();
 
     var buf: [4200]u8 = undefined;
-    const cp = try protocol.encodeCreate(&buf, "resize-test", 24, 80, "/tmp", "");
+    // Use /bin/sh: smaller startup cost than zsh, no shell-integration
+    // recursion under SIGWINCH-during-init, and `stty size` works the
+    // same. The test only cares that the kernel TIOCSWINSZ propagated.
+    const cp = try protocol.encodeCreate(&buf, "resize-test", 24, 80, "/tmp", "/bin/sh");
     try client.send(.create, cp);
     const created = try client.expect(.created, 5000);
     const sid = try protocol.decodeCreated(created);
@@ -301,12 +308,16 @@ test "pane resize updates dimensions via stty" {
     const v2 = try protocol.decodeAttachedV2(attached);
     const pane_id = v2.pane_ids[0];
 
+    // Pane is deferred-spawn until first pane_resize activates it.
+    const init_rp = try protocol.encodePaneResize(&buf, pane_id, 24, 80);
+    try client.send(.pane_resize, init_rp);
+
     // Focus the pane so we get output
     const fp = try protocol.encodeFocusPanes(&buf, &.{pane_id});
     try client.send(.focus_panes, fp);
 
     // Wait for shell startup, drain initial output
-    posix.nanosleep(0, 200_000_000);
+    posix.nanosleep(0, 400_000_000);
     _ = client.tryParse(.pane_output);
     client.read_len = 0;
 
@@ -360,6 +371,10 @@ test "focus_panes triggers replay_end for new panes" {
     const attached = try client.expect(.attached, 5000);
     const v2 = try protocol.decodeAttachedV2(attached);
     const pane_id = v2.pane_ids[0];
+
+    // Pane is deferred-spawn until first pane_resize activates it.
+    const init_rp = try protocol.encodePaneResize(&buf, pane_id, 24, 80);
+    try client.send(.pane_resize, init_rp);
 
     const fp = try protocol.encodeFocusPanes(&buf, &.{pane_id});
     try client.send(.focus_panes, fp);

--- a/src/app/daemon/session_test.zig
+++ b/src/app/daemon/session_test.zig
@@ -381,14 +381,14 @@ test "hello returns hello_ack with daemon version" {
 
     var buf: [256]u8 = undefined;
     // Send hello with a fake client version
-    const hp = try protocol.encodeHello(&buf, "99.0.0");
+    const hp = try protocol.encodeHello(&buf, "99.0.0", 0);
     try client.send(.hello, hp);
 
     // Daemon should respond with hello_ack containing its own version
     const ack_payload = try client.expect(.hello_ack, 5000);
-    const daemon_version = try protocol.decodeHello(ack_payload);
+    const daemon_hello = try protocol.decodeHello(ack_payload);
     // Version must be non-empty and match the compiled-in version
-    try testing.expect(daemon_version.len > 0);
+    try testing.expect(daemon_hello.version.len > 0);
 }
 
 test "hello with matching version does not trigger upgrade flag" {
@@ -400,17 +400,18 @@ test "hello with matching version does not trigger upgrade flag" {
 
     var buf: [256]u8 = undefined;
     // First, discover the daemon's version via hello
-    const hp = try protocol.encodeHello(&buf, "probe");
+    const hp = try protocol.encodeHello(&buf, "probe", 0);
     try client.send(.hello, hp);
     const ack = try client.expect(.hello_ack, 5000);
-    const version = try protocol.decodeHello(ack);
+    const probe_hello = try protocol.decodeHello(ack);
+    const version = probe_hello.version;
 
     // Now send hello with the matching version
-    const hp2 = try protocol.encodeHello(&buf, version);
+    const hp2 = try protocol.encodeHello(&buf, version, 0);
     try client.send(.hello, hp2);
     const ack2 = try client.expect(.hello_ack, 5000);
-    const v2 = try protocol.decodeHello(ack2);
-    try testing.expectEqualStrings(version, v2);
+    const h2 = try protocol.decodeHello(ack2);
+    try testing.expectEqualStrings(version, h2.version);
 
     // Daemon should still be running (not trying to upgrade/restart)
     // Verify by creating a session successfully

--- a/src/app/daemon/test_harness.zig
+++ b/src/app/daemon/test_harness.zig
@@ -346,7 +346,7 @@ pub const TestEnv = struct {
             if (slot.*) |*s| {
                 for (&s.panes) |*pslot| {
                     if (pslot.*) |*p| {
-                        p.replay.deinit();
+                        p.freeTransferableState();
                         pslot.* = null;
                     }
                 }

--- a/src/app/daemon/test_harness.zig
+++ b/src/app/daemon/test_harness.zig
@@ -47,7 +47,8 @@ pub const TestDaemon = struct {
             if (slot.*) |*s| {
                 for (&s.panes, 0..) |*pslot, pi| {
                     if (pslot.*) |*p| {
-                        if (p.alive) {
+                        // Skip deferred-spawn panes (master == -1).
+                        if (p.alive and p.pty.master >= 0) {
                             fds[nfds] = .{ .fd = p.pty.master, .events = 0x0001, .revents = 0 };
                             pty_fd_map[pty_fd_count] = .{ .session_idx = si, .pane_idx = pi };
                             pty_fd_count += 1;
@@ -294,6 +295,7 @@ pub fn writeAllBlocking(fd: posix.fd_t, data: []const u8) !void {
 }
 
 pub fn setNonBlocking(fd: posix.fd_t) void {
+    if (fd < 0) return; // deferred-spawn pane: PTY not yet active
     const F_GETFL: i32 = 3;
     const F_SETFL: i32 = 4;
     const O_NONBLOCK: i32 = if (@import("builtin").os.tag == .linux) 0o4000 else 0x0004;

--- a/src/app/daemon/upgrade.zig
+++ b/src/app/daemon/upgrade.zig
@@ -214,7 +214,7 @@ fn deserializeSession(r: *SliceReader, ver: u8, allocator: std.mem.Allocator) !D
     errdefer {
         for (&s.panes) |*pslot| {
             if (pslot.*) |*p| {
-                p.replay.deinit();
+                p.freeTransferableState();
                 pslot.* = null;
             }
         }
@@ -600,7 +600,7 @@ pub fn tryRecoverStale(
         if (slot.*) |*s| {
             for (&s.panes) |*pslot| {
                 if (pslot.*) |*p| {
-                    p.replay.deinit();
+                    p.freeTransferableState();
                     pslot.* = null;
                 }
             }
@@ -680,9 +680,9 @@ test "serialize/deserialize round-trip" {
     const slices = rp.replay.readSlices();
     try std.testing.expectEqualStrings("hello world", slices.first);
 
-    // Clean up ring buffers (don't deinit panes — fake fd/pid)
-    sessions[0].?.panes[0].?.replay.deinit();
-    out_sessions[0].?.panes[0].?.replay.deinit();
+    // Clean up ring buffers + engines (don't deinit panes — fake fd/pid)
+    sessions[0].?.panes[0].?.freeTransferableState();
+    out_sessions[0].?.panes[0].?.freeTransferableState();
 }
 
 test "stale recovery strips panes and marks sessions dead" {
@@ -738,7 +738,7 @@ test "stale recovery strips panes and marks sessions dead" {
         if (slot.*) |*rs| {
             for (&rs.panes) |*pslot| {
                 if (pslot.*) |*p| {
-                    p.replay.deinit();
+                    p.freeTransferableState();
                     pslot.* = null;
                 }
             }

--- a/src/app/daemon/upgrade_windows.zig
+++ b/src/app/daemon/upgrade_windows.zig
@@ -219,7 +219,7 @@ fn deserializeSessionInto(r: *SliceReader, allocator: std.mem.Allocator, slot: *
     var s = &(slot.*.?);
     errdefer {
         for (&s.panes) |*pslot| {
-            if (pslot.*) |*p| { p.replay.deinit(); pslot.* = null; }
+            if (pslot.*) |*p| { p.freeTransferableState(); pslot.* = null; }
         }
         slot.* = null;
     }

--- a/src/app/pane.zig
+++ b/src/app/pane.zig
@@ -12,6 +12,7 @@ const attyx = @import("attyx");
 const Engine = attyx.Engine;
 const Pty = @import("pty.zig").Pty;
 const IpcClient = @import("../xyron/ipc.zig").IpcClient;
+pub const ViewerState = @import("viewer_state.zig").ViewerState;
 const logging = @import("../logging/log.zig");
 const c = @cImport({
     @cInclude("bridge.h");
@@ -74,6 +75,10 @@ pub const Pane = struct {
     xyron_ipc: ?*IpcClient = null,
     /// Xyron IPC: whether handshake has been completed for this pane.
     xyron_handshake_done: bool = false,
+    /// Per-viewer UI state (scrollback offset, future: per-client overlays).
+    /// Phase 1: scaffolding. Not yet read by consumers — viewport still lives
+    /// in engine.state.viewport_offset until Phase 2 wires grid-sync.
+    viewer: ViewerState = .{},
 
     pub const daemon_backed_placeholder_id: u32 = 0xFFFF_FFFF;
 

--- a/src/app/pane.zig
+++ b/src/app/pane.zig
@@ -79,6 +79,11 @@ pub const Pane = struct {
     /// Phase 1: scaffolding. Not yet read by consumers — viewport still lives
     /// in engine.state.viewport_offset until Phase 2 wires grid-sync.
     viewer: ViewerState = .{},
+    /// Grid-sync: scrollback count at which we last fired a
+    /// `get_scrollback_range` RPC. Gate to avoid spamming requests each
+    /// poll tick while the user holds PgUp. Reset whenever a
+    /// `scrollback_range` reply lands (growing scrollbackCount).
+    last_scrollback_rpc_sb: u32 = 0,
 
     pub const daemon_backed_placeholder_id: u32 = 0xFFFF_FFFF;
 

--- a/src/app/pane.zig
+++ b/src/app/pane.zig
@@ -30,6 +30,15 @@ else
 /// the shell with prompt redraws that create ghost content.
 const pty_resize_throttle_ns: i128 = 80 * std.time.ns_per_ms;
 
+/// First-resize debounce. On cold start, tiling window managers
+/// (aerospace, yabai, ...) create the window at some default size and
+/// *then* retile. If we fire TIOCSWINSZ on the first resize event
+/// immediately, the shell renders its prompt at the wrong width and then
+/// gets a SIGWINCH mid-render — producing stranded wrap artifacts. By
+/// delaying the first resize until its dimensions have been stable for
+/// this long, the retile-induced resize coalesces with the initial size.
+const pty_initial_resize_debounce_ns: i128 = 150 * std.time.ns_per_ms;
+
 pub const Pane = struct {
     engine: Engine,
     pty: Pty,
@@ -71,6 +80,11 @@ pub const Pane = struct {
     pending_pty_cols: u16 = 0,
     pending_pty_resize: bool = false,
     last_pty_resize_ns: i128 = 0,
+    /// Timestamp when current pending dims were first set (resets each
+    /// time the pending dims change). Used by flushPtyResize to enforce
+    /// the first-resize debounce: the first TIOCSWINSZ isn't sent until
+    /// the dims have been stable for pty_initial_resize_debounce_ns.
+    pending_pty_since_ns: i128 = 0,
     /// Xyron IPC: persistent event connection for this pane (completions, etc.)
     xyron_ipc: ?*IpcClient = null,
     /// Xyron IPC: whether handshake has been completed for this pane.
@@ -247,13 +261,19 @@ pub const Pane = struct {
         if (self.shadow_engine) |*s| {
             s.state.resize(rows, cols) catch {};
         }
-        // Leading-edge throttle: record pending dimensions but don't reset
-        // the timer. flushPtyResize() fires immediately on the first event,
-        // then at most once per throttle interval during continuous resizing.
+        // Record pending dimensions. The *first* TIOCSWINSZ is gated by a
+        // debounce window (see pty_initial_resize_debounce_ns) so that a
+        // WM retile arriving just after window creation coalesces with the
+        // initial size. Subsequent resizes use leading-edge throttle.
         if (rows != old_rows or cols != old_cols) {
+            const now = std.time.nanoTimestamp();
+            const dims_changed = (rows != self.pending_pty_rows) or (cols != self.pending_pty_cols);
             self.pending_pty_rows = rows;
             self.pending_pty_cols = cols;
             self.pending_pty_resize = true;
+            if (dims_changed or self.pending_pty_since_ns == 0) {
+                self.pending_pty_since_ns = now;
+            }
         }
     }
 
@@ -262,7 +282,16 @@ pub const Pane = struct {
     pub fn flushPtyResize(self: *Pane) void {
         if (!self.pending_pty_resize) return;
         const now = std.time.nanoTimestamp();
-        if (now - self.last_pty_resize_ns < pty_resize_throttle_ns) return;
+        if (self.last_pty_resize_ns == 0) {
+            // First fire: require the pending dims to have been stable
+            // for the initial debounce window. A WM retile arriving
+            // within this window updates pending_pty_since_ns (via
+            // resize()) and restarts the wait — so by the time we fire,
+            // the dims reflect the *settled* window size.
+            if (now - self.pending_pty_since_ns < pty_initial_resize_debounce_ns) return;
+        } else if (now - self.last_pty_resize_ns < pty_resize_throttle_ns) {
+            return;
+        }
 
         if (self.daemon_pane_id) |dpid| {
             if (self.session_client) |sc| {

--- a/src/app/pty_posix.zig
+++ b/src/app/pty_posix.zig
@@ -216,12 +216,14 @@ pub const Pty = struct {
     }
 
     pub fn deinit(self: *Pty) void {
-        posix.close(self.master);
+        // master == -1 for inactive (deferred-spawn or daemon-host) panes;
+        // posix.close panics on EBADF in safe builds, so guard.
+        if (self.master != -1) posix.close(self.master);
         if (self.stdout_read_fd != -1) posix.close(self.stdout_read_fd);
         // Use raw C waitpid to handle ECHILD gracefully.
         // std.posix.waitpid treats ECHILD as unreachable, which panics
         // if the child was already reaped (common on some Linux distros).
-        _ = waitpid(self.pid, null, 1); // 1 = WNOHANG
+        if (self.pid != 0) _ = waitpid(self.pid, null, 1); // 1 = WNOHANG
     }
 
     pub fn read(self: *Pty, buf: []u8) !usize {

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -114,6 +114,11 @@ pub const SessionClient = struct {
         client.socket_fd = try conn.connectToSocket();
         conn.setNonBlocking(client.socket_fd);
         client.checkDaemonVersion();
+        // Always exchange hello after the socket is settled (post-upgrade
+        // or same-version): this is how we negotiate capability bits
+        // (grid-sync, etc.). Skipping it leaves the daemon thinking we're
+        // a legacy client and falls back to byte-stream.
+        client.exchangeHello();
         return client;
     }
 
@@ -181,6 +186,40 @@ pub const SessionClient = struct {
                 self.consumeBytes(total);
             }
         }
+    }
+
+    /// Send hello (carrying our capability bits) and parse the hello_ack
+    /// into `self.daemon_caps`. Called after every successful connect so
+    /// both sides agree on grid-sync vs byte-stream. Never blocks longer
+    /// than a short poll — if the daemon is slow, we just leave
+    /// `daemon_caps = 0` and get byte-stream, which is a safe fallback.
+    fn exchangeHello(self: *SessionClient) void {
+        if (self.socket_fd == invalid_fd) return;
+        var payload_buf: [256]u8 = undefined;
+        const payload = protocol.encodeHello(&payload_buf, attyx.version, protocol.CAPABILITIES) catch return;
+        var msg_buf: [protocol.header_size + 256]u8 = undefined;
+        const msg = protocol.encodeMessage(&msg_buf, .hello, payload) catch return;
+        socketWrite(self.socket_fd, msg) catch return;
+
+        if (!pollForData(self.socket_fd, 500)) return;
+
+        const space = self.read_buf[self.read_len..];
+        const n = socketRead(self.socket_fd, space) catch return;
+        if (n <= 0) return;
+        self.read_len += @intCast(n);
+
+        if (self.availableBytes() < protocol.header_size) return;
+        const buf = self.read_buf[self.read_off..self.read_len];
+        const header = protocol.decodeHeader(buf[0..protocol.header_size]) catch return;
+        const total = protocol.header_size + header.payload_len;
+        if (self.availableBytes() < total) return;
+        if (header.msg_type != .hello_ack) return;
+        const ack_payload = buf[protocol.header_size..total];
+        if (protocol.decodeHello(ack_payload)) |hmsg| {
+            self.daemon_caps = hmsg.caps;
+            logging.info("session", "hello negotiated: daemon_caps=0x{x}", .{hmsg.caps});
+        } else |_| {}
+        self.consumeBytes(total);
     }
 
     fn getDaemonVersionPath(buf: *[256]u8) ?[]const u8 {

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -62,6 +62,8 @@ pub const DaemonMessage = union(enum) {
     /// exposed so the handler can decode via grid_sync.decodeSnapshotHeader
     /// + grid_sync.snapshotCells.
     grid_snapshot: []const u8,
+    /// Grid-sync: daemon-pushed OSC 0/2 title for a pane.
+    pane_title: struct { pane_id: u32, title: []const u8 },
 };
 
 pub const SessionClient = struct {
@@ -863,6 +865,16 @@ fn readMessageImpl(self: *SessionClient) ?DaemonMessage {
                 @memcpy(self.output_buf[0..payload.len], payload);
                 self.consumeBytes(total);
                 return .{ .grid_snapshot = self.output_buf[0..payload.len] };
+            },
+            .pane_title => {
+                const msg = protocol.decodePaneTitle(payload) catch {
+                    self.consumeBytes(total);
+                    continue;
+                };
+                const tlen = @min(msg.title.len, self.output_buf.len);
+                @memcpy(self.output_buf[0..tlen], msg.title[0..tlen]);
+                self.consumeBytes(total);
+                return .{ .pane_title = .{ .pane_id = msg.pane_id, .title = self.output_buf[0..tlen] } };
             },
             else => { self.consumeBytes(total); continue; },
         }

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -58,6 +58,10 @@ pub const DaemonMessage = union(enum) {
     session_created: u32,
     err: void,
     hello_ack: []const u8,
+    /// A grid_snapshot chunk — full payload (header + packed cells) is
+    /// exposed so the handler can decode via grid_sync.decodeSnapshotHeader
+    /// + grid_sync.snapshotCells.
+    grid_snapshot: []const u8,
 };
 
 pub const SessionClient = struct {
@@ -98,6 +102,10 @@ pub const SessionClient = struct {
     legacy_daemon: bool = false,
     daemon_version: [64]u8 = undefined,
     daemon_version_len: u8 = 0,
+    /// Capability bits advertised by the daemon in hello_ack. 0 for legacy
+    /// daemons that don't speak the extended hello. Used to decide which
+    /// protocol features (e.g. grid-sync) are safe to use on this connection.
+    daemon_caps: u32 = 0,
 
     // ── Connect ──
 
@@ -152,7 +160,7 @@ pub const SessionClient = struct {
 
     fn sendHello(self: *SessionClient) void {
         var payload_buf: [256]u8 = undefined;
-        const payload = protocol.encodeHello(&payload_buf, attyx.version) catch return;
+        const payload = protocol.encodeHello(&payload_buf, attyx.version, protocol.CAPABILITIES) catch return;
         var msg_buf: [protocol.header_size + 256]u8 = undefined;
         const msg = protocol.encodeMessage(&msg_buf, .hello, payload) catch return;
         socketWrite(self.socket_fd, msg) catch return;
@@ -797,14 +805,25 @@ fn readMessageImpl(self: *SessionClient) ?DaemonMessage {
                 continue;
             },
             .hello_ack => {
-                if (protocol.decodeHello(payload)) |ver| {
-                    const vlen = @min(ver.len, self.output_buf.len);
-                    @memcpy(self.output_buf[0..vlen], ver[0..vlen]);
+                if (protocol.decodeHello(payload)) |hmsg| {
+                    self.daemon_caps = hmsg.caps;
+                    const vlen = @min(hmsg.version.len, self.output_buf.len);
+                    @memcpy(self.output_buf[0..vlen], hmsg.version[0..vlen]);
                     self.consumeBytes(total);
                     return .{ .hello_ack = self.output_buf[0..vlen] };
                 } else |_| {}
                 self.consumeBytes(total);
                 continue;
+            },
+            .grid_snapshot => {
+                if (payload.len > self.output_buf.len) {
+                    logging.warn("grid", "snapshot too large: {d}", .{payload.len});
+                    self.consumeBytes(total);
+                    continue;
+                }
+                @memcpy(self.output_buf[0..payload.len], payload);
+                self.consumeBytes(total);
+                return .{ .grid_snapshot = self.output_buf[0..payload.len] };
             },
             else => { self.consumeBytes(total); continue; },
         }

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -67,6 +67,11 @@ pub const DaemonMessage = union(enum) {
     /// Grid-sync: scrollback chunk. Payload is the full message payload
     /// (ScrollbackHeader + cells), decoded by the consumer.
     scrollback_chunk: []const u8,
+    /// Grid-sync: scrollback range (response to get_scrollback_range RPC).
+    /// Same wire format as scrollback_chunk; semantic difference is that
+    /// the client PREPENDS rows (they're OLDER than what we already have),
+    /// whereas scrollback_chunk APPENDS (newer than existing scrollback).
+    scrollback_range: []const u8,
 };
 
 pub const SessionClient = struct {
@@ -326,6 +331,24 @@ pub const SessionClient = struct {
 
     pub fn sendSaveLayout(self: *SessionClient, layout_data: []const u8) !void {
         try self.sendMessage(.save_layout, layout_data);
+    }
+
+    /// True if the negotiated daemon_caps advertises grid-sync.
+    pub fn hasGridSync(self: *const SessionClient) bool {
+        return self.daemon_caps & protocol.Capabilities.GRID_SYNC != 0;
+    }
+
+    /// Grid-sync: request up to `request_count` scrollback rows OLDER
+    /// than the `client_has` rows currently in our ring. Daemon replies
+    /// with a `scrollback_range` burst.
+    pub fn sendGetScrollbackRange(self: *SessionClient, pane_id: u32, client_has: u32, request_count: u32) !void {
+        var payload_buf: [12]u8 = undefined;
+        const payload = try protocol.grid_sync.encodeGetScrollbackRange(&payload_buf, .{
+            .pane_id = pane_id,
+            .client_has = client_has,
+            .request_count = request_count,
+        });
+        try self.sendMessage(.get_scrollback_range, payload);
     }
 
     // ── Session list ──
@@ -888,6 +911,16 @@ fn readMessageImpl(self: *SessionClient) ?DaemonMessage {
                 @memcpy(self.output_buf[0..payload.len], payload);
                 self.consumeBytes(total);
                 return .{ .scrollback_chunk = self.output_buf[0..payload.len] };
+            },
+            .scrollback_range => {
+                if (payload.len > self.output_buf.len) {
+                    logging.warn("grid", "scrollback_range too large: {d}", .{payload.len});
+                    self.consumeBytes(total);
+                    continue;
+                }
+                @memcpy(self.output_buf[0..payload.len], payload);
+                self.consumeBytes(total);
+                return .{ .scrollback_range = self.output_buf[0..payload.len] };
             },
             else => { self.consumeBytes(total); continue; },
         }

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -64,6 +64,9 @@ pub const DaemonMessage = union(enum) {
     grid_snapshot: []const u8,
     /// Grid-sync: daemon-pushed OSC 0/2 title for a pane.
     pane_title: struct { pane_id: u32, title: []const u8 },
+    /// Grid-sync: scrollback chunk. Payload is the full message payload
+    /// (ScrollbackHeader + cells), decoded by the consumer.
+    scrollback_chunk: []const u8,
 };
 
 pub const SessionClient = struct {
@@ -875,6 +878,16 @@ fn readMessageImpl(self: *SessionClient) ?DaemonMessage {
                 @memcpy(self.output_buf[0..tlen], msg.title[0..tlen]);
                 self.consumeBytes(total);
                 return .{ .pane_title = .{ .pane_id = msg.pane_id, .title = self.output_buf[0..tlen] } };
+            },
+            .scrollback_chunk => {
+                if (payload.len > self.output_buf.len) {
+                    logging.warn("grid", "scrollback too large: {d}", .{payload.len});
+                    self.consumeBytes(total);
+                    continue;
+                }
+                @memcpy(self.output_buf[0..payload.len], payload);
+                self.consumeBytes(total);
+                return .{ .scrollback_chunk = self.output_buf[0..payload.len] };
             },
             else => { self.consumeBytes(total); continue; },
         }

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -190,6 +190,14 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                                 startup_pane.engine.feed(out.data);
                                 _ = startup_pane.engine.state.drainResponse();
                             },
+                            .grid_snapshot => |payload| {
+                                // Grid-sync path: apply the snapshot to the
+                                // startup pane so the cursor check below sees
+                                // the daemon's current state and the initial
+                                // publish (just after this loop) draws the
+                                // shell's prompt.
+                                _ = applyGridSnapshot(ctx, payload);
+                            },
                             else => {},
                         }
                     }
@@ -852,38 +860,11 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                         got_data = true;
                     },
                     .grid_snapshot => |payload| {
-                        const info = grid_sync.decodeSnapshotHeader(payload) catch continue;
-                        const result = findPaneByDaemonId(ctx, info.pane_id) orelse continue;
-                        // Resize engine if daemon's grid differs from ours.
-                        if (result.pane.engine.state.ring.screen_rows != info.rows or
-                            result.pane.engine.state.ring.cols != info.cols)
-                        {
-                            result.pane.engine.state.resize(info.rows, info.cols) catch continue;
-                        }
-                        const cell_bytes = grid_sync.snapshotCellBytes(payload, info) catch continue;
-                        var idx: usize = 0;
-                        const end_row: usize = @as(usize, info.start_row) + info.row_count;
-                        var row: usize = info.start_row;
-                        while (row < end_row) : (row += 1) {
-                            var col: usize = 0;
-                            while (col < info.cols) : (col += 1) {
-                                const packed_cell = grid_sync.readPackedCell(cell_bytes, idx);
-                                result.pane.engine.state.ring.setScreenCell(
-                                    row,
-                                    col,
-                                    grid_sync.unpackCell(packed_cell),
-                                );
-                                idx += 1;
+                        if (applyGridSnapshot(ctx, payload)) |res| {
+                            if (res.final_chunk and res.tab_idx == ctx.tab_mgr.active) {
+                                got_data = true;
+                                actions.g_force_full_redraw = true;
                             }
-                            result.pane.engine.state.dirty.mark(row);
-                        }
-                        result.pane.engine.state.cursor.row = info.cursor_row;
-                        result.pane.engine.state.cursor.col = info.cursor_col;
-                        result.pane.engine.state.cursor_visible = info.cursor_visible;
-                        result.pane.engine.state.cursor_shape = @enumFromInt(info.cursor_shape);
-                        result.pane.engine.state.alt_active = info.alt_active;
-                        if (info.final_chunk and result.tab_idx == ctx.tab_mgr.active) {
-                            got_data = true;
                         }
                     },
                     else => {},
@@ -1591,6 +1572,51 @@ fn drainBufferedDeaths(ctx: *PtyThreadCtx) DrainResult {
         }
     }
     return .ok;
+}
+
+/// Apply a grid_snapshot payload to the matching client-side pane. Returns
+/// info on success so the caller can decide whether to force a redraw.
+/// Shared by the startup drain (xyron path) and the main event loop so
+/// snapshots aren't silently dropped during startup.
+const GridApplyResult = struct { final_chunk: bool, tab_idx: u8, pane_id: u32 };
+fn applyGridSnapshot(ctx: *PtyThreadCtx, payload: []const u8) ?GridApplyResult {
+    const info = grid_sync.decodeSnapshotHeader(payload) catch {
+        logging.warn("grid", "snapshot decode failed", .{});
+        return null;
+    };
+    const result = findPaneByDaemonId(ctx, info.pane_id) orelse {
+        logging.warn("grid", "snapshot for unknown pane {d}", .{info.pane_id});
+        return null;
+    };
+    // Resize engine if daemon's grid differs from ours.
+    if (result.pane.engine.state.ring.screen_rows != info.rows or
+        result.pane.engine.state.ring.cols != info.cols)
+    {
+        result.pane.engine.state.resize(info.rows, info.cols) catch return null;
+    }
+    const cell_bytes = grid_sync.snapshotCellBytes(payload, info) catch return null;
+    var idx: usize = 0;
+    const end_row: usize = @as(usize, info.start_row) + info.row_count;
+    var row: usize = info.start_row;
+    while (row < end_row) : (row += 1) {
+        var col: usize = 0;
+        while (col < info.cols) : (col += 1) {
+            const packed_cell = grid_sync.readPackedCell(cell_bytes, idx);
+            result.pane.engine.state.ring.setScreenCell(
+                row,
+                col,
+                grid_sync.unpackCell(packed_cell),
+            );
+            idx += 1;
+        }
+        result.pane.engine.state.dirty.mark(row);
+    }
+    result.pane.engine.state.cursor.row = info.cursor_row;
+    result.pane.engine.state.cursor.col = info.cursor_col;
+    result.pane.engine.state.cursor_visible = info.cursor_visible;
+    result.pane.engine.state.cursor_shape = @enumFromInt(info.cursor_shape);
+    result.pane.engine.state.alt_active = info.alt_active;
+    return .{ .final_chunk = info.final_chunk, .tab_idx = result.tab_idx, .pane_id = info.pane_id };
 }
 
 fn findPaneByDaemonId(ctx: *PtyThreadCtx, pane_id: u32) ?struct { pane: *@import("../pane.zig").Pane, tab_idx: u8, pool_idx: u8 } {

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -176,17 +176,61 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         }
     }
 
-    // When xyron is enabled in session mode, the daemon may not have output
-    // yet (xyron just started). Wait briefly for initial prompt data.
+    // Cold-launch dims handoff for daemon-backed startup pane.
+    //
+    // The session is created with the daemon pane in DEFERRED-SPAWN
+    // mode (`pane.deferred != null` on the daemon). The shell hasn't
+    // been forked yet — it will spawn at whatever dims we forward via
+    // the first pane_resize. So we wait for the main thread's real
+    // window dims to land in `g_pending_resize`, send pane_resize once,
+    // and the shell's very first prompt renders at the actual width.
+    //
+    // No stale 80×24 snapshot, no SIGWINCH-redraw nudge — there's
+    // nothing to redraw, the shell is starting fresh.
     if (ctx.session_client != null and ctx.xyron_path != null) {
         const startup_pane = ctx.tab_mgr.activePane();
         if (startup_pane.daemon_pane_id != null) {
+            logging.info("startup", "waiting for real window dims (session at {d}x{d})", .{ ctx.grid_cols, ctx.grid_rows });
+            // Wait up to 2s for `g_pending_resize` from the main thread.
+            // On timeout fall through with whatever dims we have so the
+            // deferred pane still activates (worst case: config defaults).
+            var dims_arrived = false;
+            for (0..40) |tick| {
+                var rr: c_int = 0;
+                var rc: c_int = 0;
+                if (c.attyx_check_resize(&rr, &rc) != 0) {
+                    logging.info("startup", "got resize {d}x{d} at tick {d}", .{ rc, rr, tick });
+                    const gaps = actions.computeSplitGaps();
+                    ctx.tab_mgr.updateGaps(gaps.h, gaps.v);
+                    ctx.grid_rows = @intCast(rr);
+                    ctx.grid_cols = @intCast(rc);
+                    c.attyx_set_grid_size(rc, rr);
+                    dims_arrived = true;
+                    break;
+                }
+                posix.nanosleep(0, 50_000_000); // 50ms
+            }
+            if (!dims_arrived) {
+                logging.warn("startup", "timed out waiting for window dims; activating at {d}x{d}", .{ ctx.grid_cols, ctx.grid_rows });
+            }
+            // Resize local panes + ship pane_resize to the daemon. This
+            // is what triggers the deferred spawn on the daemon side.
+            const pty_rows: u16 = @intCast(@max(1, @as(i32, ctx.grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
+            ctx.tab_mgr.resizeAll(pty_rows, ctx.grid_cols);
+            if (ctx.session_client) |sc_resize| {
+                if (startup_pane.daemon_pane_id) |dpid|
+                    sc_resize.sendPaneResize(dpid, pty_rows, ctx.grid_cols) catch {};
+            }
+            startup_pane.pending_pty_resize = false;
+            // Drain daemon messages until the shell draws its first
+            // prompt (cursor advances). Standard sync — no special
+            // post-resize delay needed since the shell is starting from
+            // scratch at the correct dims.
             for (0..40) |_| { // up to 2 seconds
                 if (ctx.session_client) |sc| {
                     _ = sc.recvData();
-                    while (sc.readMessage()) |msg| {
+                    while (sc.readMessage()) |msg|
                         _ = applyDaemonContentMessage(ctx, msg);
-                    }
                 }
                 if (startup_pane.engine.state.cursor.row > 0 or startup_pane.engine.state.cursor.col > 0) break;
                 posix.nanosleep(0, 50_000_000); // 50ms
@@ -203,18 +247,6 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
             c.attyx_mark_all_dirty();
             eng.state.dirty.clear();
             c.attyx_end_cell_update();
-            // Nudge the daemon to re-fire TIOCSWINSZ / SIGWINCH so the
-            // shell redraws its prompt at the current-known dimensions.
-            // Without this, starship/zsh's first-paint prompt can land at
-            // stale dims (size race with window init / xyron child proc)
-            // and wrap awkwardly until user input triggers zle redraw.
-            if (ctx.session_client) |sc2| {
-                if (startup_pane.daemon_pane_id) |dpid| {
-                    const pty_rows: u16 = @intCast(eng.state.ring.screen_rows);
-                    const pty_cols: u16 = @intCast(eng.state.ring.cols);
-                    sc2.sendPaneResize(dpid, pty_rows, pty_cols) catch {};
-                }
-            }
         }
     }
 

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -198,6 +198,9 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                                 // shell's prompt.
                                 _ = applyGridSnapshot(ctx, payload);
                             },
+                            .scrollback_chunk => |payload| {
+                                _ = applyScrollbackChunk(ctx, payload);
+                            },
                             else => {},
                         }
                     }
@@ -872,6 +875,12 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                             result.pane.engine.state.setTitle(pt.title);
                             if (result.tab_idx == ctx.tab_mgr.active) got_data = true;
                         }
+                    },
+                    .scrollback_chunk => |payload| {
+                        const n = applyScrollbackChunk(ctx, payload);
+                        logging.info("grid", "scrollback_chunk applied: {d} rows, ring.sb={d}", .{ n, publish.ctxEngine(ctx).state.ring.scrollbackCount() });
+                        got_data = true;
+                        actions.g_force_full_redraw = true;
                     },
                     else => {},
                 }
@@ -1623,6 +1632,35 @@ fn applyGridSnapshot(ctx: *PtyThreadCtx, payload: []const u8) ?GridApplyResult {
     result.pane.engine.state.cursor_shape = @enumFromInt(info.cursor_shape);
     result.pane.engine.state.alt_active = info.alt_active;
     return .{ .final_chunk = info.final_chunk, .tab_idx = result.tab_idx, .pane_id = info.pane_id };
+}
+
+/// Apply a scrollback_chunk payload to the matching pane, prepending rows
+/// (newest-first wire order) into the engine's ring. Returns the number of
+/// rows actually prepended.
+fn applyScrollbackChunk(ctx: *PtyThreadCtx, payload: []const u8) u16 {
+    const info = grid_sync.decodeScrollbackHeader(payload) catch return 0;
+    const result = findPaneByDaemonId(ctx, info.pane_id) orelse return 0;
+    const ring = &result.pane.engine.state.ring;
+    if (info.cols != ring.cols) return 0;
+    const cell_bytes = grid_sync.scrollbackCellBytes(payload, info) catch return 0;
+    const cols = info.cols;
+    var row_cells: [512]attyx.Cell = undefined;
+    var idx: usize = 0;
+    var r: u16 = 0;
+    var applied: u16 = 0;
+    while (r < info.row_count) : (r += 1) {
+        const limit: usize = @min(cols, row_cells.len);
+        for (0..limit) |c_idx| {
+            row_cells[c_idx] = grid_sync.unpackCell(grid_sync.readPackedCell(cell_bytes, idx));
+            idx += 1;
+        }
+        while (idx % cols != 0) : (idx += 1) {}
+        if (ring.prependRow(row_cells[0..limit], false)) applied += 1;
+    }
+    if (result.tab_idx == ctx.tab_mgr.active) {
+        result.pane.engine.state.dirty.markAll(result.pane.engine.state.ring.screen_rows);
+    }
+    return applied;
 }
 
 fn findPaneByDaemonId(ctx: *PtyThreadCtx, pane_id: u32) ?struct { pane: *@import("../pane.zig").Pane, tab_idx: u8, pool_idx: u8 } {

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -201,6 +201,34 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                             .scrollback_chunk => |payload| {
                                 _ = applyScrollbackChunk(ctx, payload);
                             },
+                            .pane_fg_cwd => |fc| {
+                                // Grid-sync's focus_panes handshake ships
+                                // the pane's cwd via pane_fg_cwd — must be
+                                // handled here too, otherwise it hits the
+                                // `else` branch below and is silently eaten,
+                                // leaving the client with no cwd until a
+                                // later tick re-sends (which only happens
+                                // on an actual cwd change, so effectively
+                                // never for a stable pane).
+                                if (findPaneByDaemonId(ctx, fc.pane_id)) |result| {
+                                    const len: u16 = @intCast(@min(fc.cwd.len, 512));
+                                    @memcpy(result.pane.daemon_fg_cwd[0..len], fc.cwd[0..len]);
+                                    result.pane.daemon_fg_cwd_len = len;
+                                }
+                            },
+                            .pane_title => |pt| {
+                                // Same deal — don't drop title updates.
+                                if (findPaneByDaemonId(ctx, pt.pane_id)) |result| {
+                                    result.pane.engine.state.setTitle(pt.title);
+                                }
+                            },
+                            .pane_proc_name => |pn| {
+                                if (findPaneByDaemonId(ctx, pn.pane_id)) |result| {
+                                    const len: u8 = @intCast(@min(pn.name.len, 64));
+                                    @memcpy(result.pane.daemon_proc_name[0..len], pn.name[0..len]);
+                                    result.pane.daemon_proc_name_len = len;
+                                }
+                            },
                             else => {},
                         }
                     }
@@ -220,6 +248,18 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
             c.attyx_mark_all_dirty();
             eng.state.dirty.clear();
             c.attyx_end_cell_update();
+            // Nudge the daemon to re-fire TIOCSWINSZ / SIGWINCH so the
+            // shell redraws its prompt at the current-known dimensions.
+            // Without this, starship/zsh's first-paint prompt can land at
+            // stale dims (size race with window init / xyron child proc)
+            // and wrap awkwardly until user input triggers zle redraw.
+            if (ctx.session_client) |sc2| {
+                if (startup_pane.daemon_pane_id) |dpid| {
+                    const pty_rows: u16 = @intCast(eng.state.ring.screen_rows);
+                    const pty_cols: u16 = @intCast(eng.state.ring.cols);
+                    sc2.sendPaneResize(dpid, pty_rows, pty_cols) catch {};
+                }
+            }
         }
     }
 

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -185,52 +185,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                 if (ctx.session_client) |sc| {
                     _ = sc.recvData();
                     while (sc.readMessage()) |msg| {
-                        switch (msg) {
-                            .pane_output => |out| {
-                                startup_pane.engine.feed(out.data);
-                                _ = startup_pane.engine.state.drainResponse();
-                            },
-                            .grid_snapshot => |payload| {
-                                // Grid-sync path: apply the snapshot to the
-                                // startup pane so the cursor check below sees
-                                // the daemon's current state and the initial
-                                // publish (just after this loop) draws the
-                                // shell's prompt.
-                                _ = applyGridSnapshot(ctx, payload);
-                            },
-                            .scrollback_chunk => |payload| {
-                                _ = applyScrollbackChunk(ctx, payload);
-                            },
-                            .pane_fg_cwd => |fc| {
-                                // Grid-sync's focus_panes handshake ships
-                                // the pane's cwd via pane_fg_cwd — must be
-                                // handled here too, otherwise it hits the
-                                // `else` branch below and is silently eaten,
-                                // leaving the client with no cwd until a
-                                // later tick re-sends (which only happens
-                                // on an actual cwd change, so effectively
-                                // never for a stable pane).
-                                if (findPaneByDaemonId(ctx, fc.pane_id)) |result| {
-                                    const len: u16 = @intCast(@min(fc.cwd.len, 512));
-                                    @memcpy(result.pane.daemon_fg_cwd[0..len], fc.cwd[0..len]);
-                                    result.pane.daemon_fg_cwd_len = len;
-                                }
-                            },
-                            .pane_title => |pt| {
-                                // Same deal — don't drop title updates.
-                                if (findPaneByDaemonId(ctx, pt.pane_id)) |result| {
-                                    result.pane.engine.state.setTitle(pt.title);
-                                }
-                            },
-                            .pane_proc_name => |pn| {
-                                if (findPaneByDaemonId(ctx, pn.pane_id)) |result| {
-                                    const len: u8 = @intCast(@min(pn.name.len, 64));
-                                    @memcpy(result.pane.daemon_proc_name[0..len], pn.name[0..len]);
-                                    result.pane.daemon_proc_name_len = len;
-                                }
-                            },
-                            else => {},
-                        }
+                        _ = applyDaemonContentMessage(ctx, msg);
                     }
                 }
                 if (startup_pane.engine.state.cursor.row > 0 or startup_pane.engine.state.cursor.col > 0) break;
@@ -725,6 +680,25 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         const synced_vp: i32 = @bitCast(c.g_viewport_offset);
         publish.syncViewportFromC(&publish.ctxEngine(ctx).state);
 
+        // Grid-sync: if the user scrolled past what we've hydrated, ask
+        // the daemon for older rows. Gate on `last_scrollback_rpc_sb` so
+        // we only fire one RPC per distinct scrollback count — a held
+        // PgUp keeps viewport_offset > sb until the response lands and
+        // grows sb, which then unblocks the next request.
+        if (ctx.session_client) |sc_rpc| {
+            if (sc_rpc.hasGridSync()) {
+                const active_pane = ctx.tab_mgr.activePane();
+                if (active_pane.daemon_pane_id) |dpid| {
+                    const sb: u32 = @intCast(publish.ctxEngine(ctx).state.ring.scrollbackCount());
+                    const vp: u32 = @intCast(publish.ctxEngine(ctx).state.viewport_offset);
+                    if (vp > sb and active_pane.last_scrollback_rpc_sb != sb) {
+                        sc_rpc.sendGetScrollbackRange(dpid, sb, 256) catch {};
+                        active_pane.last_scrollback_rpc_sb = sb;
+                    }
+                }
+            }
+        }
+
         // Snapshot scrollback count before feeding data — used to adjust
         // selection coordinates when new content scrolls the viewport.
         const sb_before: i32 = @intCast(publish.ctxEngine(ctx).state.ring.scrollbackCount());
@@ -919,6 +893,12 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                     .scrollback_chunk => |payload| {
                         const n = applyScrollbackChunk(ctx, payload);
                         logging.debug("grid", "scrollback_chunk applied: {d} rows, ring.sb={d}", .{ n, publish.ctxEngine(ctx).state.ring.scrollbackCount() });
+                        got_data = true;
+                        actions.g_force_full_redraw = true;
+                    },
+                    .scrollback_range => |payload| {
+                        const n = applyScrollbackRange(ctx, payload);
+                        logging.debug("grid", "scrollback_range applied: {d} rows, ring.sb={d}", .{ n, publish.ctxEngine(ctx).state.ring.scrollbackCount() });
                         got_data = true;
                         actions.g_force_full_redraw = true;
                     },
@@ -1692,6 +1672,34 @@ fn applyGridSnapshot(ctx: *PtyThreadCtx, payload: []const u8) ?GridApplyResult {
     return .{ .final_chunk = info.final_chunk, .tab_idx = result.tab_idx, .pane_id = info.pane_id };
 }
 
+/// Apply a scrollback_range payload (RPC response) to the matching pane,
+/// PREPENDING rows (newest-first wire order) at the oldest end of
+/// scrollback. Returns the number of rows actually prepended.
+fn applyScrollbackRange(ctx: *PtyThreadCtx, payload: []const u8) u16 {
+    const info = grid_sync.decodeScrollbackHeader(payload) catch return 0;
+    const result = findPaneByDaemonId(ctx, info.pane_id) orelse return 0;
+    const ring = &result.pane.engine.state.ring;
+    if (info.cols != ring.cols) return 0;
+    const cell_bytes = grid_sync.scrollbackCellBytes(payload, info) catch return 0;
+    const cols = info.cols;
+    var row_cells: [512]attyx.Cell = undefined;
+    var idx: usize = 0;
+    var r: u16 = 0;
+    var applied: u16 = 0;
+    while (r < info.row_count) : (r += 1) {
+        const limit: usize = @min(cols, row_cells.len);
+        for (0..limit) |c_idx| {
+            row_cells[c_idx] = grid_sync.unpackCell(grid_sync.readPackedCell(cell_bytes, idx));
+            idx += 1;
+        }
+        while (idx % cols != 0) : (idx += 1) {}
+        if (ring.prependRow(row_cells[0..limit], false)) applied += 1;
+    }
+    // No dirty-mark needed — the SCREEN didn't change, only scrollback
+    // (which affects what viewportRow returns for offsets > sb_old).
+    return applied;
+}
+
 /// Apply a scrollback_chunk payload to the matching pane, APPENDING rows
 /// (oldest-first wire order) at the newest end of scrollback. Returns the
 /// number of rows actually appended.
@@ -1719,6 +1727,78 @@ fn applyScrollbackChunk(ctx: *PtyThreadCtx, payload: []const u8) u16 {
         result.pane.engine.state.dirty.markAll(result.pane.engine.state.ring.screen_rows);
     }
     return applied;
+}
+
+/// Apply a daemon → client "content" message (cells, scrollback, title,
+/// cwd, proc name, byte-stream output) to the appropriate pane. Returns
+/// true if the message was a content message (handled) — false for
+/// loop-control messages (pane_died, replay_end, layout_sync) which
+/// the caller must handle itself.
+///
+/// Shared between the startup drain loop and the main event loop so
+/// metadata messages that arrive during startup don't get dropped.
+fn applyDaemonContentMessage(ctx: *PtyThreadCtx, msg: @import("../session_client.zig").DaemonMessage) bool {
+    switch (msg) {
+        .pane_output => |out| {
+            if (findPaneByDaemonId(ctx, out.pane_id)) |result| {
+                if (result.pane.needs_engine_reinit) {
+                    if (result.pane.shadow_engine == null) {
+                        const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);
+                        const cols: u16 = @intCast(result.pane.engine.state.ring.cols);
+                        const shadow = @import("attyx").Engine.init(
+                            result.pane.allocator,
+                            rows,
+                            cols,
+                            ctx.applied_scrollback_lines,
+                        ) catch return true;
+                        result.pane.shadow_engine = shadow;
+                        result.pane.shadow_engine.?.state.theme_colors = publish.themeToEngineColors(&ctx.active_theme);
+                    }
+                    result.pane.shadow_engine.?.feed(out.data);
+                    _ = result.pane.shadow_engine.?.state.drainResponse();
+                } else {
+                    result.pane.engine.feed(out.data);
+                    _ = result.pane.engine.state.drainResponse();
+                }
+            }
+            return true;
+        },
+        .grid_snapshot => |payload| {
+            _ = applyGridSnapshot(ctx, payload);
+            return true;
+        },
+        .scrollback_chunk => |payload| {
+            _ = applyScrollbackChunk(ctx, payload);
+            return true;
+        },
+        .scrollback_range => |payload| {
+            _ = applyScrollbackRange(ctx, payload);
+            return true;
+        },
+        .pane_fg_cwd => |fc| {
+            if (findPaneByDaemonId(ctx, fc.pane_id)) |result| {
+                const len: u16 = @intCast(@min(fc.cwd.len, 512));
+                @memcpy(result.pane.daemon_fg_cwd[0..len], fc.cwd[0..len]);
+                result.pane.daemon_fg_cwd_len = len;
+            }
+            return true;
+        },
+        .pane_title => |pt| {
+            if (findPaneByDaemonId(ctx, pt.pane_id)) |result| {
+                result.pane.engine.state.setTitle(pt.title);
+            }
+            return true;
+        },
+        .pane_proc_name => |pn| {
+            if (findPaneByDaemonId(ctx, pn.pane_id)) |result| {
+                const len: u8 = @intCast(@min(pn.name.len, 64));
+                @memcpy(result.pane.daemon_proc_name[0..len], pn.name[0..len]);
+                result.pane.daemon_proc_name_len = len;
+            }
+            return true;
+        },
+        else => return false,
+    }
 }
 
 fn findPaneByDaemonId(ctx: *PtyThreadCtx, pane_id: u32) ?struct { pane: *@import("../pane.zig").Pane, tab_idx: u8, pool_idx: u8 } {

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -31,6 +31,7 @@ const selection = @import("selection.zig");
 const toast = attyx.overlay_toast;
 const ipc_queue = @import("../../ipc/queue.zig");
 const ipc_handler = @import("../../ipc/handler.zig");
+const grid_sync = @import("../daemon/grid_sync.zig");
 
 /// Re-export from actions module for external access.
 pub const computeSplitGaps = actions.computeSplitGaps;
@@ -849,6 +850,40 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                     .layout_sync => |sync| {
                         session_actions.handleLayoutSync(ctx, sync.layout);
                         got_data = true;
+                    },
+                    .grid_snapshot => |payload| {
+                        const info = grid_sync.decodeSnapshotHeader(payload) catch continue;
+                        const result = findPaneByDaemonId(ctx, info.pane_id) orelse continue;
+                        // Resize engine if daemon's grid differs from ours.
+                        if (result.pane.engine.state.ring.screen_rows != info.rows or
+                            result.pane.engine.state.ring.cols != info.cols)
+                        {
+                            result.pane.engine.state.resize(info.rows, info.cols) catch continue;
+                        }
+                        const cells = grid_sync.snapshotCells(payload, info) catch continue;
+                        var idx: usize = 0;
+                        const end_row: usize = @as(usize, info.start_row) + info.row_count;
+                        var row: usize = info.start_row;
+                        while (row < end_row) : (row += 1) {
+                            var col: usize = 0;
+                            while (col < info.cols) : (col += 1) {
+                                result.pane.engine.state.ring.setScreenCell(
+                                    row,
+                                    col,
+                                    grid_sync.unpackCell(cells[idx]),
+                                );
+                                idx += 1;
+                            }
+                            result.pane.engine.state.dirty.mark(row);
+                        }
+                        result.pane.engine.state.cursor.row = info.cursor_row;
+                        result.pane.engine.state.cursor.col = info.cursor_col;
+                        result.pane.engine.state.cursor_visible = info.cursor_visible;
+                        result.pane.engine.state.cursor_shape = @enumFromInt(info.cursor_shape);
+                        result.pane.engine.state.alt_active = info.alt_active;
+                        if (info.final_chunk and result.tab_idx == ctx.tab_mgr.active) {
+                            got_data = true;
+                        }
                     },
                     else => {},
                 }

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -867,6 +867,12 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                             }
                         }
                     },
+                    .pane_title => |pt| {
+                        if (findPaneByDaemonId(ctx, pt.pane_id)) |result| {
+                            result.pane.engine.state.setTitle(pt.title);
+                            if (result.tab_idx == ctx.tab_mgr.active) got_data = true;
+                        }
+                    },
                     else => {},
                 }
             }

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -860,17 +860,18 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                         {
                             result.pane.engine.state.resize(info.rows, info.cols) catch continue;
                         }
-                        const cells = grid_sync.snapshotCells(payload, info) catch continue;
+                        const cell_bytes = grid_sync.snapshotCellBytes(payload, info) catch continue;
                         var idx: usize = 0;
                         const end_row: usize = @as(usize, info.start_row) + info.row_count;
                         var row: usize = info.start_row;
                         while (row < end_row) : (row += 1) {
                             var col: usize = 0;
                             while (col < info.cols) : (col += 1) {
+                                const packed_cell = grid_sync.readPackedCell(cell_bytes, idx);
                                 result.pane.engine.state.ring.setScreenCell(
                                     row,
                                     col,
-                                    grid_sync.unpackCell(cells[idx]),
+                                    grid_sync.unpackCell(packed_cell),
                                 );
                                 idx += 1;
                             }

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -878,7 +878,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                     },
                     .scrollback_chunk => |payload| {
                         const n = applyScrollbackChunk(ctx, payload);
-                        logging.info("grid", "scrollback_chunk applied: {d} rows, ring.sb={d}", .{ n, publish.ctxEngine(ctx).state.ring.scrollbackCount() });
+                        logging.debug("grid", "scrollback_chunk applied: {d} rows, ring.sb={d}", .{ n, publish.ctxEngine(ctx).state.ring.scrollbackCount() });
                         got_data = true;
                         actions.g_force_full_redraw = true;
                     },
@@ -1603,12 +1603,30 @@ fn applyGridSnapshot(ctx: *PtyThreadCtx, payload: []const u8) ?GridApplyResult {
         logging.warn("grid", "snapshot for unknown pane {d}", .{info.pane_id});
         return null;
     };
-    // Resize engine if daemon's grid differs from ours.
-    if (result.pane.engine.state.ring.screen_rows != info.rows or
-        result.pane.engine.state.ring.cols != info.cols)
-    {
+    // Resize engine if daemon's grid differs from ours. If cols changed,
+    // any cached scrollback rows have the old width and are no longer
+    // compatible with the new snapshot stream. The reflow pass inside
+    // state.resize will attempt to preserve scrollback, but its output
+    // may mismatch what the daemon has (the daemon did its own resize +
+    // reflow independently). Safest: wipe client scrollback on cols
+    // change so a fresh focus cycle re-hydrates from the daemon.
+    const ring_cols_before: usize = result.pane.engine.state.ring.cols;
+    const cols_changed = ring_cols_before != info.cols;
+    if (result.pane.engine.state.ring.screen_rows != info.rows or cols_changed) {
         result.pane.engine.state.resize(info.rows, info.cols) catch return null;
+        if (cols_changed) {
+            // Drop any scrollback accumulated with the old cols: reset
+            // count to screen_rows (so scrollbackCount() == 0).
+            const ring = &result.pane.engine.state.ring;
+            ring.count = ring.screen_rows;
+        }
     }
+    // Scrollback growth is handled EXPLICITLY via scrollback_chunk
+    // messages the daemon ships right before the snapshot (oldest-first
+    // order, appended to our ring). We no longer rely on shifting the
+    // client's own top-of-screen rows into scrollback — that was unsound
+    // when multiple daemon-side scrolls batched into one snapshot tick.
+    _ = info.scrollback_delta;
     const cell_bytes = grid_sync.snapshotCellBytes(payload, info) catch return null;
     var idx: usize = 0;
     const end_row: usize = @as(usize, info.start_row) + info.row_count;
@@ -1634,9 +1652,9 @@ fn applyGridSnapshot(ctx: *PtyThreadCtx, payload: []const u8) ?GridApplyResult {
     return .{ .final_chunk = info.final_chunk, .tab_idx = result.tab_idx, .pane_id = info.pane_id };
 }
 
-/// Apply a scrollback_chunk payload to the matching pane, prepending rows
-/// (newest-first wire order) into the engine's ring. Returns the number of
-/// rows actually prepended.
+/// Apply a scrollback_chunk payload to the matching pane, APPENDING rows
+/// (oldest-first wire order) at the newest end of scrollback. Returns the
+/// number of rows actually appended.
 fn applyScrollbackChunk(ctx: *PtyThreadCtx, payload: []const u8) u16 {
     const info = grid_sync.decodeScrollbackHeader(payload) catch return 0;
     const result = findPaneByDaemonId(ctx, info.pane_id) orelse return 0;
@@ -1655,7 +1673,7 @@ fn applyScrollbackChunk(ctx: *PtyThreadCtx, payload: []const u8) u16 {
             idx += 1;
         }
         while (idx % cols != 0) : (idx += 1) {}
-        if (ring.prependRow(row_cells[0..limit], false)) applied += 1;
+        if (ring.appendScrollbackRow(row_cells[0..limit], false)) applied += 1;
     }
     if (result.tab_idx == ctx.tab_mgr.active) {
         result.pane.engine.state.dirty.markAll(result.pane.engine.state.ring.screen_rows);

--- a/src/app/ui/publish.zig
+++ b/src/app/ui/publish.zig
@@ -650,10 +650,11 @@ pub fn fillCellsStride(
 ) void {
     const vp = eng.state.viewport_offset;
     const cols = eng.state.ring.cols;
-    const rows = eng.state.ring.screen_rows;
     const wrapped: *volatile [c.ATTYX_MAX_ROWS]u8 = @ptrCast(&c.g_row_wrapped);
     const stride_usize: usize = stride;
     const cols_to_copy = @min(@as(usize, cols), stride_usize);
+    const max_rows = if (stride_usize > 0) cells.len / stride_usize else 0;
+    const rows = @min(eng.state.ring.screen_rows, max_rows);
 
     for (0..rows) |row| {
         const row_cells = eng.state.ring.viewportRow(vp, row);

--- a/src/app/ui/win_daemon.zig
+++ b/src/app/ui/win_daemon.zig
@@ -73,6 +73,15 @@ pub fn drainDaemon(ctx: *WinCtx) bool {
             .pane_created => {},
             .err => {},
             .hello_ack => {},
+            // Grid-sync messages: ignored on Windows until the grid-sync
+            // receivers in event_loop.zig are ported over. The Windows
+            // build advertises caps=0 in its hello, so a spec-conforming
+            // daemon won't send these — but in practice a mixed-version
+            // daemon or rogue server could, and we must not panic on them.
+            .grid_snapshot => {},
+            .scrollback_chunk => {},
+            .scrollback_range => {},
+            .pane_title => {},
         }
     }
     return got_output;

--- a/src/app/viewer_state.zig
+++ b/src/app/viewer_state.zig
@@ -1,0 +1,19 @@
+// Attyx — ViewerState: per-viewer (client-side) UI state for a Pane.
+//
+// In plain mode the engine and viewer both live on the client, so this
+// struct is filled in-process. In session mode (daemon owns the engine)
+// the same fields are still owned by the client — each attached viewer
+// can scroll independently, hold its own search highlights, etc.
+//
+// Phase 1: scaffolding only. viewport_offset is still driven by the
+// engine in TerminalState; consumers will migrate to ViewerState in
+// Phase 2 when the engine moves daemon-side and viewport becomes a
+// purely client-side concept.
+
+const std = @import("std");
+
+pub const ViewerState = struct {
+    /// Scrollback scroll position. 0 = pinned to live screen;
+    /// N = scrolled up N rows into history.
+    viewport_offset: usize = 0,
+};

--- a/src/term/ring.zig
+++ b/src/term/ring.zig
@@ -188,6 +188,28 @@ pub const RingBuffer = struct {
 
     // -- Screen mutation: scroll operations --
 
+    /// Prepend a single row to the beginning of scrollback (abs=0, oldest).
+    /// Used by grid-sync clients to hydrate scrollback from the daemon
+    /// without disturbing the current screen contents. No-op if the ring
+    /// is already at capacity. Returns true on success.
+    pub fn prependRow(self: *RingBuffer, cells: []const Cell, wrapped: bool) bool {
+        if (self.count >= self.capacity) return false;
+        // Move head one slot back (wrap), growing scrollback by 1 without
+        // touching the slots currently used by the screen — screen row r
+        // stays at slot (new_head + scrollbackCount + r) = (old_head + r).
+        self.head = (self.head + self.capacity - 1) % self.capacity;
+        self.count += 1;
+        const slot = self.ringSlot(0);
+        const offset = slot * self.cols;
+        const copy_n = @min(cells.len, self.cols);
+        @memcpy(self.cells[offset .. offset + copy_n], cells[0..copy_n]);
+        if (copy_n < self.cols) {
+            for (self.cells[offset + copy_n .. offset + self.cols]) |*c| c.* = .{};
+        }
+        self.wrapped[slot] = wrapped;
+        return true;
+    }
+
     /// Advance screen: push top screen row into scrollback, clear new bottom row.
     /// Zero-copy when scroll_top=0 (the common case for full-screen scroll).
     /// Returns true if a row was actually pushed into scrollback (for viewport bumping).

--- a/src/term/ring.zig
+++ b/src/term/ring.zig
@@ -188,6 +188,31 @@ pub const RingBuffer = struct {
 
     // -- Screen mutation: scroll operations --
 
+    /// Append a row as the NEWEST scrollback (abs = scrollbackCount-1
+    /// after the call). The ring grows by 1 (or rotates head if full,
+    /// evicting the oldest scrollback row). Used by grid-sync clients
+    /// to mirror rows that scrolled off on the daemon — the daemon ships
+    /// the actual cell contents, so the client doesn't rely on its own
+    /// stale top-of-screen rows matching what got scrolled.
+    pub fn appendScrollbackRow(self: *RingBuffer, cells: []const Cell, wrapped: bool) bool {
+        if (self.count < self.capacity) {
+            self.count += 1;
+        } else {
+            self.head = (self.head + 1) % self.capacity;
+        }
+        const sb = self.scrollbackCount();
+        if (sb == 0) return false;
+        const slot = self.ringSlot(sb - 1);
+        const offset = slot * self.cols;
+        const copy_n = @min(cells.len, self.cols);
+        @memcpy(self.cells[offset .. offset + copy_n], cells[0..copy_n]);
+        if (copy_n < self.cols) {
+            for (self.cells[offset + copy_n .. offset + self.cols]) |*c| c.* = .{};
+        }
+        self.wrapped[slot] = wrapped;
+        return true;
+    }
+
     /// Prepend a single row to the beginning of scrollback (abs=0, oldest).
     /// Used by grid-sync clients to hydrate scrollback from the daemon
     /// without disturbing the current screen contents. No-op if the ring


### PR DESCRIPTION
Moves the VT engine from client to daemon so session switching ships cell grids instead of replaying raw PTY bytes. Switch latency drops from hundreds of milliseconds to a single-digit millisecond range. Also defers the daemon-side shell spawn until the client supplies real window dims, so the first prompt always renders at the actual width — no more cold-launch wrap.

## Why

The daemon was a byte-level multiplexer: on every focus change it replayed the raw PTY ring, and the client re-parsed those bytes through the VT engine to rebuild cell state. For sessions with multiple TUIs (Claude Code, vim, htop) each switch was 60–200ms of per-pane replay parsing.

With the engine on the daemon, a rendered cell grid already exists per pane — switching just ships the grid, nothing to re-parse. This PR makes that the default path while keeping the legacy byte-stream path alive for wire compat.

## How

- **Daemon owns an `Engine` per pane** (heap-allocated so `[32]?DaemonSession` stays stack-safe). PTY bytes feed into both the existing ring buffer and the engine.
- **Wire format** (`grid_sync.zig`): `grid_snapshot` (chunked) + `scrollback_chunk` messages ship `PackedCell` (28 bytes, extern struct, stable layout). Themes are not baked in — the client resolves `Color → RGB` at publish time.
- **Capability negotiation** in `hello`/`hello_ack` (new `caps: u32` trailing field, backward-compatible). Both peers must advertise `CAP_GRID_SYNC` to enter grid-sync mode; otherwise the daemon serves byte-stream. A legacy peer advertises `caps=0` and the intersection is 0.
- **Hot-upgrade preserved**: `fromRestored` replays the inherited ring into a fresh engine so sessions survive the daemon handoff without protocol-format bumps to `upgrade.bin`.
- **Per-client tracking** on the daemon (`active_pane_last_gen` + `active_pane_last_sb` per slot) drives snapshot + scrollback emission. `handleFocusPanes` ships the initial snapshot, a one-shot scrollback burst (up to 1024 rows), title, and cwd in a single handshake — no SIGWINCH nudge, no `replay_end`.
- **Incremental scrollback**: `sendScrollbackRange` emits newly-scrolled rows (oldest-first) before every snapshot when scrollback grew, and the client's `RingBuffer.appendScrollbackRow` extends its ring with the *actual* scrolled-off cells (not the client's own stale top-of-screen rows — that was an earlier design dead end).
- **On-demand scrollback RPC** (`get_scrollback_range` / `scrollback_range`): when the user scrolls past what's hydrated in the client's ring, the client requests older rows and the daemon replies newest-first via `prependRow`. Gated per-pane on the current `scrollbackCount` to avoid RPC spam while PgUp is held.
- **Metadata propagation**: `pane_title` (OSC 0/2), existing `pane_fg_cwd` re-sourced from engine's OSC 7 `working_directory` (xyron's `OSC 7339 cwd_changed` flows through this), and cwd cached so late-arriving clients get it on focus even if the periodic tick fired before their `focus_panes` was processed.
- **Shared message helper** (`applyDaemonContentMessage`): the xyron startup-drain loop and the main event loop now both delegate content-message handling to the same helper, so new message types can't silently fall into an `else => {}` branch in one of the two places.

## Cold-launch correctness: deferred PTY spawn

The new architecture surfaced a pre-existing race. The daemon was forking the shell at config-default dims (typically 80×24) before the client could compute the real window size on the main thread. The shell drew its first prompt at 80 cols, with hard newlines baked into the engine's cell grid, and grid-sync faithfully shipped those wrapped cells to the viewer. The visible wrap then stuck around until the user typed something (zle reset-prompt) — window resize alone didn't fix it because the wrong layout was already in the engine grid, and SIGWINCH-redraws don't wipe content above the cursor.

Fix: panes are now born in deferred-spawn state — `Pty.initInactive()`, no engine, spawn params stashed in a heap-side `DeferredSpawnParams`. The first `pane_resize` triggers the actual fork+exec at the supplied dims, and the engine is allocated to match. Attach-time `session.resize` skips deferred panes (attach dims are still config defaults at that point); the explicit `pane_resize` from the client's startup drain is what activates the spawn at real dims.

The client's startup drain (`event_loop.zig` Phase 1) shrinks accordingly: wait for `g_pending_resize` from the main thread, send one `pane_resize`, drain until the prompt lands. The previous post-resize 400ms drain + row-nudge dance are gone — there's no stale prompt to redraw because there was no shell running yet.

## User-facing behavior

- Session switch: **60–200ms → 5–15ms**.
- Cold launch: prompt renders at the correct window width on the first frame — no more wrap that unsticks on first keystroke.
- Fresh install after update: client hot-upgrades the daemon on version mismatch; on next connect both sides negotiate grid-sync and kick in automatically. No user action needed.
- Mixed-version fallback: stays on byte-stream cleanly — daemons with the old binary still work with new clients and vice versa.

## Seamless daemon migration

The hard constraint: existing daemon sessions must survive the update with no user intervention. The existing hot-upgrade path (`performUpgrade` + `upgrade.bin` + inherited PTY fds) is untouched. New daemon replays each pane's ring buffer into a fresh engine on startup — sessions, scrollback, and foreground processes persist across the version bump. Deferred-spawn state is process-local: only freshly-created sessions on the new daemon enter that state, migrated sessions keep their already-running PTYs.

## Collateral fixes along the way

- **xyron SIGWINCH** (xyron repo): first prompt was wrapping at stale dims until user input, because xyron's SIGWINCH handler only flipped a flag that wasn't observed until the next `readLine` iteration. Added a drain of `winch_pending` at the top of `keys.readKey`'s poll loop so resizes that arrive between render and poll still trigger a repaint. The deferred-spawn change above eliminates the upstream cause for fresh sessions; this fix still matters for resizes during a running TUI.
- **Startup drain loop** in `event_loop.zig` was silently dropping any message type other than `pane_output`/`grid_snapshot`/`scrollback_chunk` into `else => {}`. Now shares the same content-message handler as the main loop.
- **Resize invalidation** of client-side scrollback cache when cols change (otherwise old-width rows corrupt scrollback display).
- **Windows build** stays on byte-stream (advertises `caps=0`) since the grid-sync receivers live in client code that doesn't compile for Windows. Daemon-side message arms are no-op stubs so an exhaustive switch still compiles.

## Test plan

- [x] `zig build test` — all 1068 tests pass.
- [x] Fresh install cold-start — grid-sync active, `daemon_caps=0x1` on hello, prompt at correct width on first frame.
- [x] Session switch with multiple TUIs loaded.
- [x] `ll`-style output on short screens (stresses incremental scrollback).
- [x] Tab titles (OSC 0/2) update live.
- [x] `new tab` inherits focused pane's cwd on first focus (xyron and non-xyron shells).
- [x] Hot-upgrade from old daemon to this version — sessions preserved.
- [ ] Old client binary → new daemon — smoke test on byte-stream fallback.