### PR TITLE
fix: resolve cwd from daemon for statusbar widgets

### DIFF
--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -327,7 +327,19 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
             for (ctx.active_theme.palette, 0..) |opt_color, i| {
                 if (opt_color) |p| sb.ansi_palette[i] = .{ .r = p.r, .g = p.g, .b = p.b };
             }
-            statusbar_refreshed = sb.tick(std.time.timestamp(), publish.ctxPty(ctx).master, publish.ctxEngine(ctx).state.working_directory);
+            // SSR-mode panes don't populate engine.state.working_directory
+            // because the daemon owns the parser. Fall back to the daemon's
+            // fg_cwd notification (raw path) and present it as a file:// URI
+            // so the widget paths (which expect URIs) handle it uniformly.
+            const sb_pane = ctx.tab_mgr.activePane();
+            var sb_cwd_buf: [@import("../statusbar.zig").max_output_len]u8 = undefined;
+            const sb_cwd: ?[]const u8 = blk: {
+                if (sb_pane.engine.state.working_directory) |uri| break :blk uri;
+                if (sb_pane.daemon_fg_cwd_len == 0) break :blk null;
+                const path = sb_pane.daemon_fg_cwd[0..sb_pane.daemon_fg_cwd_len];
+                break :blk std.fmt.bufPrint(&sb_cwd_buf, "file://{s}", .{path}) catch null;
+            };
+            statusbar_refreshed = sb.tick(std.time.timestamp(), publish.ctxPty(ctx).master, sb_cwd);
         };
 
         // Debug overlay toggle check


### PR DESCRIPTION
In SSR mode the daemon owns the parser, so OSC 7 never reaches the client engine and `engine.state.working_directory` stays null. The statusbar tick passed that null cwd to the widgets, causing `cwd` and `git` to silently bail (they need a working directory to do anything). `time` kept working because it ignores cwd; tabs kept working because they use process names.

The daemon already pushes `pane_fg_cwd` notifications and the client stores them in `pane.daemon_fg_cwd`. This change uses that as a fallback at the statusbar tick site, formatted as a `file://` URI so the existing widget paths handle it uniformly. Same precedence pattern already used by `actions.zig`'s cwd resolver.
