### PR TITLE
feat: vertical sidebar tabs

### DIFF
--- a/src/app/bridge.h
+++ b/src/app/bridge.h
@@ -27,9 +27,19 @@ extern volatile int g_cursor_col;
 // Overlays are NOT shifted — they render at the original offY.
 extern volatile int g_grid_top_offset;
 extern volatile int g_grid_bottom_offset;
+// Number of grid columns reserved on each side for the vertical tab bar.
+// When non-zero, the engine grid is narrower than the window grid and
+// content is shifted right by g_grid_left_offset cells.  Overlays are NOT
+// shifted — they render at the original offX.
+extern volatile int g_grid_left_offset;
+extern volatile int g_grid_right_offset;
 extern volatile int g_statusbar_visible;
 extern volatile int g_statusbar_position; // 0=top, 1=bottom
 extern volatile int g_tab_bar_visible;
+extern volatile int g_tab_side; // 0=top (default), 1=left, 2=right
+// User-resized side bar width in cells. 0 = use built-in default.
+// Written by the input thread during a sidebar drag.
+extern volatile int g_tab_side_width;
 
 // Spawn a new attyx window (new instance via NSWorkspace, or fork for Linux/dev).
 void attyx_spawn_new_window(void);
@@ -350,7 +360,7 @@ extern volatile uint64_t g_image_gen; // bumped when image placements change
 // Overlay system (written by PTY thread inside seqlock, read by renderer)
 // ---------------------------------------------------------------------------
 
-#define ATTYX_OVERLAY_MAX_CELLS  2048
+#define ATTYX_OVERLAY_MAX_CELLS  8192
 #define ATTYX_OVERLAY_MAX_LAYERS 16
 
 typedef struct {
@@ -519,6 +529,14 @@ extern volatile int g_session_switch_id;         // main→PTY: session ID to sw
 void attyx_tab_action(int action);
 void attyx_tab_bar_click(int col, int grid_cols);
 void attyx_statusbar_tab_click(int col, int grid_cols);
+// Vertical tab bar click: row is the grid row clicked within the side bar.
+void attyx_side_tab_click(int row, int grid_rows);
+
+// Sidebar drag-to-resize: input thread reports the user's drag.
+// `width` is the desired sidebar width in cells (engine-clamped on the PTY thread).
+void attyx_sidebar_drag_start(void);
+void attyx_sidebar_drag_update(int width);
+void attyx_sidebar_drag_end(void);
 
 // Split pane management (called from input thread via keybind dispatch)
 void attyx_split_action(int action);

--- a/src/app/linux_input.c
+++ b/src/app/linux_input.c
@@ -452,6 +452,7 @@ static int g_click_count = 0;
 static int g_selecting = 0;
 static int g_left_down = 0;
 static int g_split_dragging = 0;
+static int g_sidebar_dragging = 0;
 
 static inline int clampInt(int val, int lo, int hi) {
     if (val < lo) return lo;
@@ -494,10 +495,13 @@ void mouseToCell1(double mx, double my, int* outCol, int* outRow) {
 }
 
 static void sendSgrMouse(int button, int col, int row, int press) {
-    // Adjust row from screen-space to content-space: subtract the grid top
-    // offset (statusbar / tab bar rows) so TUI apps receive correct coords.
+    // Adjust to content-space: subtract grid top / left offsets (statusbar
+    // / tab bar rows / side tab gutter) so TUI apps receive coords relative
+    // to their visible terminal area.
     row -= g_grid_top_offset;
+    col -= g_grid_left_offset;
     if (row < 1) row = 1;
+    if (col < 1) col = 1;
     char buf[32];
     int len = snprintf(buf, sizeof(buf), "\x1b[<%d;%d;%d%c",
                        button, col, row, press ? 'M' : 'm');
@@ -739,6 +743,29 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
             int col, row;
             mouseToCell(mx, my, &col, &row);
 
+            // Sidebar resize drag — clicking on (or within ±1 cell of)
+            // the vertical border starts a drag.
+            if (g_tab_side != 0) {
+                int border_col = (g_tab_side == 1) ? (g_grid_left_offset - 1) : (g_cols - g_grid_right_offset);
+                if (border_col >= 0 && col >= border_col - 1 && col <= border_col + 1) {
+                    attyx_sidebar_drag_start();
+                    g_sidebar_dragging = 1;
+                    glfwSetCursor(w, glfwCreateStandardCursor(GLFW_HRESIZE_CURSOR));
+                    return;
+                }
+            }
+
+            // Side tab bar click: consume if click lands inside the gutter.
+            if (g_tab_side != 0) {
+                int side_w = (g_tab_side == 1) ? g_grid_left_offset : g_grid_right_offset;
+                int side_col_start = (g_tab_side == 1) ? 0 : (g_cols - side_w);
+                int side_col_end = side_col_start + side_w;
+                if (col >= side_col_start && col < side_col_end) {
+                    attyx_side_tab_click(row, g_rows);
+                    return;
+                }
+            }
+
             // Tab bar click: consume if click is on the tab bar row
             if (row == 0 && g_tab_bar_visible) {
                 attyx_tab_bar_click(col, g_cols);
@@ -757,6 +784,10 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
             // Overlay click: consume if hit
             if (g_overlay_has_actions && attyx_overlay_click(col, row)) return;
 
+            int eng_col = col - g_grid_left_offset;
+            int eng_cols = g_cols - g_grid_left_offset - g_grid_right_offset;
+            if (eng_cols < 1) eng_cols = 1;
+
             // Let pane switching win over app mouse tracking so OpenCode and other
             // mouse-aware apps do not trap clicks meant to focus another split.
             if (g_split_active && g_pane_rect_rows > 0) {
@@ -764,8 +795,8 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
                 int pr = g_pane_rect_row, pc = g_pane_rect_col;
                 int pe = pr + g_pane_rect_rows, pce = pc + g_pane_rect_cols;
                 if (content_row >= 0 &&
-                    (content_row < pr || content_row >= pe || col < pc || col >= pce)) {
-                    attyx_split_click(col, row);
+                    (content_row < pr || content_row >= pe || eng_col < pc || eng_col >= pce)) {
+                    attyx_split_click(eng_col, row);
                     return;
                 }
             }
@@ -780,15 +811,17 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
 
             // Split pane click: focus the clicked pane + start drag resize
             if (g_split_active) {
-                attyx_split_drag_start(col, row);
+                attyx_split_drag_start(eng_col, row);
                 g_split_dragging = 1;
-                attyx_split_click(col, row);
+                attyx_split_click(eng_col, row);
             }
 
             // Adjust row to content space for selection and cell access.
             // Tab bar, statusbar, overlay, and split all use grid-space row above.
             row -= g_grid_top_offset;
             if (row < 0) row = 0;
+            if (eng_col < 0) eng_col = 0;
+            if (eng_col >= eng_cols) eng_col = eng_cols - 1;
 
             // Clamp to focused pane bounds when splits are active
             if (g_split_active && g_pane_rect_rows > 0) {
@@ -796,8 +829,8 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
                 int pe = pr + g_pane_rect_rows, pce = pc + g_pane_rect_cols;
                 if (row < pr) row = pr;
                 if (row >= pe) row = pe - 1;
-                if (col < pc) col = pc;
-                if (col >= pce) col = pce - 1;
+                if (eng_col < pc) eng_col = pc;
+                if (eng_col >= pce) eng_col = pce - 1;
             }
 
             // Ctrl-click link handling runs earlier (before mouse-reporting)
@@ -806,7 +839,7 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
             // Shift-click extends existing selection
             if ((mods & GLFW_MOD_SHIFT) && g_sel_active) {
                 g_sel_end_row = row;
-                g_sel_end_col = col;
+                g_sel_end_col = eng_col;
                 g_selecting = 1;
                 g_left_down = 1;
                 attyx_mark_all_dirty();
@@ -814,27 +847,27 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
             }
 
             double now = glfwGetTime();
-            if (now - g_last_click_time < 0.35 && col == g_last_click_col && row == g_last_click_row)
+            if (now - g_last_click_time < 0.35 && eng_col == g_last_click_col && row == g_last_click_row)
                 g_click_count++;
             else
                 g_click_count = 1;
             g_last_click_time = now;
-            g_last_click_col = col;
+            g_last_click_col = eng_col;
             g_last_click_row = row;
 
             if (g_click_count >= 3) {
                 g_sel_start_row = row; g_sel_start_col = 0;
-                g_sel_end_row = row;   g_sel_end_col = g_cols - 1;
+                g_sel_end_row = row;   g_sel_end_col = eng_cols - 1;
                 g_sel_active = 1;
             } else if (g_click_count == 2) {
                 int wS, wE;
-                findWordBounds(row, col, g_cols, &wS, &wE);
+                findWordBounds(row, eng_col, eng_cols, &wS, &wE);
                 g_sel_start_row = row; g_sel_start_col = wS;
                 g_sel_end_row = row;   g_sel_end_col = wE;
                 g_sel_active = 1;
             } else {
-                g_sel_start_row = row; g_sel_start_col = col;
-                g_sel_end_row = row;   g_sel_end_col = col;
+                g_sel_start_row = row; g_sel_start_col = eng_col;
+                g_sel_end_row = row;   g_sel_end_col = eng_col;
                 g_sel_active = 0;
             }
             g_selecting = 1;
@@ -842,6 +875,12 @@ static void mouseButtonCallback(GLFWwindow* w, int button, int action, int mods)
             attyx_mark_all_dirty();
         } else {
             g_left_down = 0;
+            if (g_sidebar_dragging) {
+                attyx_sidebar_drag_end();
+                g_sidebar_dragging = 0;
+                glfwSetCursor(w, glfwCreateStandardCursor(GLFW_IBEAM_CURSOR));
+                return;
+            }
             if (g_split_dragging) {
                 if (g_split_drag_active) attyx_split_drag_end();
                 g_split_dragging = 0;
@@ -942,11 +981,36 @@ static void cursorPosCallback(GLFWwindow* w, double mx, double my) {
         }
         return;
     }
+    if (g_sidebar_dragging) {
+        int col, row;
+        mouseToCell(mx, my, &col, &row);
+        int new_w = (g_tab_side == 1) ? (col + 1) : (g_cols - col);
+        attyx_sidebar_drag_update(new_w);
+        return;
+    }
     if (g_split_dragging && g_split_drag_active) {
         int col, row;
         mouseToCell(mx, my, &col, &row);
         attyx_split_drag_update(col, row);
         return;
+    }
+
+    // Sidebar separator hover: show resize cursor over (and ±1 cell from)
+    // the vertical line.
+    if (g_tab_side != 0) {
+        static int wasOnSidebar = 0;
+        int hcol, hrow;
+        mouseToCell(mx, my, &hcol, &hrow);
+        int border_col = (g_tab_side == 1) ? (g_grid_left_offset - 1) : (g_cols - g_grid_right_offset);
+        if (border_col >= 0 && hcol >= border_col - 1 && hcol <= border_col + 1) {
+            glfwSetCursor(w, glfwCreateStandardCursor(GLFW_HRESIZE_CURSOR));
+            wasOnSidebar = 1;
+            return;
+        }
+        if (wasOnSidebar) {
+            wasOnSidebar = 0;
+            glfwSetCursor(w, glfwCreateStandardCursor(GLFW_IBEAM_CURSOR));
+        }
     }
 
     // Split separator hover: check before mouse tracking so the resize
@@ -1020,6 +1084,11 @@ static void cursorPosCallback(GLFWwindow* w, double mx, double my) {
         mouseToCell(mx, my, &col, &row);
         row -= g_grid_top_offset;
         if (row < 0) row = 0;
+        int eng_col = col - g_grid_left_offset;
+        int eng_cols = g_cols - g_grid_left_offset - g_grid_right_offset;
+        if (eng_cols < 1) eng_cols = 1;
+        if (eng_col < 0) eng_col = 0;
+        if (eng_col >= eng_cols) eng_col = eng_cols - 1;
 
         // Clamp to focused pane bounds when splits are active
         if (g_split_active && g_pane_rect_rows > 0) {
@@ -1027,28 +1096,28 @@ static void cursorPosCallback(GLFWwindow* w, double mx, double my) {
             int pe = pr + g_pane_rect_rows, pce = pc + g_pane_rect_cols;
             if (row < pr) row = pr;
             if (row >= pe) row = pe - 1;
-            if (col < pc) col = pc;
-            if (col >= pce) col = pce - 1;
+            if (eng_col < pc) eng_col = pc;
+            if (eng_col >= pce) eng_col = pce - 1;
         }
 
-        if (col == g_sel_end_col && row == g_sel_end_row) return;
+        if (eng_col == g_sel_end_col && row == g_sel_end_row) return;
 
         if (g_click_count >= 3) {
             g_sel_end_row = row;
-            g_sel_end_col = (row >= g_sel_start_row) ? g_cols - 1 : 0;
-            if (row < g_sel_start_row) g_sel_start_col = g_cols - 1;
+            g_sel_end_col = (row >= g_sel_start_row) ? eng_cols - 1 : 0;
+            if (row < g_sel_start_row) g_sel_start_col = eng_cols - 1;
             else g_sel_start_col = 0;
         } else if (g_click_count == 2) {
             int wS, wE;
-            findWordBounds(row, col, g_cols, &wS, &wE);
+            findWordBounds(row, eng_col, eng_cols, &wS, &wE);
             g_sel_end_row = row;
-            if (row > g_sel_start_row || (row == g_sel_start_row && col >= g_sel_start_col))
+            if (row > g_sel_start_row || (row == g_sel_start_row && eng_col >= g_sel_start_col))
                 g_sel_end_col = wE;
             else
                 g_sel_end_col = wS;
         } else {
             g_sel_end_row = row;
-            g_sel_end_col = col;
+            g_sel_end_col = eng_col;
         }
         g_sel_active = 1;
         attyx_mark_all_dirty();

--- a/src/app/linux_render_util.c
+++ b/src/app/linux_render_util.c
@@ -175,6 +175,10 @@ int emitString(Vertex* v, int i, GlyphCache* gc,
 
 int cellIsSelected(int row, int col) {
     if (!g_sel_active) return 0;
+    // Selection coords are engine-relative; translate the screen-grid col
+    // back into engine space before any comparison.
+    col -= g_grid_left_offset;
+    if (col < 0) return 0;
     // With splits, clip selection to focused pane rect
     if ((g_copy_mode || g_split_active) && g_pane_rect_rows > 0) {
         int pr = g_pane_rect_row, pc = g_pane_rect_col;

--- a/src/app/macos_input.m
+++ b/src/app/macos_input.m
@@ -61,10 +61,13 @@ static int mouseModifiers(NSEventModifierFlags flags) {
 }
 
 static void sendSgrMouse(int button, int col, int row, BOOL press) {
-    // Adjust row from screen-space to content-space: subtract the grid top
-    // offset (statusbar / tab bar rows) so TUI apps receive correct coords.
+    // Adjust to content-space: subtract the grid top / left offsets
+    // (statusbar / tab bar / side tab gutter) so TUI apps receive coords
+    // relative to their visible terminal area.
     row -= g_grid_top_offset;
+    col -= g_grid_left_offset;
     if (row < 1) row = 1;
+    if (col < 1) col = 1;
     char buf[32];
     int len = snprintf(buf, sizeof(buf), "\x1b[<%d;%d;%d%c",
                        button, col, row, press ? 'M' : 'm');
@@ -379,6 +382,30 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
     int col, row;
     mouseCell0(event, self, &col, &row);
 
+    // Sidebar resize drag — clicking on (or within ±1 cell of) the vertical
+    // border column starts a drag. The wider hit zone makes the line easier
+    // to grab without precisely targeting a single cell.
+    if (g_tab_side != 0) {
+        int border_col = (g_tab_side == 1) ? (g_grid_left_offset - 1) : (g_cols - g_grid_right_offset);
+        if (border_col >= 0 && col >= border_col - 1 && col <= border_col + 1) {
+            attyx_sidebar_drag_start();
+            _sidebarDragging = YES;
+            [[NSCursor resizeLeftRightCursor] set];
+            return;
+        }
+    }
+
+    // Side tab bar click: consume if click lands inside the reserved gutter.
+    if (g_tab_side != 0) {
+        int side_w = (g_tab_side == 1) ? g_grid_left_offset : g_grid_right_offset;
+        int side_col_start = (g_tab_side == 1) ? 0 : (g_cols - side_w);
+        int side_col_end = side_col_start + side_w;
+        if (col >= side_col_start && col < side_col_end) {
+            attyx_side_tab_click(row, g_rows);
+            return;
+        }
+    }
+
     // Tab bar click: consume if click is on the tab bar row
     if (row == 0 && g_tab_bar_visible) {
         attyx_tab_bar_click(col, g_cols);
@@ -397,6 +424,11 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
     // Overlay click: consume if hit
     if (g_overlay_has_actions && attyx_overlay_click(col, row)) return;
 
+    // Engine column space (subtract gutter for split / selection / TUI use).
+    int eng_col = col - g_grid_left_offset;
+    int eng_cols = g_cols - g_grid_left_offset - g_grid_right_offset;
+    if (eng_cols < 1) eng_cols = 1;
+
     // Let pane switching win over app mouse tracking so OpenCode and other
     // mouse-aware apps do not trap clicks meant to focus another split.
     if (g_split_active && g_pane_rect_rows > 0) {
@@ -404,8 +436,8 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
         int pr = g_pane_rect_row, pc = g_pane_rect_col;
         int pe = pr + g_pane_rect_rows, pce = pc + g_pane_rect_cols;
         if (content_row >= 0 &&
-            (content_row < pr || content_row >= pe || col < pc || col >= pce)) {
-            attyx_split_click(col, row);
+            (content_row < pr || content_row >= pe || eng_col < pc || eng_col >= pce)) {
+            attyx_split_click(eng_col, row);
             return;
         }
     }
@@ -423,15 +455,17 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
 
     // Split pane click: focus the clicked pane + start drag resize
     if (g_split_active) {
-        attyx_split_drag_start(col, row);
+        attyx_split_drag_start(eng_col, row);
         _splitDragging = YES;
-        attyx_split_click(col, row);
+        attyx_split_click(eng_col, row);
     }
 
     // Adjust row to content space for selection and cell access.
     // Tab bar, statusbar, overlay, and split all use grid-space row above.
     row -= g_grid_top_offset;
     if (row < 0) row = 0;
+    if (eng_col < 0) eng_col = 0;
+    if (eng_col >= eng_cols) eng_col = eng_cols - 1;
 
     // Clamp to focused pane bounds when splits are active
     if (g_split_active && g_pane_rect_rows > 0) {
@@ -439,8 +473,8 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
         int pe = pr + g_pane_rect_rows, pce = pc + g_pane_rect_cols;
         if (row < pr) row = pr;
         if (row >= pe) row = pe - 1;
-        if (col < pc) col = pc;
-        if (col >= pce) col = pce - 1;
+        if (eng_col < pc) eng_col = pc;
+        if (eng_col >= pce) eng_col = pce - 1;
     }
 
     // Cmd-click link handling runs earlier (before mouse-reporting) so it
@@ -449,7 +483,7 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
     // Shift-click extends existing selection
     if ((event.modifierFlags & NSEventModifierFlagShift) && g_sel_active) {
         g_sel_end_row = row;
-        g_sel_end_col = col;
+        g_sel_end_col = eng_col;
         _selecting = YES;
         attyx_mark_all_dirty();
         return;
@@ -459,19 +493,19 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
 
     if (_clickCount >= 3) {
         g_sel_start_row = row; g_sel_start_col = 0;
-        g_sel_end_row = row;   g_sel_end_col = g_cols - 1;
+        g_sel_end_row = row;   g_sel_end_col = eng_cols - 1;
         g_sel_active = 1;
         _selecting = YES;
     } else if (_clickCount == 2) {
         int wStart, wEnd;
-        findWordBounds(row, col, g_cols, &wStart, &wEnd);
+        findWordBounds(row, eng_col, eng_cols, &wStart, &wEnd);
         g_sel_start_row = row; g_sel_start_col = wStart;
         g_sel_end_row = row;   g_sel_end_col = wEnd;
         g_sel_active = 1;
         _selecting = YES;
     } else {
-        g_sel_start_row = row; g_sel_start_col = col;
-        g_sel_end_row = row;   g_sel_end_col = col;
+        g_sel_start_row = row; g_sel_start_col = eng_col;
+        g_sel_end_row = row;   g_sel_end_col = eng_col;
         g_sel_active = 0;
         _selecting = YES;
     }
@@ -493,6 +527,12 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
         return;
     }
     _leftDown = NO;
+    if (_sidebarDragging) {
+        attyx_sidebar_drag_end();
+        _sidebarDragging = NO;
+        [[NSCursor IBeamCursor] set];
+        return;
+    }
     if (_splitDragging) {
         if (g_split_drag_active) attyx_split_drag_end();
         _splitDragging = NO;
@@ -658,6 +698,16 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
         }
         return;
     }
+    if (_sidebarDragging) {
+        int col, row;
+        mouseCell0(event, self, &col, &row);
+        // For left-side bars, width = mouse col + 1 (cells to the left of cursor).
+        // For right-side bars, width = grid_cols - mouse col.
+        int new_w = (g_tab_side == 1) ? (col + 1) : (g_cols - col);
+        attyx_sidebar_drag_update(new_w);
+        [[NSCursor resizeLeftRightCursor] set];
+        return;
+    }
     if (_splitDragging && g_split_drag_active) {
         int col, row;
         mouseCell0(event, self, &col, &row);
@@ -704,6 +754,11 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
         mouseCell0(event, self, &col, &row);
         row -= g_grid_top_offset;
         if (row < 0) row = 0;
+        int eng_col = col - g_grid_left_offset;
+        int eng_cols = g_cols - g_grid_left_offset - g_grid_right_offset;
+        if (eng_cols < 1) eng_cols = 1;
+        if (eng_col < 0) eng_col = 0;
+        if (eng_col >= eng_cols) eng_col = eng_cols - 1;
 
         // Clamp to focused pane bounds when splits are active
         if (g_split_active && g_pane_rect_rows > 0) {
@@ -711,21 +766,21 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
             int pe = pr + g_pane_rect_rows, pce = pc + g_pane_rect_cols;
             if (row < pr) row = pr;
             if (row >= pe) row = pe - 1;
-            if (col < pc) col = pc;
-            if (col >= pce) col = pce - 1;
+            if (eng_col < pc) eng_col = pc;
+            if (eng_col >= pce) eng_col = pce - 1;
         }
 
-        if (col == g_sel_end_col && row == g_sel_end_row) return;
+        if (eng_col == g_sel_end_col && row == g_sel_end_row) return;
 
         if (_clickCount >= 3) {
             g_sel_end_row = row;
-            g_sel_end_col = (row >= g_sel_start_row) ? g_cols - 1 : 0;
-            if (row < g_sel_start_row) g_sel_start_col = g_cols - 1;
+            g_sel_end_col = (row >= g_sel_start_row) ? eng_cols - 1 : 0;
+            if (row < g_sel_start_row) g_sel_start_col = eng_cols - 1;
             else g_sel_start_col = 0;
         } else if (_clickCount == 2) {
             int wStart, wEnd;
-            findWordBounds(row, col, g_cols, &wStart, &wEnd);
-            if (row > g_sel_start_row || (row == g_sel_start_row && col >= g_sel_start_col)) {
+            findWordBounds(row, eng_col, eng_cols, &wStart, &wEnd);
+            if (row > g_sel_start_row || (row == g_sel_start_row && eng_col >= g_sel_start_col)) {
                 g_sel_end_row = row;
                 g_sel_end_col = wEnd;
             } else {
@@ -734,7 +789,7 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
             }
         } else {
             g_sel_end_row = row;
-            g_sel_end_col = col;
+            g_sel_end_col = eng_col;
         }
         g_sel_active = 1;
         attyx_mark_all_dirty();
@@ -815,6 +870,23 @@ static void findWordBounds(int row, int col, int cols, int *outStart, int *outEn
             }
         }
         return;
+    }
+    // Sidebar separator hover: show resize cursor over (and ±1 cell from)
+    // the vertical line.
+    if (g_tab_side != 0) {
+        static BOOL wasOnSidebar = NO;
+        int hcol, hrow;
+        mouseCell0(event, self, &hcol, &hrow);
+        int border_col = (g_tab_side == 1) ? (g_grid_left_offset - 1) : (g_cols - g_grid_right_offset);
+        if (border_col >= 0 && hcol >= border_col - 1 && hcol <= border_col + 1) {
+            [[NSCursor resizeLeftRightCursor] set];
+            wasOnSidebar = YES;
+            return;
+        }
+        if (wasOnSidebar) {
+            wasOnSidebar = NO;
+            [[NSCursor IBeamCursor] set];
+        }
     }
     // Split separator hover: always check before mouse tracking so the
     // resize cursor appears even when the focused pane tracks the mouse.

--- a/src/app/macos_input_private.h
+++ b/src/app/macos_input_private.h
@@ -12,6 +12,7 @@
     CGFloat _scrollAccum;
     BOOL _selecting;
     BOOL _splitDragging;
+    BOOL _sidebarDragging;
     int _clickCount;
     NSMutableString* _markedText;
     NSRange _markedRange;

--- a/src/app/macos_renderer_draw.m
+++ b/src/app/macos_renderer_draw.m
@@ -9,6 +9,10 @@
 
 static BOOL cellIsSelected(int row, int col) {
     if (!g_sel_active) return NO;
+    // Selection coords are engine-relative; translate the screen-grid col
+    // back into engine space before any comparison.
+    col -= g_grid_left_offset;
+    if (col < 0) return NO;
     // With splits, clip selection to focused pane rect
     if ((g_copy_mode || g_split_active) && g_pane_rect_rows > 0) {
         int pr = g_pane_rect_row, pc = g_pane_rect_col;

--- a/src/app/main.zig
+++ b/src/app/main.zig
@@ -53,9 +53,13 @@ export var g_app_version: [*]const u8 = @ptrCast(&_ver_stub);
 export var g_app_version_len: c_int = 0;
 export var g_grid_top_offset: i32 = 0;
 export var g_grid_bottom_offset: i32 = 0;
+export var g_grid_left_offset: i32 = 0;
+export var g_grid_right_offset: i32 = 0;
 export var g_statusbar_visible: i32 = 0;
 export var g_statusbar_position: i32 = 0;
 export var g_tab_bar_visible: i32 = 0;
+export var g_tab_side: i32 = 0;
+export var g_tab_side_width: i32 = 0;
 export var g_toggle_debug_overlay: i32 = 0;
 export fn attyx_toggle_debug_overlay() void {}
 export var g_toggle_anchor_demo: i32 = 0;
@@ -88,6 +92,10 @@ export fn attyx_picker_cmd(_: c_int) void {}
 export fn attyx_tab_action(_: c_int) void {}
 export fn attyx_tab_bar_click(_: c_int, _: c_int) void {}
 export fn attyx_statusbar_tab_click(_: c_int, _: c_int) void {}
+export fn attyx_side_tab_click(_: c_int, _: c_int) void {}
+export fn attyx_sidebar_drag_start() void {}
+export fn attyx_sidebar_drag_update(_: c_int) void {}
+export fn attyx_sidebar_drag_end() void {}
 
 // Split pane stubs (terminal.zig provides the real implementations)
 export fn attyx_split_action(_: c_int) void {}

--- a/src/app/session_connect.zig
+++ b/src/app/session_connect.zig
@@ -392,6 +392,32 @@ pub fn loadLastSession() ?u32 {
     return std.fmt.parseInt(u32, buf[0..n], 10) catch null;
 }
 
+pub fn getSidebarWidthPath(buf: *[256]u8) ?[]const u8 {
+    return statePath(buf, "sidebar-width{s}");
+}
+
+pub fn saveSidebarWidth(width: u16) void {
+    var path_buf: [256]u8 = undefined;
+    const path = getSidebarWidthPath(&path_buf) orelse return;
+    var id_buf: [16]u8 = undefined;
+    const id_str = std.fmt.bufPrint(&id_buf, "{d}", .{width}) catch return;
+    const file = std.fs.createFileAbsolute(path, .{}) catch return;
+    defer file.close();
+    file.writeAll(id_str) catch {};
+}
+
+pub fn loadSidebarWidth() ?u16 {
+    var path_buf: [256]u8 = undefined;
+    const path = getSidebarWidthPath(&path_buf) orelse return null;
+    const file = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer file.close();
+    var buf: [16]u8 = undefined;
+    const n = file.read(&buf) catch return null;
+    if (n == 0) return null;
+    const trimmed = std.mem.trim(u8, buf[0..n], &std.ascii.whitespace);
+    return std.fmt.parseInt(u16, trimmed, 10) catch null;
+}
+
 // ── One-time migration: move runtime files from config dir to state dir ──
 
 /// Migrate runtime files from ~/.config/attyx/ to the XDG state directory.

--- a/src/app/split_render.zig
+++ b/src/app/split_render.zig
@@ -34,15 +34,32 @@ pub const Cell = extern struct {
 
 /// Fill the cell buffer from a multi-pane split layout.
 /// Draws separators and composites each pane's engine into its region.
+///
+/// The buffer has dimensions `grid_rows × full_grid_cols` (stride passed
+/// separately as `buf_stride`). Pane rectangles are engine-relative; they
+/// are shifted right by `col_offset` so the side-tab gutter (if any) is
+/// preserved.
 pub fn fillCellsSplit(
     cells: [*]Cell,
     layout_ptr: *SplitLayout,
     grid_rows: u16,
-    grid_cols: u16,
+    eng_cols: u16,
+    theme: *const Theme,
+) void {
+    fillCellsSplitAt(cells, layout_ptr, grid_rows, eng_cols, eng_cols, 0, theme);
+}
+
+pub fn fillCellsSplitAt(
+    cells: [*]Cell,
+    layout_ptr: *SplitLayout,
+    grid_rows: u16,
+    eng_cols: u16,
+    buf_stride: u16,
+    col_offset: u16,
     theme: *const Theme,
 ) void {
     // 1. Clear entire buffer to dark background
-    const total: usize = @as(usize, grid_rows) * @as(usize, grid_cols);
+    const total: usize = @as(usize, grid_rows) * @as(usize, buf_stride);
     const bg = theme.background;
     for (0..total) |i| {
         cells[i] = .{
@@ -59,25 +76,26 @@ pub fn fillCellsSplit(
         };
     }
 
-    // If zoomed, render only the zoomed pane at full grid size
+    // If zoomed, render only the zoomed pane across the engine's full grid size
     if (layout_ptr.isZoomed()) {
         const zoomed_pane = layout_ptr.pool[layout_ptr.zoomed_leaf].pane orelse return;
-        const full_rect = Rect{ .row = 0, .col = 0, .rows = grid_rows, .cols = grid_cols };
-        fillRegion(cells, &zoomed_pane.engine, full_rect, grid_cols, theme);
+        const full_rect = Rect{ .row = 0, .col = col_offset, .rows = grid_rows, .cols = eng_cols };
+        fillRegion(cells, &zoomed_pane.engine, full_rect, buf_stride, theme);
         return;
     }
 
-    // 2. Draw separator characters on branch nodes
-    drawSeparators(cells, layout_ptr, grid_rows, grid_cols, theme);
+    // 2. Draw separator characters on branch nodes (shifted by col_offset)
+    drawSeparatorsAt(cells, layout_ptr, grid_rows, eng_cols, buf_stride, col_offset, theme);
 
     // 3. Fill each leaf's region from its engine
     var leaves: [max_panes]LeafEntry = undefined;
     const leaf_count = layout_ptr.collectLeaves(&leaves);
     const dim = (term_globals.g_tab_dim_unfocused != 0);
     for (leaves[0..leaf_count]) |leaf| {
-        fillRegion(cells, &leaf.pane.engine, leaf.rect, grid_cols, theme);
+        const shifted = Rect{ .row = leaf.rect.row, .col = leaf.rect.col + col_offset, .rows = leaf.rect.rows, .cols = leaf.rect.cols };
+        fillRegion(cells, &leaf.pane.engine, shifted, buf_stride, theme);
         if (dim and leaf.index != layout_ptr.focused) {
-            dimRegion(cells, leaf.rect, grid_cols);
+            dimRegion(cells, shifted, buf_stride);
         }
     }
 }
@@ -120,13 +138,28 @@ fn dimRegion(cells: [*]Cell, rect: Rect, grid_cols: u16) void {
 }
 
 /// Walk branch nodes and draw box-drawing separator characters.
+fn drawSeparatorsAt(
+    cells: [*]Cell,
+    layout_ptr: *SplitLayout,
+    grid_rows: u16,
+    eng_cols: u16,
+    buf_stride: u16,
+    col_offset: u16,
+    theme: *const Theme,
+) void {
+    drawSeparators(cells, layout_ptr, grid_rows, eng_cols, theme, buf_stride, col_offset);
+}
+
 fn drawSeparators(
     cells: [*]Cell,
     layout_ptr: *SplitLayout,
     grid_rows: u16,
     grid_cols: u16,
     theme: *const Theme,
+    buf_stride_param: u16,
+    col_offset: u16,
 ) void {
+    const buf_stride: u16 = if (buf_stride_param == 0) grid_cols else buf_stride_param;
     // Dim the separator: blend foreground 1/3 toward background
     const fg = .{
         .r = @as(u8, @intCast((@as(u16, theme.foreground.r) + @as(u16, theme.background.r) * 2) / 3)),
@@ -161,13 +194,14 @@ fn drawSeparators(
                 const available = rect.cols -| gap_h;
                 const left_cols = @as(u16, @intFromFloat(@as(f32, @floatFromInt(available)) * node.ratio));
                 const padding = (gap_h -| 1) / 2;
-                const sep_col = rect.col + left_cols + padding;
-                if (sep_col >= grid_cols) continue;
+                const sep_col_eng = rect.col + left_cols + padding;
+                if (sep_col_eng >= grid_cols) continue;
+                const sep_col = sep_col_eng + col_offset;
                 // Extend into parent gaps so vertical lines meet horizontal ones
                 const row_start = rect.row -| gap_v;
                 const row_end = @min(grid_rows, rect.row + rect.rows + gap_v);
                 for (row_start..row_end) |r| {
-                    const idx = r * @as(usize, grid_cols) + sep_col;
+                    const idx = r * @as(usize, buf_stride) + sep_col;
                     cells[idx] = sep_cell_template;
                     cells[idx].character = 0x2502; // │
                 }
@@ -178,10 +212,12 @@ fn drawSeparators(
                 const padding = (gap_v -| 1) / 2;
                 const sep_row = rect.row + top_rows + padding;
                 if (sep_row >= grid_rows) continue;
-                const row_offset = @as(usize, sep_row) * @as(usize, grid_cols);
+                const row_offset = @as(usize, sep_row) * @as(usize, buf_stride);
                 // Extend into parent gaps so horizontal lines meet vertical ones
-                const col_start = rect.col -| gap_h;
-                const col_end = @min(grid_cols, rect.col + rect.cols + gap_h);
+                const col_start_eng = rect.col -| gap_h;
+                const col_end_eng = @min(grid_cols, rect.col + rect.cols + gap_h);
+                const col_start: usize = @as(usize, col_start_eng) + col_offset;
+                const col_end: usize = @as(usize, col_end_eng) + col_offset;
                 for (col_start..col_end) |cc| {
                     cells[row_offset + cc] = sep_cell_template;
                     cells[row_offset + cc].character = 0x2500; // ─
@@ -190,10 +226,12 @@ fn drawSeparators(
         }
     }
 
-    // Pass 2: fix up intersections with proper junction characters
-    const gcols: usize = grid_cols;
+    // Pass 2: fix up intersections — only scan the engine area in the buffer.
+    const gcols: usize = buf_stride;
+    const eng_col_start: usize = col_offset;
+    const eng_col_end: usize = col_offset + grid_cols;
     for (0..grid_rows) |r| {
-        for (0..gcols) |cc| {
+        for (eng_col_start..eng_col_end) |cc| {
             const idx = r * gcols + cc;
             const ch = cells[idx].character;
             if (ch != 0x2502 and ch != 0x2500) continue;
@@ -201,8 +239,8 @@ fn drawSeparators(
             // Check 4 neighbors for separator lines
             const has_up = r > 0 and isVerticalSep(cells[(r - 1) * gcols + cc].character);
             const has_down = r + 1 < grid_rows and isVerticalSep(cells[(r + 1) * gcols + cc].character);
-            const has_left = cc > 0 and isHorizontalSep(cells[r * gcols + (cc - 1)].character);
-            const has_right = cc + 1 < gcols and isHorizontalSep(cells[r * gcols + (cc + 1)].character);
+            const has_left = cc > eng_col_start and isHorizontalSep(cells[r * gcols + (cc - 1)].character);
+            const has_right = cc + 1 < eng_col_end and isHorizontalSep(cells[r * gcols + (cc + 1)].character);
 
             const junction = junctionChar(has_up, has_down, has_left, has_right);
             if (junction != 0) cells[idx].character = junction;

--- a/src/app/tab_bar.zig
+++ b/src/app/tab_bar.zig
@@ -25,6 +25,10 @@ pub const Style = struct {
     agent_idle_fg: Rgb = .{ .r = 96, .g = 208, .b = 120 },
     agent_running_fg: Rgb = .{ .r = 255, .g = 170, .b = 64 },
     agent_waiting_fg: Rgb = .{ .r = 176, .g = 112, .b = 255 },
+    /// Foreground for the vertical separator border in side mode. Defaults
+    /// to a dimmed gray; callers can blend toward the active theme bg/fg
+    /// for better contrast.
+    border_fg: Rgb = .{ .r = 70, .g = 70, .b = 80 },
     bg_alpha: u8 = 230,
 };
 
@@ -424,6 +428,220 @@ pub fn generate(
     };
 }
 
+pub const min_side_width: u16 = 8;
+pub const default_side_width: u16 = 24;
+
+/// Side bar width in cells. Honors the user override (`requested`) when
+/// non-zero; otherwise falls back to a readable fixed default. Always
+/// clamped to [min_side_width, grid_cols / 2] so the content area stays
+/// usable.
+pub fn sideBarWidthRequested(grid_cols: u16, requested: u16) u16 {
+    if (grid_cols == 0) return 0;
+    const half: u16 = grid_cols / 2;
+    var w: u16 = if (requested != 0) requested else default_side_width;
+    if (w < min_side_width) w = min_side_width;
+    if (w > half) w = half;
+    if (w == 0) w = 1;
+    return w;
+}
+
+pub fn sideBarWidth(grid_cols: u16) u16 {
+    return sideBarWidthRequested(grid_cols, 0);
+}
+
+/// Vertical tab bar result: a `width` × `height` block of cells laid out
+/// row-major (`cells[row * width + col]`).
+pub const VerticalResult = struct {
+    cells: []StyledCell,
+    width: u16,
+    height: u16,
+};
+
+/// Cached row span [start, end) per tab for hit testing in vertical mode.
+var v_cached_starts: [max_tabs]u16 = .{0} ** max_tabs;
+var v_cached_ends: [max_tabs]u16 = .{0} ** max_tabs;
+var v_cached_count: u8 = 0;
+
+/// Generate vertical tab bar cells into a caller-provided buffer.
+/// Each tab takes one row; cells inside the bar are laid out row-major
+/// with `width` columns and `height` rows.
+///
+/// Visual style: rows are mostly transparent (terminal background shows
+/// through). The active row gets a subtle highlight bg behind its text.
+/// A vertical box-drawing separator `│` runs along the inner edge —
+/// rightmost col when `border_on_right = true` (left-side bar), leftmost
+/// col otherwise (right-side bar).
+pub fn generateVertical(
+    buf: []StyledCell,
+    tab_count: u8,
+    active: u8,
+    width: u16,
+    height: u16,
+    style: Style,
+    titles: *const TabTitles,
+    zoomed_tabs: u16,
+    statuses: *const AgentStatuses,
+    border_on_right: bool,
+) ?VerticalResult {
+    if (width == 0 or height == 0 or tab_count == 0) return null;
+    const total: usize = @as(usize, width) * @as(usize, height);
+    if (buf.len < total) return null;
+
+    const transparent: StyledCell = .{
+        .char = ' ',
+        .fg = style.fg,
+        .bg = .{ .r = 0, .g = 0, .b = 0 },
+        .bg_alpha = 0,
+    };
+
+    // Border lives on the inner edge: rightmost col for left-side bars,
+    // leftmost col for right-side bars. The remaining columns hold tab text
+    // and stay transparent so the terminal background shows through.
+    const border_col: u16 = if (border_on_right) width - 1 else 0;
+    const text_start: u16 = if (border_on_right) 0 else 1;
+    const text_end: u16 = if (border_on_right) width - 1 else width;
+
+    // Initialize: transparent everywhere, with a vertical line on border col.
+    for (0..height) |r| {
+        const base = r * @as(usize, width);
+        for (0..width) |c2| buf[base + c2] = transparent;
+        buf[base + border_col] = .{
+            .char = 0x2502, // │
+            .fg = style.border_fg,
+            .bg = .{ .r = 0, .g = 0, .b = 0 },
+            .bg_alpha = 0,
+        };
+    }
+
+    var fallback_bufs: [max_tabs][20]u8 = undefined;
+    var resolved: [max_tabs]ParsedTitle = undefined;
+    for (0..tab_count) |i| {
+        resolved[i] = parseAgentTitle(resolveTitle(titles, i, &fallback_bufs[i]));
+    }
+
+    const writeCell = struct {
+        fn w(buf2: []StyledCell, idx: usize, ch: u21, fg: Rgb, is_act: bool, st: Style) void {
+            if (is_act) {
+                const abg = st.active_tab_bg orelse st.tab_bg;
+                buf2[idx] = .{ .char = ch, .fg = fg, .bg = abg, .bg_alpha = st.bg_alpha };
+            } else {
+                buf2[idx] = .{ .char = ch, .fg = fg, .bg = .{ .r = 0, .g = 0, .b = 0 }, .bg_alpha = 0 };
+            }
+        }
+    }.w;
+
+    v_cached_count = tab_count;
+    var row: u16 = 0;
+    for (0..tab_count) |i| {
+        if (row >= height) break;
+        v_cached_starts[i] = row;
+
+        const is_active = (i == active);
+        const t_fg = if (is_active) (style.active_fg orelse style.fg) else style.fg;
+        const merged_status = if (statuses[i] != .none) statuses[i] else resolved[i].agent_status;
+        const row_base = @as(usize, row) * width;
+
+        if (text_end <= text_start) {
+            v_cached_ends[i] = row + 1;
+            row += 1;
+            continue;
+        }
+
+        // Paint active row's text area with the highlight bg.
+        if (is_active) {
+            const abg = style.active_tab_bg orelse style.tab_bg;
+            for (text_start..text_end) |c2| {
+                buf[row_base + c2] = .{ .char = ' ', .fg = t_fg, .bg = abg, .bg_alpha = style.bg_alpha };
+            }
+        }
+
+        // Layout: " " (1) [zoom 2]? [agent 2]? title… " N "(right)
+        var col: u16 = text_start;
+        if (col < text_end) { writeCell(buf, row_base + col, ' ', t_fg, is_active, style); col += 1; }
+        const tab_zoomed = (zoomed_tabs & (@as(u16, 1) << @intCast(i))) != 0;
+        if (tab_zoomed) {
+            if (col < text_end) { writeCell(buf, row_base + col, 0x229E, t_fg, is_active, style); col += 1; }
+            if (col < text_end) { writeCell(buf, row_base + col, ' ', t_fg, is_active, style); col += 1; }
+        }
+        if (merged_status != .none) {
+            const dot_fg = switch (merged_status) {
+                .generic => style.agent_fg,
+                .idle => style.agent_idle_fg,
+                .running => style.agent_running_fg,
+                .waiting => style.agent_waiting_fg,
+                .none => t_fg,
+            };
+            if (col < text_end) { writeCell(buf, row_base + col, 0x25CF, dot_fg, is_active, style); col += 1; }
+            if (col < text_end) { writeCell(buf, row_base + col, ' ', t_fg, is_active, style); col += 1; }
+        }
+
+        // Tab number badge at the right edge of the text area: " N " or " NN ".
+        var num_buf: [3]u8 = undefined;
+        const num = std.fmt.bufPrint(&num_buf, "{d}", .{i + 1}) catch "?";
+        const badge_w: u16 = @intCast(num.len + 2);
+        const badge_start: u16 = if (text_end > text_start + badge_w) text_end - badge_w else text_start;
+        const title_end: u16 = if (badge_start > col) badge_start else col;
+
+        // Title characters fill [col, title_end).
+        var title_col: u16 = col;
+        const title = resolved[i].title;
+        var ti: usize = 0;
+        while (nextCodepoint(title, &ti)) |cp| {
+            if (title_col >= title_end) break;
+            if (unicode.isCombiningMark(cp) or unicode.isZeroWidth(cp)) {
+                if (title_col > text_start) {
+                    const cidx = row_base + (title_col - 1);
+                    if (buf[cidx].combining[0] == 0) {
+                        buf[cidx].combining[0] = cp;
+                    } else if (buf[cidx].combining[1] == 0) {
+                        buf[cidx].combining[1] = cp;
+                    }
+                }
+                continue;
+            }
+            const w = unicode.charDisplayWidth(cp);
+            if (title_col + w > title_end) break;
+            writeCell(buf, row_base + title_col, cp, t_fg, is_active, style);
+            title_col += 1;
+            if (w == 2 and title_col < title_end) {
+                writeCell(buf, row_base + title_col, ' ', t_fg, is_active, style);
+                title_col += 1;
+            }
+        }
+
+        // Badge: " N " — uses num highlight colors when active.
+        if (badge_start < text_end) {
+            const n_fg = if (is_active) style.num_highlight_fg else style.fg;
+            const n_bg = if (is_active) style.num_highlight_bg else style.tab_bg;
+            const use_alpha: u8 = if (is_active) style.bg_alpha else 0;
+            buf[row_base + badge_start] = .{ .char = ' ', .fg = n_fg, .bg = n_bg, .bg_alpha = use_alpha };
+            var bi: u16 = badge_start + 1;
+            for (num) |ch| {
+                if (bi >= text_end) break;
+                buf[row_base + bi] = .{ .char = ch, .fg = n_fg, .bg = n_bg, .bg_alpha = use_alpha };
+                bi += 1;
+            }
+            while (bi < text_end) : (bi += 1) {
+                buf[row_base + bi] = .{ .char = ' ', .fg = n_fg, .bg = n_bg, .bg_alpha = use_alpha };
+            }
+        }
+
+        v_cached_ends[i] = row + 1;
+        row += 1;
+    }
+
+    return .{ .cells = buf[0..total], .width = width, .height = height };
+}
+
+/// Map a row within the side tab bar back to a tab index.
+pub fn tabIndexAtRow(row: u16, tab_count: u8) ?u8 {
+    const count = @min(tab_count, v_cached_count);
+    for (0..count) |i| {
+        if (row >= v_cached_starts[i] and row < v_cached_ends[i]) return @intCast(i);
+    }
+    return null;
+}
+
 /// Given a column position, return the tab index at that column (or null if outside tabs
 /// or on a gap between tabs). Accounts for scroll offset and overflow indicators.
 pub fn tabIndexAtCol(col: u16, tab_count: u8, grid_cols: u16) ?u8 {
@@ -732,6 +950,64 @@ test "tabIndexAtCol: works with scroll offset" {
 
     // Col 19 is tab content (no right indicator) — virtual col 18+15=33, tab 4 (starts 28, width 6)
     try std.testing.expectEqual(@as(?u8, 4), tabIndexAtCol(19, 5, 20));
+}
+
+test "sideBarWidth: fixed 24 cells, shrinks only on narrow windows" {
+    try std.testing.expectEqual(@as(u16, 24), sideBarWidth(80));
+    try std.testing.expectEqual(@as(u16, 24), sideBarWidth(120));
+    try std.testing.expectEqual(@as(u16, 24), sideBarWidth(300));
+    try std.testing.expectEqual(@as(u16, 20), sideBarWidth(40)); // half of 40
+    try std.testing.expectEqual(@as(u16, 0), sideBarWidth(0));
+}
+
+test "sideBarWidthRequested: honors override clamped to [min, half]" {
+    try std.testing.expectEqual(@as(u16, 30), sideBarWidthRequested(120, 30));
+    try std.testing.expectEqual(@as(u16, 8), sideBarWidthRequested(120, 4)); // below min
+    try std.testing.expectEqual(@as(u16, 60), sideBarWidthRequested(120, 200)); // capped at half
+    try std.testing.expectEqual(@as(u16, 24), sideBarWidthRequested(120, 0)); // default
+}
+
+test "generateVertical: lays out one tab per row with badge + border" {
+    var buf: [16 * 24]StyledCell = undefined;
+    var titles: TabTitles = .{null} ** max_tabs;
+    titles[0] = "vim";
+    titles[1] = "zsh";
+    // Left-side bar → border on right (column width-1 = 15).
+    const result = generateVertical(&buf, 2, 1, 16, 24, .{}, &titles, 0, &no_statuses, true) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(u16, 16), result.width);
+    try std.testing.expectEqual(@as(u16, 24), result.height);
+
+    // Border column: vertical line at col 15 of every row.
+    try std.testing.expectEqual(@as(u21, 0x2502), result.cells[15].char);
+    try std.testing.expectEqual(@as(u21, 0x2502), result.cells[16 * 5 + 15].char);
+
+    // Row 0: tab 0 — title text, badge `" 1 "` ends just before the border.
+    try std.testing.expectEqual(@as(u21, 'v'), result.cells[1].char);
+    try std.testing.expectEqual(@as(u21, '1'), result.cells[13].char);
+
+    // Row 1: tab 1 (active)
+    const r1 = 16 * 1;
+    try std.testing.expectEqual(@as(u21, 'z'), result.cells[r1 + 1].char);
+    try std.testing.expectEqual(@as(u21, '2'), result.cells[r1 + 13].char);
+
+    // Empty rows below the last tab keep transparent bg with border line.
+    try std.testing.expectEqual(@as(u8, 0), result.cells[16 * 10 + 5].bg_alpha);
+    try std.testing.expectEqual(@as(u21, 0x2502), result.cells[16 * 10 + 15].char);
+
+    // Hit test
+    try std.testing.expectEqual(@as(?u8, 0), tabIndexAtRow(0, 2));
+    try std.testing.expectEqual(@as(?u8, 1), tabIndexAtRow(1, 2));
+    try std.testing.expectEqual(@as(?u8, null), tabIndexAtRow(5, 2));
+}
+
+test "generateVertical: right-side bar puts border at column 0" {
+    var buf: [16 * 8]StyledCell = undefined;
+    var titles: TabTitles = .{null} ** max_tabs;
+    titles[0] = "a";
+    const result = generateVertical(&buf, 1, 0, 16, 8, .{}, &titles, 0, &no_statuses, false) orelse return error.TestUnexpectedResult;
+    // Border at col 0 every row.
+    try std.testing.expectEqual(@as(u21, 0x2502), result.cells[0].char);
+    try std.testing.expectEqual(@as(u21, 0x2502), result.cells[16].char);
 }
 
 test "autoScroll: active tab scrolled into view" {

--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -25,6 +25,7 @@ const split_layout_mod = @import("split_layout.zig");
 const diag = @import("../logging/diag.zig");
 const platform = @import("../platform/platform.zig");
 const statusbar_mod = @import("statusbar.zig");
+const tab_bar_mod = @import("tab_bar.zig");
 pub const Statusbar = statusbar_mod.Statusbar;
 const ipc_server = @import("../ipc/server.zig");
 
@@ -155,8 +156,14 @@ pub export var g_app_version_len: c_int = @intCast(attyx.version.len);
 
 pub export var g_grid_top_offset: i32 = 0;
 pub export var g_grid_bottom_offset: i32 = 0;
+pub export var g_grid_left_offset: i32 = 0;
+pub export var g_grid_right_offset: i32 = 0;
 pub export var g_statusbar_visible: i32 = 0;
 pub export var g_statusbar_position: i32 = 0; // 0=top, 1=bottom
+pub export var g_tab_side: i32 = 0; // 0=top, 1=left, 2=right
+// User-resized side bar width in cells (0 = use sideBarWidth default).
+// Updated live by mouse drag; persisted to state dir on drag end.
+pub export var g_tab_side_width: i32 = 0;
 pub export var g_toggle_debug_overlay: i32 = 0;
 pub export var g_toggle_anchor_demo: i32 = 0;
 pub export var g_toggle_ai_demo: i32 = 0;
@@ -277,6 +284,10 @@ export fn attyx_picker_cmd(cmd: c_int) void { input.pickerCmd(cmd); }
 export fn attyx_tab_action(action: c_int) void { input.tabAction(action); }
 export fn attyx_tab_bar_click(col: c_int, grid_cols: c_int) void { input.tabBarClick(col, grid_cols); }
 export fn attyx_statusbar_tab_click(col: c_int, grid_cols: c_int) void { input.statusbarTabClick(col, grid_cols); }
+export fn attyx_side_tab_click(row: c_int, grid_rows: c_int) void { input.sideTabClick(row, grid_rows); }
+export fn attyx_sidebar_drag_start() void { input.sidebarDragStart(); }
+export fn attyx_sidebar_drag_update(width: c_int) void { input.sidebarDragUpdate(width); }
+export fn attyx_sidebar_drag_end() void { input.sidebarDragEnd(); }
 export fn attyx_split_action(action: c_int) void { input.splitAction(action); }
 export fn attyx_split_click(col: c_int, row: c_int) void { input.splitClick(col, row); }
 export fn attyx_split_drag_start(col: c_int, row: c_int) void { input.splitDragStart(col, row); }
@@ -342,6 +353,17 @@ pub fn run(
     g_native_tabs_enabled = if (config.tab_appearance == .native) @as(i32, 1) else @as(i32, 0);
     g_tab_always_show = if (config.tab_always_show) @as(i32, 1) else @as(i32, 0);
     g_tab_dim_unfocused = if (config.tab_dim_unfocused) @as(i32, 1) else @as(i32, 0);
+    g_tab_side = switch (config.tab_side) {
+        .none => 0,
+        .left => 1,
+        .right => 2,
+    };
+    // Native tabs win — they reserve the title bar instead of the grid.
+    if (g_native_tabs_enabled != 0) g_tab_side = 0;
+    // Restore the user's last sidebar width across restarts.
+    if (g_tab_side != 0) {
+        if (conn.loadSidebarWidth()) |saved| g_tab_side_width = @intCast(saved);
+    }
 
     var theme_registry = ThemeRegistry.init(allocator);
     defer theme_registry.deinit();
@@ -394,7 +416,16 @@ pub fn run(
             g_statusbar_visible = 1;
         }
     }
+    // Reserve side-tab gutter columns up-front too — otherwise the shell
+    // spawns at full grid width and the prompt overflows past the gutter
+    // until the first SIGWINCH lands.
+    if (g_tab_side != 0) {
+        const req_w: u16 = @intCast(@max(0, g_tab_side_width));
+        const sw: i32 = @intCast(tab_bar_mod.sideBarWidthRequested(config.cols, req_w));
+        if (g_tab_side == 1) g_grid_left_offset = sw else g_grid_right_offset = sw;
+    }
     const initial_pty_rows: u16 = @intCast(@max(1, @as(i32, config.rows) - g_grid_top_offset - g_grid_bottom_offset));
+    const initial_pty_cols: u16 = @intCast(@max(1, @as(i32, config.cols) - g_grid_left_offset - g_grid_right_offset));
 
     // Session mode: connect to daemon. On failure, fall back to direct PTY.
     // Ownership transfers to the initial pane's heap-allocated copy below.
@@ -476,13 +507,13 @@ pub fn run(
 
         // Try to get existing sessions
         sc.requestListSync(2000) catch {
-            const sid = sc.createSession("default", initial_pty_rows, config.cols, initial_cwd, initial_shell) catch |err| {
+            const sid = sc.createSession("default", initial_pty_rows, initial_pty_cols, initial_cwd, initial_shell) catch |err| {
                 logging.err("session", "create session failed: {}", .{err});
                 sc.deinit();
                 session_client = null;
                 break :attach_or_create;
             };
-            _ = doAttach(sc, sid, initial_pty_rows, config.cols, &initial_pane_ids, &initial_pane_count);
+            _ = doAttach(sc, sid, initial_pty_rows, initial_pty_cols, &initial_pane_ids, &initial_pane_count);
             conn.saveLastSession(sid);
             logging.info("session", "created and attached to session {d}", .{sid});
             break :attach_or_create;
@@ -491,13 +522,13 @@ pub fn run(
         // When -d / --working-directory is explicitly set, always create a
         // fresh session in that directory instead of reattaching to an existing one.
         if (config.working_directory != null) {
-            const sid = sc.createSession("default", initial_pty_rows, config.cols, initial_cwd, initial_shell) catch |err| {
+            const sid = sc.createSession("default", initial_pty_rows, initial_pty_cols, initial_cwd, initial_shell) catch |err| {
                 logging.err("session", "create session failed: {}", .{err});
                 sc.deinit();
                 session_client = null;
                 break :attach_or_create;
             };
-            _ = doAttach(sc, sid, initial_pty_rows, config.cols, &initial_pane_ids, &initial_pane_count);
+            _ = doAttach(sc, sid, initial_pty_rows, initial_pty_cols, &initial_pane_ids, &initial_pane_count);
             conn.saveLastSession(sid);
             logging.info("session", "created new session {d} for working directory", .{sid});
             break :attach_or_create;
@@ -533,26 +564,26 @@ pub fn run(
         }
 
         if (found_alive) |sid| {
-            if (!doAttach(sc, sid, initial_pty_rows, config.cols, &initial_pane_ids, &initial_pane_count)) {
+            if (!doAttach(sc, sid, initial_pty_rows, initial_pty_cols, &initial_pane_ids, &initial_pane_count)) {
                 logging.err("session", "attach to session {d} failed", .{sid});
-                const new_sid = sc.createSession("default", initial_pty_rows, config.cols, initial_cwd, initial_shell) catch |err2| {
+                const new_sid = sc.createSession("default", initial_pty_rows, initial_pty_cols, initial_cwd, initial_shell) catch |err2| {
                     logging.err("session", "create session failed: {}", .{err2});
                     sc.deinit();
                     session_client = null;
                     break :attach_or_create;
                 };
-                _ = doAttach(sc, new_sid, initial_pty_rows, config.cols, &initial_pane_ids, &initial_pane_count);
+                _ = doAttach(sc, new_sid, initial_pty_rows, initial_pty_cols, &initial_pane_ids, &initial_pane_count);
             }
             conn.saveLastSession(found_alive.?);
             logging.info("session", "reattached to session {d}", .{found_alive.?});
         } else {
-            const sid = sc.createSession("default", initial_pty_rows, config.cols, initial_cwd, initial_shell) catch |err| {
+            const sid = sc.createSession("default", initial_pty_rows, initial_pty_cols, initial_cwd, initial_shell) catch |err| {
                 logging.err("session", "create session failed: {}", .{err});
                 sc.deinit();
                 session_client = null;
                 break :attach_or_create;
             };
-            _ = doAttach(sc, sid, initial_pty_rows, config.cols, &initial_pane_ids, &initial_pane_count);
+            _ = doAttach(sc, sid, initial_pty_rows, initial_pty_cols, &initial_pane_ids, &initial_pane_count);
             conn.saveLastSession(sid);
             logging.info("session", "created and attached to session {d}", .{sid});
         }
@@ -567,9 +598,9 @@ pub fn run(
     // Spawn initial pane: xyron --ipc if detected, otherwise default shell
     if (xyron_heap_path) |xhp| {
         const xa: [2][:0]const u8 = .{ xhp, "--ipc" };
-        initial_pane.* = try Pane.spawn(allocator, initial_pty_rows, config.cols, &xa, cwd_ptr, config.scrollback_lines);
+        initial_pane.* = try Pane.spawn(allocator, initial_pty_rows, initial_pty_cols, &xa, cwd_ptr, config.scrollback_lines);
     } else {
-        initial_pane.* = try Pane.spawn(allocator, initial_pty_rows, config.cols, spawn_argv, cwd_ptr, config.scrollback_lines);
+        initial_pane.* = try Pane.spawn(allocator, initial_pty_rows, initial_pty_cols, spawn_argv, cwd_ptr, config.scrollback_lines);
     }
 
     // Show visible error in terminal when xyron was enabled but detection failed.
@@ -613,7 +644,7 @@ pub fn run(
             if (layout_codec.deserialize(heap_sc.layout_buf[0..heap_sc.layout_len])) |info| {
                 if (info.tab_count > 0) {
                     tab_mgr.reset(); // tear down initial pane
-                    tab_mgr.reconstructFromLayout(&info, initial_pty_rows, config.cols, config.scrollback_lines) catch {
+                    tab_mgr.reconstructFromLayout(&info, initial_pty_rows, initial_pty_cols, config.scrollback_lines) catch {
                         logging.err("session", "layout reconstruction failed", .{});
                     };
                     if (tab_mgr.count > 0) {
@@ -688,9 +719,13 @@ pub fn run(
     defer allocator.free(scratch_cells);
 
     const active_eng = &tab_mgr.activePane().engine;
-    const total: usize = @as(usize, initial_pty_rows) * @as(usize, config.cols);
-    publish.fillCells(render_cells[0..total], active_eng, total, &initial_theme, null);
-    c.attyx_set_cursor(@intCast(active_eng.state.cursor.row + @as(usize, @intCast(g_grid_top_offset))), @intCast(active_eng.state.cursor.col));
+    const total: usize = @as(usize, config.rows) * @as(usize, config.cols);
+    const left_off_u16: u16 = @intCast(@max(0, g_grid_left_offset));
+    publish.fillCellsStrideAt(render_cells[0..total], active_eng, &initial_theme, config.cols, left_off_u16, null);
+    c.attyx_set_cursor(
+        @intCast(active_eng.state.cursor.row + @as(usize, @intCast(g_grid_top_offset))),
+        @intCast(active_eng.state.cursor.col + left_off_u16),
+    );
 
     var session = try SessionLog.init(allocator);
     defer session.deinit();

--- a/src/app/terminal_windows.zig
+++ b/src/app/terminal_windows.zig
@@ -96,6 +96,8 @@ pub fn run(
     ws.g_native_tabs_enabled = if (config.tab_appearance == .native) @as(i32, 1) else @as(i32, 0);
     ws.g_tab_always_show = if (config.tab_always_show) @as(i32, 1) else @as(i32, 0);
     ws.g_tab_dim_unfocused = if (config.tab_dim_unfocused) @as(i32, 1) else @as(i32, 0);
+    // Vertical side tabs: not implemented on Windows yet — force off.
+    ws.g_tab_side = 0;
 
     // Theme setup
     var theme_registry = ThemeRegistry.init(allocator);

--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -399,28 +399,34 @@ pub fn switchActiveTab(ctx: *PtyThreadCtx) void {
     var cursor_row: usize = 0;
     var cursor_col: usize = 0;
 
+    const left_off_u16: u16 = @intCast(@max(0, terminal.g_grid_left_offset));
+    const right_off_u16: u16 = @intCast(@max(0, terminal.g_grid_right_offset));
+    const eng_cols: u16 = grid_cols -| left_off_u16 -| right_off_u16;
+
     if (layout.pane_count > 1 and !layout.isZoomed()) {
         const pty_rows: u16 = @intCast(@max(1, @as(i32, grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
-        split_render.fillCellsSplit(
+        split_render.fillCellsSplitAt(
             @ptrCast(ctx.scratch_cells),
             layout,
             pty_rows,
+            eng_cols,
             grid_cols,
+            left_off_u16,
             &ctx.active_theme,
         );
         const rect = layout.pool[layout.focused].rect;
         const eng = &pane.engine;
         const vp_cur = @min(eng.state.viewport_offset, eng.state.ring.scrollbackCount());
         cursor_row = eng.state.cursor.row + vp_cur + rect.row + @as(usize, @intCast(terminal.g_grid_top_offset));
-        cursor_col = eng.state.cursor.col + rect.col;
+        cursor_col = eng.state.cursor.col + rect.col + left_off_u16;
     } else {
         const bg_cell = publish.bgCell(&ctx.active_theme);
         @memset(scratch, bg_cell);
         const eng = &pane.engine;
-        publish.fillCellsStride(scratch, eng, &ctx.active_theme, grid_cols, null);
+        publish.fillCellsStrideAt(scratch, eng, &ctx.active_theme, grid_cols, left_off_u16, null);
         const vp_cur = @min(eng.state.viewport_offset, eng.state.ring.scrollbackCount());
         cursor_row = eng.state.cursor.row + vp_cur + @as(usize, @intCast(terminal.g_grid_top_offset));
-        cursor_col = eng.state.cursor.col;
+        cursor_col = eng.state.cursor.col + left_off_u16;
         eng.state.dirty.clear();
     }
 

--- a/src/app/ui/copy_mode.zig
+++ b/src/app/ui/copy_mode.zig
@@ -51,7 +51,7 @@ pub export fn attyx_copy_mode_enter() void {
     state = .{
         .mode = .navigate,
         .cursor_row = c.g_cursor_row - c.g_grid_top_offset - pr,
-        .cursor_col = c.g_cursor_col - pc,
+        .cursor_col = c.g_cursor_col - c.g_grid_left_offset - pc,
         .pane_row = pr,
         .pane_col = pc,
         .pane_rows = if (c.g_pane_rect_rows > 0) c.g_pane_rect_rows else getVisibleRows(),

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -140,10 +140,11 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                     ctx.grid_rows = @intCast(rr);
                     ctx.grid_cols = @intCast(rc);
                     const pty_rows: u16 = @intCast(@max(1, rr - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
-                    ctx.tab_mgr.resizeAll(pty_rows, @intCast(rc));
+                    const pty_cols: u16 = @intCast(@max(1, rc - terminal.g_grid_left_offset - terminal.g_grid_right_offset));
+                    ctx.tab_mgr.resizeAll(pty_rows, pty_cols);
                     // Send TIOCSWINSZ immediately so the shell starts at the
                     // correct size — no debounce during startup.
-                    startup_pane.pty.resize(pty_rows, @intCast(rc)) catch {};
+                    startup_pane.pty.resize(pty_rows, pty_cols) catch {};
                     startup_pane.pending_pty_resize = false;
                     c.attyx_set_grid_size(rc, rr);
                 }
@@ -162,12 +163,15 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
         // Publish whatever the engine has to the cell buffer.
         {
             const eng = &startup_pane.engine;
-            const total = eng.state.ring.screen_rows * eng.state.ring.cols;
+            const left_off_u16: u16 = @intCast(@max(0, terminal.g_grid_left_offset));
+            const grid_total: usize = @as(usize, ctx.grid_rows) * @as(usize, ctx.grid_cols);
             c.attyx_begin_cell_update();
-            publish.fillCells(ctx.cells[0..total], eng, total, &ctx.active_theme, null);
+            const bg_cell = publish.bgCell(&ctx.active_theme);
+            @memset(ctx.cells[0..grid_total], bg_cell);
+            publish.fillCellsStrideAt(ctx.cells[0..grid_total], eng, &ctx.active_theme, ctx.grid_cols, left_off_u16, null);
             c.attyx_set_cursor(
                 @intCast(eng.state.cursor.row + @as(usize, @intCast(terminal.g_grid_top_offset))),
-                @intCast(eng.state.cursor.col),
+                @intCast(eng.state.cursor.col + left_off_u16),
             );
             c.attyx_mark_all_dirty();
             eng.state.dirty.clear();
@@ -198,12 +202,15 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
             }
             // Publish whatever we got
             const eng = &startup_pane.engine;
-            const total = eng.state.ring.screen_rows * eng.state.ring.cols;
+            const left_off_u16: u16 = @intCast(@max(0, terminal.g_grid_left_offset));
+            const grid_total: usize = @as(usize, ctx.grid_rows) * @as(usize, ctx.grid_cols);
             c.attyx_begin_cell_update();
-            publish.fillCells(ctx.cells[0..total], eng, total, &ctx.active_theme, null);
+            const bg_cell = publish.bgCell(&ctx.active_theme);
+            @memset(ctx.cells[0..grid_total], bg_cell);
+            publish.fillCellsStrideAt(ctx.cells[0..grid_total], eng, &ctx.active_theme, ctx.grid_cols, left_off_u16, null);
             c.attyx_set_cursor(
                 @intCast(eng.state.cursor.row + @as(usize, @intCast(terminal.g_grid_top_offset))),
-                @intCast(eng.state.cursor.col),
+                @intCast(eng.state.cursor.col + left_off_u16),
             );
             c.attyx_mark_all_dirty();
             eng.state.dirty.clear();
@@ -484,6 +491,58 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                     ctx.tab_mgr.switchTo(idx);
                     actions.switchActiveTab(ctx);
                 }
+            }
+        }
+
+        // Sidebar drag-resize: apply any pending width and persist on release.
+        if (terminal.g_tab_side != 0) {
+            const dragging = @atomicLoad(i32, &input.g_sidebar_drag_active, .seq_cst) != 0;
+            const pending = @atomicLoad(i32, &input.g_sidebar_drag_pending_width, .seq_cst);
+            if ((dragging or pending != 0) and pending > 0) {
+                const cur = @atomicLoad(i32, &terminal.g_tab_side_width, .seq_cst);
+                if (pending != cur) {
+                    @atomicStore(i32, &terminal.g_tab_side_width, pending, .seq_cst);
+                    // Recompute offsets, resize all pane engines, and flush
+                    // the pending TIOCSWINSZ → SIGWINCH so the shell reflows
+                    // live. handleResize() normally does this for OS-level
+                    // window resizes; sidebar drag bypasses that path.
+                    publish.updateGridOffsets(ctx);
+                    for (ctx.tab_mgr.tabs[0..ctx.tab_mgr.count]) |*maybe_layout| {
+                        if (maybe_layout.*) |*lay| {
+                            var sd_leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
+                            const sd_count = lay.collectLeaves(&sd_leaves);
+                            for (sd_leaves[0..sd_count]) |fleaf| {
+                                const was_pending = fleaf.pane.pending_pty_resize;
+                                const pr = fleaf.pane.pending_pty_rows;
+                                const pc = fleaf.pane.pending_pty_cols;
+                                fleaf.pane.flushPtyResize();
+                                if (was_pending and !fleaf.pane.pending_pty_resize) {
+                                    if (fleaf.pane.daemon_pane_id) |dpid| {
+                                        if (ctx.session_client) |sc| {
+                                            sc.sendPaneResize(dpid, pr, pc) catch {};
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    actions.g_force_full_redraw = true;
+                }
+            }
+            const release = @atomicRmw(i32, &input.g_sidebar_drag_release_pending, .Xchg, 0, .seq_cst);
+            if (release != 0) {
+                // Persist the actually-applied (clamped) width, not the raw
+                // drag value, so a runaway drag past the half-cap doesn't
+                // serialize a useless huge number.
+                const applied: i32 = if (terminal.g_tab_side == 1)
+                    terminal.g_grid_left_offset
+                else
+                    terminal.g_grid_right_offset;
+                if (applied > 0) {
+                    @atomicStore(i32, &terminal.g_tab_side_width, applied, .seq_cst);
+                    @import("../session_connect.zig").saveSidebarWidth(@intCast(applied));
+                }
+                @atomicStore(i32, &input.g_sidebar_drag_pending_width, 0, .seq_cst);
             }
         }
 
@@ -1098,11 +1157,16 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                 // multiple non-atomic global writes (g_pane_rect_*) span the
                 // begin/end window.
                 const scratch_total: usize = @as(usize, ctx.grid_rows) * @as(usize, ctx.grid_cols);
-                split_render.fillCellsSplit(
+                const split_left_off: u16 = @intCast(@max(0, terminal.g_grid_left_offset));
+                const split_right_off: u16 = @intCast(@max(0, terminal.g_grid_right_offset));
+                const split_eng_cols: u16 = ctx.grid_cols -| split_left_off -| split_right_off;
+                split_render.fillCellsSplitAt(
                     @ptrCast(ctx.scratch_cells),
                     layout,
                     pty_rows,
+                    split_eng_cols,
                     ctx.grid_cols,
+                    split_left_off,
                     &ctx.active_theme,
                 );
                 c.attyx_begin_cell_update();
@@ -1116,17 +1180,21 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                 const vp_cur = @min(eng.state.viewport_offset, eng.state.ring.scrollbackCount());
                 c.attyx_set_cursor(
                     @intCast(eng.state.cursor.row + vp_cur + rect.row + @as(usize, @intCast(terminal.g_grid_top_offset))),
-                    @intCast(eng.state.cursor.col + rect.col),
+                    @intCast(eng.state.cursor.col + rect.col + split_left_off),
                 );
                 c.attyx_mark_all_dirty();
                 actions.g_force_full_redraw = false;
             } else {
+                const left_off: i32 = terminal.g_grid_left_offset;
+                const right_off: i32 = terminal.g_grid_right_offset;
                 const pty_rows_s: i32 = @max(1, @as(i32, ctx.grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset);
+                const pty_cols_s: i32 = @max(1, @as(i32, ctx.grid_cols) - left_off - right_off);
                 terminal.g_pane_rect_row = 0;
                 terminal.g_pane_rect_col = 0;
                 terminal.g_pane_rect_rows = pty_rows_s;
-                terminal.g_pane_rect_cols = @intCast(ctx.grid_cols);
+                terminal.g_pane_rect_cols = pty_cols_s;
                 const eng = publish.ctxEngine(ctx);
+                const left_off_u16: u16 = @intCast(@max(0, left_off));
                 // Force full redraw when frames were throttled during rapid
                 // output — incremental dirty tracking may miss rows when
                 // the engine processes many screenfuls between publishes.
@@ -1143,9 +1211,17 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                     const scratch_total: usize = @as(usize, ctx.grid_rows) * @as(usize, ctx.grid_cols);
                     const bg_cell = publish.bgCell(&ctx.active_theme);
                     @memset(ctx.scratch_cells[0..scratch_total], bg_cell);
-                    publish.fillCellsStride(ctx.scratch_cells[0..scratch_total], eng, &ctx.active_theme, ctx.grid_cols, null);
+                    publish.fillCellsStrideAt(ctx.scratch_cells[0..scratch_total], eng, &ctx.active_theme, ctx.grid_cols, left_off_u16, null);
                     c.attyx_begin_cell_update();
                     @memcpy(ctx.cells[0..scratch_total], ctx.scratch_cells[0..scratch_total]);
+                } else if (left_off_u16 != 0 or right_off > 0) {
+                    // Side tabs reserve gutter columns; partial dirty must use
+                    // the grid stride + left offset so engine cells land in
+                    // the right place. The gutter cells stay as the bg fill
+                    // from the last full redraw.
+                    c.attyx_begin_cell_update();
+                    const live_total: usize = @as(usize, ctx.grid_rows) * @as(usize, ctx.grid_cols);
+                    publish.fillCellsStrideAt(ctx.cells[0..live_total], eng, &ctx.active_theme, ctx.grid_cols, left_off_u16, &eng.state.dirty);
                 } else {
                     c.attyx_begin_cell_update();
                     const total = eng.state.ring.screen_rows * eng.state.ring.cols;
@@ -1155,7 +1231,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                 const vp_cur = @min(eng.state.viewport_offset, eng.state.ring.scrollbackCount());
                 c.attyx_set_cursor(
                     @intCast(eng.state.cursor.row + vp_cur + @as(usize, @intCast(terminal.g_grid_top_offset))),
-                    @intCast(eng.state.cursor.col),
+                    @intCast(eng.state.cursor.col + left_off_u16),
                 );
                 if (full_redraw) {
                     c.attyx_mark_all_dirty();

--- a/src/app/ui/input.zig
+++ b/src/app/ui/input.zig
@@ -220,6 +220,8 @@ const statusbar_mod = @import("../statusbar.zig");
 
 pub fn statusbarTabClick(col: c_int, grid_cols: c_int) void {
     if (terminal.g_statusbar_visible == 0) return;
+    // Side tabs hijack the tab section, so the statusbar doesn't render any.
+    if (terminal.g_tab_side != 0) return;
     const offset = statusbar_mod.tab_col_offset;
     if (col < offset) return;
     const adjusted_col: u16 = @intCast(@as(c_uint, @bitCast(col)) -| offset);
@@ -230,6 +232,44 @@ pub fn statusbarTabClick(col: c_int, grid_cols: c_int) void {
         remaining,
     ) orelse return;
     @atomicStore(i32, &g_tab_click_index, @as(i32, idx), .seq_cst);
+    wake();
+}
+
+pub fn sideTabClick(row: c_int, grid_rows: c_int) void {
+    _ = grid_rows;
+    if (terminal.g_tab_side == 0) return;
+    if (row < 0) return;
+    const idx = tab_bar_mod.tabIndexAtRow(
+        @intCast(row),
+        @intCast(@atomicLoad(i32, &terminal.g_tab_count, .seq_cst)),
+    ) orelse return;
+    @atomicStore(i32, &g_tab_click_index, @as(i32, idx), .seq_cst);
+    wake();
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar resize drag — input thread writes pending width; PTY thread polls
+// each frame, applies via updateGridOffsets, and persists on drag end.
+// ---------------------------------------------------------------------------
+
+pub var g_sidebar_drag_active: i32 = 0;
+pub var g_sidebar_drag_pending_width: i32 = 0;
+pub var g_sidebar_drag_release_pending: i32 = 0;
+
+pub fn sidebarDragStart() void {
+    @atomicStore(i32, &g_sidebar_drag_pending_width, 0, .seq_cst);
+    @atomicStore(i32, &g_sidebar_drag_active, 1, .seq_cst);
+}
+
+pub fn sidebarDragUpdate(width: c_int) void {
+    if (@atomicLoad(i32, &g_sidebar_drag_active, .seq_cst) == 0) return;
+    @atomicStore(i32, &g_sidebar_drag_pending_width, width, .seq_cst);
+    wake();
+}
+
+pub fn sidebarDragEnd() void {
+    @atomicStore(i32, &g_sidebar_drag_active, 0, .seq_cst);
+    @atomicStore(i32, &g_sidebar_drag_release_pending, 1, .seq_cst);
     wake();
 }
 

--- a/src/app/ui/publish.zig
+++ b/src/app/ui/publish.zig
@@ -324,6 +324,7 @@ pub fn viewportInfoFromCtx(ctx: *PtyThreadCtx) overlay_anchor.ViewportInfo {
     const pane_row: u16 = if (in_split) @intCast(layout.pool[layout.focused].rect.row) else 0;
     const pane_col: u16 = if (in_split) @intCast(layout.pool[layout.focused].rect.col) else 0;
     const top_offset: u16 = @intCast(terminal.g_grid_top_offset);
+    const left_offset: u16 = @intCast(terminal.g_grid_left_offset);
 
     return .{
         .grid_cols = @intCast(eng.state.ring.cols),
@@ -335,7 +336,7 @@ pub fn viewportInfoFromCtx(ctx: *PtyThreadCtx) overlay_anchor.ViewportInfo {
         .sel_end_col = if (sel_end_col_raw >= 0) @intCast(@as(u32, @bitCast(sel_end_col_raw))) else 0,
         .alt_active = eng.state.alt_active,
         .offset_row = pane_row + top_offset,
-        .offset_col = pane_col,
+        .offset_col = pane_col + left_offset,
     };
 }
 
@@ -364,6 +365,7 @@ pub fn viewportInfoForPane(ctx: *PtyThreadCtx, pane_id: u32) ?overlay_anchor.Vie
     const pane_row: u16 = if (in_split) @intCast(layout.pool[idx].rect.row) else 0;
     const pane_col: u16 = if (in_split) @intCast(layout.pool[idx].rect.col) else 0;
     const top_offset: u16 = @intCast(terminal.g_grid_top_offset);
+    const left_offset: u16 = @intCast(terminal.g_grid_left_offset);
 
     const st = &pane.engine.state;
     return .{
@@ -376,7 +378,7 @@ pub fn viewportInfoForPane(ctx: *PtyThreadCtx, pane_id: u32) ?overlay_anchor.Vie
         .sel_end_col = 0,
         .alt_active = st.alt_active,
         .offset_row = pane_row + top_offset,
-        .offset_col = pane_col,
+        .offset_col = pane_col + left_offset,
     };
 }
 
@@ -648,12 +650,28 @@ pub fn fillCellsStride(
     stride: u16,
     dirty: ?*const DirtyRows,
 ) void {
+    fillCellsStrideAt(cells, eng, theme, stride, 0, dirty);
+}
+
+/// Like `fillCellsStride`, but writes engine cells starting at column
+/// `col_offset` within each buffer row. Used when vertical side tabs
+/// reserve the leftmost N columns of the displayed grid.
+pub fn fillCellsStrideAt(
+    cells: []c.AttyxCell,
+    eng: *Engine,
+    theme: *const Theme,
+    stride: u16,
+    col_offset: u16,
+    dirty: ?*const DirtyRows,
+) void {
     const vp = eng.state.viewport_offset;
     const cols = eng.state.ring.cols;
     const rows = eng.state.ring.screen_rows;
     const wrapped: *volatile [c.ATTYX_MAX_ROWS]u8 = @ptrCast(&c.g_row_wrapped);
     const stride_usize: usize = stride;
-    const cols_to_copy = @min(@as(usize, cols), stride_usize);
+    const off: usize = col_offset;
+    const remaining: usize = if (off >= stride_usize) 0 else stride_usize - off;
+    const cols_to_copy = @min(@as(usize, cols), remaining);
 
     for (0..rows) |row| {
         const row_cells = eng.state.ring.viewportRow(vp, row);
@@ -661,7 +679,7 @@ pub fn fillCellsStride(
         if (dirty) |d| {
             if (!d.isDirty(row)) continue;
         }
-        const base = row * stride_usize;
+        const base = row * stride_usize + off;
         for (0..cols_to_copy) |col| {
             cells[base + col] = cellToAttyxCell(row_cells[col], theme);
         }
@@ -691,15 +709,30 @@ pub fn statusbarActive(ctx: *PtyThreadCtx) bool {
 }
 
 /// Centralized offset calculation for tab bar, search bar, and statusbar.
-/// Resizes panes when the total consumed rows change.
+/// Resizes panes when the total consumed rows or columns change.
 pub fn updateGridOffsets(ctx: *PtyThreadCtx) void {
-    const old_total = terminal.g_grid_top_offset + terminal.g_grid_bottom_offset;
+    const old_top = terminal.g_grid_top_offset;
+    const old_bottom = terminal.g_grid_bottom_offset;
+    const old_left = terminal.g_grid_left_offset;
+    const old_right = terminal.g_grid_right_offset;
     var top: i32 = 0;
     var bottom: i32 = 0;
+    var left: i32 = 0;
+    var right: i32 = 0;
     const sb_active = statusbarActive(ctx);
     const native_tabs = (terminal.g_native_tabs_enabled != 0);
     const always_show = (terminal.g_tab_always_show != 0);
     const search_active = (@as(i32, @bitCast(c.g_search_active)) != 0);
+    const tab_side = terminal.g_tab_side; // 0=top, 1=left, 2=right
+    const side_active = !native_tabs and tab_side != 0;
+
+    // Side tab bar: reserves left/right columns whenever configured.
+    // Persistent reservation (no flicker) — user opted in by setting tabs.side.
+    if (side_active and ctx.grid_cols > 0) {
+        const req: u16 = @intCast(@max(0, terminal.g_tab_side_width));
+        const w: i32 = @intCast(tab_bar_mod.sideBarWidthRequested(ctx.grid_cols, req));
+        if (tab_side == 1) left = w else right = w;
+    }
 
     // Bottom row: statusbar at bottom (unaffected by search)
     if (sb_active) {
@@ -715,14 +748,15 @@ pub fn updateGridOffsets(ctx: *PtyThreadCtx) void {
         terminal.g_statusbar_visible = 0;
     }
 
-    // Top row: search > statusbar-top > tab bar (mutually exclusive)
+    // Top row: search > statusbar-top > horizontal tab bar (mutually exclusive).
+    // When side tabs are active, the top horizontal tab bar is suppressed.
     if (search_active) {
         top += 1;
         terminal.g_tab_bar_visible = 0;
     } else if (sb_active and ctx.statusbar.?.config.position == .top) {
         top += 1;
         // tab_bar_visible already 0 from above
-    } else if (!sb_active and !native_tabs) {
+    } else if (!sb_active and !native_tabs and !side_active) {
         const show_builtin = (ctx.tab_mgr.count > 1) or always_show;
         if (show_builtin) top += 1;
         terminal.g_tab_bar_visible = if (show_builtin) @as(i32, 1) else @as(i32, 0);
@@ -731,11 +765,20 @@ pub fn updateGridOffsets(ctx: *PtyThreadCtx) void {
     }
     terminal.g_grid_top_offset = top;
     terminal.g_grid_bottom_offset = bottom;
+    terminal.g_grid_left_offset = left;
+    terminal.g_grid_right_offset = right;
     @atomicStore(i32, &terminal.g_tab_count, @as(i32, ctx.tab_mgr.count), .seq_cst);
-    const new_total = top + bottom;
-    if (new_total != old_total and ctx.grid_rows > 0) {
-        const pty_rows = @as(u16, @intCast(@max(1, @as(i32, ctx.grid_rows) - new_total)));
-        ctx.tab_mgr.resizeAll(pty_rows, ctx.grid_cols);
+
+    const changed = (top != old_top) or (bottom != old_bottom) or
+        (left != old_left) or (right != old_right);
+    if (changed and ctx.grid_rows > 0 and ctx.grid_cols > 0) {
+        const pty_rows = @as(u16, @intCast(@max(1, @as(i32, ctx.grid_rows) - top - bottom)));
+        const pty_cols = @as(u16, @intCast(@max(1, @as(i32, ctx.grid_cols) - left - right)));
+        ctx.tab_mgr.resizeAll(pty_rows, pty_cols);
+        // Layout changed — force a full-buffer recompose so the gutter
+        // columns get refilled with bg cells before the side tab overlay
+        // paints on top.
+        @import("actions.zig").g_force_full_redraw = true;
     }
 }
 pub const updateGridTopOffset = updateGridOffsets;
@@ -804,7 +847,8 @@ fn computeZoomedTabs(ctx: *PtyThreadCtx) u16 {
     return mask;
 }
 
-/// Generate the tab bar overlay (only visible when count > 1 and statusbar is not active).
+/// Generate the tab bar overlay (horizontal on top by default, vertical on
+/// the side when `tabs.side` is configured).
 pub fn generateTabBar(ctx: *PtyThreadCtx) void {
     const mgr = ctx.overlay_mgr orelse return;
 
@@ -814,20 +858,24 @@ pub fn generateTabBar(ctx: *PtyThreadCtx) void {
         return;
     }
 
-    // When statusbar is active, tabs are rendered inside the statusbar overlay
-    if (statusbarActive(ctx)) {
-        if (mgr.isVisible(.tab_bar)) mgr.hide(.tab_bar);
-        return;
-    }
+    const tab_side = terminal.g_tab_side; // 0=top, 1=left, 2=right
+    const side_active = (tab_side != 0);
 
-    // Search takes priority for the top row — yield while it's active
-    if (@as(i32, @bitCast(c.g_search_active)) != 0) {
-        if (mgr.isVisible(.tab_bar)) mgr.hide(.tab_bar);
-        return;
+    // Horizontal tab bar yields to statusbar / search; the vertical side
+    // tab bar coexists with both — it lives outside the top/bottom area.
+    if (!side_active) {
+        if (statusbarActive(ctx)) {
+            if (mgr.isVisible(.tab_bar)) mgr.hide(.tab_bar);
+            return;
+        }
+        if (@as(i32, @bitCast(c.g_search_active)) != 0) {
+            if (mgr.isVisible(.tab_bar)) mgr.hide(.tab_bar);
+            return;
+        }
     }
 
     const always_show = (terminal.g_tab_always_show != 0);
-    if (ctx.tab_mgr.count <= 1 and !always_show) {
+    if (!side_active and ctx.tab_mgr.count <= 1 and !always_show) {
         if (mgr.isVisible(.tab_bar)) {
             mgr.hide(.tab_bar);
         }
@@ -839,7 +887,6 @@ pub fn generateTabBar(ctx: *PtyThreadCtx) void {
     var name_bufs: [tab_bar_mod.max_tabs][256]u8 = undefined;
     resolveTabTitles(ctx, &titles, &statuses, &name_bufs);
 
-    var tab_cells: [512]overlay_mod.StyledCell = undefined;
     const zoomed_tabs = computeZoomedTabs(ctx);
     const tbg = ctx.active_theme.background;
     const tfg = ctx.active_theme.foreground;
@@ -854,6 +901,13 @@ pub fn generateTabBar(ctx: *PtyThreadCtx) void {
             return @intCast((@as(u16, bg_c) * 13 + @as(u16, fg_c) * 7) / 20);
         }
     }.m;
+    // Dim border for the side bar separator: blend bg ~85% toward fg for a
+    // subtle line that's visible but not distracting.
+    const mix_border = struct {
+        fn m(bg_c: u8, fg_c: u8) u8 {
+            return @intCast((@as(u16, bg_c) * 17 + @as(u16, fg_c) * 3) / 20);
+        }
+    }.m;
     const tab_style = tab_bar_mod.Style{
         .tab_bg = .{ .r = mix20(tbg.r, tfg.r), .g = mix20(tbg.g, tfg.g), .b = mix20(tbg.b, tfg.b) },
         .active_tab_bg = .{ .r = mix35(tbg.r, tfg.r), .g = mix35(tbg.g, tfg.g), .b = mix35(tbg.b, tfg.b) },
@@ -861,7 +915,54 @@ pub fn generateTabBar(ctx: *PtyThreadCtx) void {
         .active_fg = .{ .r = tfg.r, .g = tfg.g, .b = tfg.b },
         .num_highlight_bg = .{ .r = tfg.r / 2, .g = tfg.g / 2, .b = tfg.b / 2 },
         .num_highlight_fg = .{ .r = tfg.r, .g = tfg.g, .b = tfg.b },
+        .border_fg = .{ .r = mix_border(tbg.r, tfg.r), .g = mix_border(tbg.g, tfg.g), .b = mix_border(tbg.b, tfg.b) },
+        // Side tabs sit on the reserved gutter and should be fully opaque so
+        // nothing bleeds through; the horizontal bar keeps the historical 230.
+        .bg_alpha = if (side_active) @as(u8, 255) else @as(u8, 230),
     };
+
+    if (side_active) {
+        const req_w: u16 = @intCast(@max(0, terminal.g_tab_side_width));
+        const width: u16 = tab_bar_mod.sideBarWidthRequested(ctx.grid_cols, req_w);
+        if (width == 0 or ctx.grid_rows == 0) {
+            if (mgr.isVisible(.tab_bar)) mgr.hide(.tab_bar);
+            return;
+        }
+        // Side bar lives outside the statusbar/search rows: it starts after
+        // any top reservation and ends before any bottom reservation.
+        const top_off: u16 = @intCast(@max(0, terminal.g_grid_top_offset));
+        const bot_off: u16 = @intCast(@max(0, terminal.g_grid_bottom_offset));
+        const avail_h: u16 = ctx.grid_rows -| top_off -| bot_off;
+        if (avail_h == 0) {
+            if (mgr.isVisible(.tab_bar)) mgr.hide(.tab_bar);
+            return;
+        }
+        // Stack-side buffer must hold width × height. Cap at the overlay
+        // limit so we never exceed what the C bridge can publish.
+        const max_cells: usize = @intCast(c.ATTYX_OVERLAY_MAX_CELLS);
+        var v_cells: [c.ATTYX_OVERLAY_MAX_CELLS]overlay_mod.StyledCell = undefined;
+        const max_h_for_buf: u16 = @intCast(max_cells / @as(usize, width));
+        const height: u16 = @min(avail_h, max_h_for_buf);
+        const left_side = (tab_side == 1);
+        const result = tab_bar_mod.generateVertical(
+            v_cells[0 .. @as(usize, width) * @as(usize, height)],
+            ctx.tab_mgr.count,
+            ctx.tab_mgr.active,
+            width,
+            height,
+            tab_style,
+            &titles,
+            zoomed_tabs,
+            &statuses,
+            left_side, // border on right edge for left-side bars
+        ) orelse return;
+        const place_col: u16 = if (left_side) 0 else ctx.grid_cols -| width;
+        mgr.setContent(.tab_bar, place_col, top_off, result.width, result.height, result.cells) catch return;
+        if (!mgr.isVisible(.tab_bar)) mgr.show(.tab_bar);
+        return;
+    }
+
+    var tab_cells: [512]overlay_mod.StyledCell = undefined;
     const result = tab_bar_mod.generate(
         &tab_cells,
         ctx.tab_mgr.count,
@@ -949,7 +1050,11 @@ pub fn generateStatusbar(ctx: *PtyThreadCtx) void {
         .bg_alpha = sb.config.background_opacity,
     };
     // When native tabs are active, hide the tab section in the statusbar.
-    const sb_tab_count: u8 = if (terminal.g_native_tabs_enabled != 0) 0 else ctx.tab_mgr.count;
+    // When a side tab bar is active, the statusbar gives up its tab section
+    // to the side bar (the side bar starts below the statusbar row, so the
+    // statusbar is free to span the full window width).
+    const side_active = (terminal.g_tab_side != 0);
+    const sb_tab_count: u8 = if (terminal.g_native_tabs_enabled != 0 or side_active) 0 else ctx.tab_mgr.count;
     const zoomed_tabs = computeZoomedTabs(ctx);
     const result = statusbar_mod.generate(&sb_cells, sb, sb_tab_count, ctx.tab_mgr.active, ctx.grid_cols, sb_style, &titles, zoomed_tabs, &statuses) orelse return;
 

--- a/src/app/ui/resize.zig
+++ b/src/app/ui/resize.zig
@@ -35,6 +35,9 @@ pub fn handleResize(ctx: *PtyThreadCtx, buf: []u8) void {
     ctx.tab_mgr.updateGaps(gaps.h, gaps.v);
 
     const pty_rows: u16 = @intCast(@max(1, rr - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));
+    const pty_cols_i: i32 = @max(1, rc - terminal.g_grid_left_offset - terminal.g_grid_right_offset);
+    const pty_cols: u16 = @intCast(pty_cols_i);
+    const left_off_u16: u16 = @intCast(@max(0, terminal.g_grid_left_offset));
 
     // Drain in-flight daemon data at the OLD grid size for the active
     // pane BEFORE resizing.  Old-size output must be processed
@@ -58,7 +61,7 @@ pub fn handleResize(ctx: *PtyThreadCtx, buf: []u8) void {
         }
     }
 
-    ctx.tab_mgr.resizeAll(pty_rows, @intCast(rc));
+    ctx.tab_mgr.resizeAll(pty_rows, pty_cols);
 
     // Forward resize to each session-backed pane on the daemon.
     // Only send when the local debounce fires (pending_pty_resize is false)
@@ -100,27 +103,31 @@ pub fn handleResize(ctx: *PtyThreadCtx, buf: []u8) void {
     c.attyx_begin_cell_update();
     const resize_layout = ctx.tab_mgr.activeLayout();
     if (resize_layout.pane_count > 1 and !resize_layout.isZoomed()) {
-        split_render.fillCellsSplit(
+        split_render.fillCellsSplitAt(
             @ptrCast(ctx.cells),
             resize_layout,
             pty_rows,
+            pty_cols,
             @intCast(rc),
+            left_off_u16,
             &ctx.active_theme,
         );
         const resize_rect = resize_layout.pool[resize_layout.focused].rect;
         const vp_cur = @min(publish.ctxEngine(ctx).state.viewport_offset, publish.ctxEngine(ctx).state.ring.scrollbackCount());
         c.attyx_set_cursor(
             @intCast(publish.ctxEngine(ctx).state.cursor.row + vp_cur + resize_rect.row + @as(usize, @intCast(terminal.g_grid_top_offset))),
-            @intCast(publish.ctxEngine(ctx).state.cursor.col + resize_rect.col),
+            @intCast(publish.ctxEngine(ctx).state.cursor.col + resize_rect.col + left_off_u16),
         );
         c.attyx_mark_all_dirty();
     } else {
-        const new_total = nr * nc;
-        publish.fillCells(ctx.cells[0..new_total], publish.ctxEngine(ctx), new_total, &ctx.active_theme, null);
+        const new_total: usize = @as(usize, @intCast(rr)) * @as(usize, @intCast(rc));
+        const bg_cell = publish.bgCell(&ctx.active_theme);
+        @memset(ctx.cells[0..new_total], bg_cell);
+        publish.fillCellsStrideAt(ctx.cells[0..new_total], publish.ctxEngine(ctx), &ctx.active_theme, @intCast(rc), left_off_u16, null);
         const vp_cur = @min(publish.ctxEngine(ctx).state.viewport_offset, publish.ctxEngine(ctx).state.ring.scrollbackCount());
         c.attyx_set_cursor(
             @intCast(publish.ctxEngine(ctx).state.cursor.row + vp_cur + @as(usize, @intCast(terminal.g_grid_top_offset))),
-            @intCast(publish.ctxEngine(ctx).state.cursor.col),
+            @intCast(publish.ctxEngine(ctx).state.cursor.col + left_off_u16),
         );
         c.attyx_set_dirty(&publish.ctxEngine(ctx).state.dirty.bits);
     }

--- a/src/app/windows_stubs.zig
+++ b/src/app/windows_stubs.zig
@@ -342,6 +342,16 @@ export fn attyx_statusbar_tab_click(col: c_int, grid_cols: c_int) void {
         @atomicStore(i32, &tab_click_index, idx, .seq_cst);
 }
 
+export fn attyx_side_tab_click(row: c_int, grid_rows: c_int) void {
+    _ = row;
+    _ = grid_rows;
+    // Windows port: vertical tabs not yet implemented.
+}
+
+export fn attyx_sidebar_drag_start() void {}
+export fn attyx_sidebar_drag_update(width: c_int) void { _ = width; }
+export fn attyx_sidebar_drag_end() void {}
+
 // ---------------------------------------------------------------------------
 // Splits — atomic action signals
 // ---------------------------------------------------------------------------
@@ -514,9 +524,13 @@ pub export var g_app_version_len: c_int = 0;
 
 pub export var g_grid_top_offset: i32 = 0;
 pub export var g_grid_bottom_offset: i32 = 0;
+pub export var g_grid_left_offset: i32 = 0;
+pub export var g_grid_right_offset: i32 = 0;
 pub export var g_statusbar_visible: i32 = 0;
 pub export var g_statusbar_position: i32 = 0;
 pub export var g_tab_bar_visible: i32 = 0;
+pub export var g_tab_side: i32 = 0;
+pub export var g_tab_side_width: i32 = 0;
 pub export var g_toggle_debug_overlay: i32 = 0;
 pub export var g_toggle_anchor_demo: i32 = 0;
 pub export var g_toggle_ai_demo: i32 = 0;

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -77,6 +77,21 @@ pub const TabAppearance = enum {
     }
 };
 
+/// Tab side: render the built-in tab bar vertically on the left / right edge.
+/// `.none` keeps the default horizontal placement.
+pub const TabSide = enum {
+    none,
+    left,
+    right,
+
+    pub fn fromString(s: []const u8) ?TabSide {
+        if (std.mem.eql(u8, s, "none")) return .none;
+        if (std.mem.eql(u8, s, "left")) return .left;
+        if (std.mem.eql(u8, s, "right")) return .right;
+        return null;
+    }
+};
+
 const keybinds = @import("keybinds.zig");
 pub const KeybindOverride = keybinds.KeybindOverride;
 pub const SequenceEntry = keybinds.SequenceEntry;
@@ -170,6 +185,7 @@ pub const AppConfig = struct {
     tab_appearance: TabAppearance = .builtin,
     tab_always_show: bool = false,
     tab_dim_unfocused: bool = false,
+    tab_side: TabSide = .none,
 
     // [sessions]
     sessions_enabled: bool = false,

--- a/src/config/config_parse.zig
+++ b/src/config/config_parse.zig
@@ -5,6 +5,7 @@ const AppConfig = config_mod.AppConfig;
 const CursorShapeConfig = config_mod.CursorShapeConfig;
 const CellSize = config_mod.CellSize;
 const TabAppearance = config_mod.TabAppearance;
+const TabSide = config_mod.TabSide;
 const PopupConfigEntry = config_mod.PopupConfigEntry;
 const KeybindOverride = config_mod.KeybindOverride;
 const SequenceEntry = config_mod.SequenceEntry;
@@ -383,6 +384,19 @@ pub fn applyToml(allocator: std.mem.Allocator, content: []const u8, path: []cons
             config.tab_dim_unfocused = v.bool;
         } else {
             std.debug.print("error: {s}: tabs.dim_unfocused must be a boolean\n", .{path});
+            return error.ConfigValidationError;
+        }
+    }
+    if (Lookup.get(root, "tabs", "side")) |v| {
+        if (v == .string) {
+            if (TabSide.fromString(v.string)) |side| {
+                config.tab_side = side;
+            } else {
+                std.debug.print("error: {s}: tabs.side must be \"none\", \"left\", or \"right\"\n", .{path});
+                return error.ConfigValidationError;
+            }
+        } else {
+            std.debug.print("error: {s}: tabs.side must be a string\n", .{path});
             return error.ConfigValidationError;
         }
     }

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -136,6 +136,12 @@
 # Dim inactive/unfocused tabs.  [restart]
 # dim_unfocused = false
 
+# Render tabs vertically on the side instead of horizontally on top.
+# Valid values: "none" (default — top), "left", "right". When set to
+# "left" or "right" the tab bar is always visible (independent of the
+# statusbar) and reserves up to 10% of the window width.  [live]
+# side = "none"
+
 
 # ── Splits ────────────────────────────────────────────────────────────
 

--- a/src/overlay/overlay.zig
+++ b/src/overlay/overlay.zig
@@ -135,6 +135,11 @@ pub const OverlayManager = struct {
         self.grid_cols = vp.grid_cols;
         self.grid_rows = vp.grid_rows;
 
+        // Full window bounds (vp.grid_* describes the engine's content area;
+        // overlays can extend into reserved gutter / statusbar rows).
+        const win_cols: u16 = vp.grid_cols + vp.offset_col;
+        const win_rows: u16 = vp.grid_rows + vp.offset_row;
+
         for (&self.layers) |*layer| {
             if (!layer.visible or layer.cells == null) continue;
 
@@ -149,16 +154,18 @@ pub const OverlayManager = struct {
                 layer.col = rect.col + vp.offset_col;
                 layer.row = rect.row + vp.offset_row;
             } else {
-                // Fallback: simple clamp
-                if (layer.width > vp.grid_cols) {
+                // Fallback: clamp against the FULL window so overlays anchored
+                // to the gutter (e.g. side tab bar) aren't pulled into the
+                // engine area on completion repositioning.
+                if (layer.width > win_cols) {
                     layer.col = 0;
-                } else if (layer.col + layer.width > vp.grid_cols) {
-                    layer.col = vp.grid_cols - layer.width;
+                } else if (layer.col + layer.width > win_cols) {
+                    layer.col = win_cols - layer.width;
                 }
-                if (layer.height > vp.grid_rows) {
+                if (layer.height > win_rows) {
                     layer.row = 0;
-                } else if (layer.row + layer.height > vp.grid_rows) {
-                    layer.row = vp.grid_rows - layer.height;
+                } else if (layer.row + layer.height > win_rows) {
+                    layer.row = win_rows - layer.height;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- New `tabs.side = "left" | "right"` config renders the built-in tab bar as a vertical column on the left or right edge of the window.
- The sidebar coexists with the statusbar (sits between top/bottom statusbars), is mouse-resizable by dragging its border, and persists its width across restarts in the XDG state dir.
- Engine cols become `grid_cols - left_gutter - right_gutter`; cell fill, selection, mouse reporting, cursor positioning, and split rendering all translate engine-relative coords through the gutter offset.

## Test plan

- [ ] `tabs.side = "left"` shows a vertical tab column on the left; clicking switches tabs
- [ ] `tabs.side = "right"` mirrors to the right edge
- [ ] Drag the inner border to resize; width persists after restart
- [ ] With top statusbar enabled, sidebar starts below it; with bottom statusbar, sidebar ends above it
- [ ] Cursor, selection, and mouse reporting land on correct cells (no off-by-gutter)
- [ ] Splits render and resize correctly with sidebar enabled
- [ ] `tabs.side = "none"` (default) preserves existing horizontal behavior