### PR TITLE
fix: send pane-local mouse coords in splits

### DIFF
--- a/src/app/linux_input.c
+++ b/src/app/linux_input.c
@@ -494,10 +494,18 @@ void mouseToCell1(double mx, double my, int* outCol, int* outRow) {
 }
 
 static void sendSgrMouse(int button, int col, int row, int press) {
-    // Adjust row from screen-space to content-space: subtract the grid top
-    // offset (statusbar / tab bar rows) so TUI apps receive correct coords.
-    row -= g_grid_top_offset;
+    // Convert from screen-grid 1-based coords to focused-pane 1-based coords:
+    //   - subtract g_grid_top_offset for tab bar / statusbar rows
+    //   - subtract g_pane_rect_row/col for the pane's offset within the split
+    // Without this, mouse-aware apps (opencode, vim, …) running in any pane
+    // other than the top-left one receive coords past their visible area
+    // and their own selection / click handling breaks.
+    row -= g_grid_top_offset + g_pane_rect_row;
+    col -= g_pane_rect_col;
     if (row < 1) row = 1;
+    if (col < 1) col = 1;
+    if (g_pane_rect_cols > 0 && col > g_pane_rect_cols) col = g_pane_rect_cols;
+    if (g_pane_rect_rows > 0 && row > g_pane_rect_rows) row = g_pane_rect_rows;
     char buf[32];
     int len = snprintf(buf, sizeof(buf), "\x1b[<%d;%d;%d%c",
                        button, col, row, press ? 'M' : 'm');

--- a/src/app/macos_input.m
+++ b/src/app/macos_input.m
@@ -61,10 +61,18 @@ static int mouseModifiers(NSEventModifierFlags flags) {
 }
 
 static void sendSgrMouse(int button, int col, int row, BOOL press) {
-    // Adjust row from screen-space to content-space: subtract the grid top
-    // offset (statusbar / tab bar rows) so TUI apps receive correct coords.
-    row -= g_grid_top_offset;
+    // Convert from screen-grid 1-based coords to focused-pane 1-based coords:
+    //   - subtract g_grid_top_offset for tab bar / statusbar rows
+    //   - subtract g_pane_rect_row/col for the pane's offset within the split
+    // Without this, mouse-aware apps (opencode, vim, …) running in any pane
+    // other than the top-left one receive coords past their visible area
+    // and their own selection / click handling breaks.
+    row -= g_grid_top_offset + g_pane_rect_row;
+    col -= g_pane_rect_col;
     if (row < 1) row = 1;
+    if (col < 1) col = 1;
+    if (g_pane_rect_cols > 0 && col > g_pane_rect_cols) col = g_pane_rect_cols;
+    if (g_pane_rect_rows > 0 && row > g_pane_rect_rows) row = g_pane_rect_rows;
     char buf[32];
     int len = snprintf(buf, sizeof(buf), "\x1b[<%d;%d;%d%c",
                        button, col, row, press ? 'M' : 'm');

--- a/src/app/windows_mouse.c
+++ b/src/app/windows_mouse.c
@@ -63,10 +63,18 @@ void mouseToCell1(int px, int py, int* outCol, int* outRow) {
 // ---------------------------------------------------------------------------
 
 static void sendSgrMouse(int button, int col, int row, int press) {
-    // Adjust row from screen-space to content-space: subtract the grid top
-    // offset (statusbar / tab bar rows) so TUI apps receive correct coords.
-    row -= g_grid_top_offset;
+    // Convert from screen-grid 1-based coords to focused-pane 1-based coords:
+    //   - subtract g_grid_top_offset for tab bar / statusbar rows
+    //   - subtract g_pane_rect_row/col for the pane's offset within the split
+    // Without this, mouse-aware apps (opencode, vim, …) running in any pane
+    // other than the top-left one receive coords past their visible area
+    // and their own selection / click handling breaks.
+    row -= g_grid_top_offset + g_pane_rect_row;
+    col -= g_pane_rect_col;
     if (row < 1) row = 1;
+    if (col < 1) col = 1;
+    if (g_pane_rect_cols > 0 && col > g_pane_rect_cols) col = g_pane_rect_cols;
+    if (g_pane_rect_rows > 0 && row > g_pane_rect_rows) row = g_pane_rect_rows;
     char buf[32];
     int len = snprintf(buf, sizeof(buf), "\x1b[<%d;%d;%d%c",
                        button, col, row, press ? 'M' : 'm');


### PR DESCRIPTION
Fixes #221 

## Summary
- `sendSgrMouse` was emitting screen-grid coordinates, so mouse-aware TUIs (opencode, vim, …) running in any pane other than the top-left one received coords past their own viewport — their built-in selection and click handling broke.
- Now subtract `g_pane_rect_row/col` alongside the existing `g_grid_top_offset` so the app sees 1-based pane-local coords.
- Applied symmetrically across macOS, Linux, and Windows mouse paths.

## Test plan
- [ ] Split vertically with shell on the left and a mouse-aware TUI (e.g. opencode) on the right; click + drag inside the right pane and confirm the TUI's own selection works.
- [ ] Repeat with a horizontal split (TUI in the bottom pane).
- [ ] Confirm the unsplit case is unchanged (pane rect is 0,0 so no offset applied).
- [ ] Confirm tab bar / statusbar still take a row off the top correctly.