### PR TITLE
fix: respect altscreen apps' own selection in grid-sync mode

### DIFF
--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -567,6 +567,8 @@ pub const DaemonClient = struct {
                 // chunks in the same snapshot ship 0 so the client doesn't
                 // double-shift.
                 .scrollback_delta = if (start == 0) scrollback_delta else 0,
+                .mouse_tracking = @intFromEnum(eng.state.mouse_tracking),
+                .mouse_sgr = eng.state.mouse_sgr,
             }) catch return;
 
             // Pack cells into the scratch buffer via memcpy — the wire

--- a/src/app/daemon/grid_sync.zig
+++ b/src/app/daemon/grid_sync.zig
@@ -134,6 +134,12 @@ pub const cursor_visible_flag: u8 = 1 << 0;
 pub const alt_active_flag: u8 = 1 << 1;
 pub const final_chunk_flag: u8 = 1 << 2;
 
+// `mode_flags` (formerly `_pad`) bit layout. Old daemons emit 0, which
+// decodes to mouse_tracking=off / mouse_sgr=false — matching pre-existing
+// client behavior (mouse state was never propagated), so no regression.
+pub const mouse_tracking_mask: u16 = 0b11; // bits 0–1
+pub const mouse_sgr_flag: u16 = 1 << 2; // bit 2
+
 /// grid_snapshot header. Each message carries a CONTIGUOUS row range
 /// `[start_row, start_row + row_count)` of the pane grid. Large panes
 /// require multiple messages (bounded by the 64KB wire framing). The
@@ -158,7 +164,10 @@ pub const SnapshotHeader = extern struct {
     /// screen rows into scrollback, mirroring what happened on the daemon.
     /// Subsequent chunks in the same snapshot carry delta=0.
     scrollback_delta: u16,
-    _pad: u16 = 0,
+    /// Mouse mode bits (see mouse_tracking_mask / mouse_sgr_flag). Was
+    /// `_pad: u16 = 0` in earlier protocol versions; old daemons send 0,
+    /// which decodes as off/false — same as the legacy client behavior.
+    mode_flags: u16 = 0,
 };
 
 comptime {
@@ -181,6 +190,8 @@ pub const SnapshotInfo = struct {
     row_count: u16,
     final_chunk: bool,
     scrollback_delta: u16,
+    mouse_tracking: u8 = 0, // matches MouseTrackingMode enum (off=0..any_event=3)
+    mouse_sgr: bool = false,
 };
 
 pub fn encodedSnapshotChunkSize(cols: u16, row_count: u16) usize {
@@ -194,6 +205,8 @@ pub fn encodeSnapshotHeader(buf: []u8, info: SnapshotInfo) !usize {
     if (info.cursor_visible) flags |= cursor_visible_flag;
     if (info.alt_active) flags |= alt_active_flag;
     if (info.final_chunk) flags |= final_chunk_flag;
+    var mode_flags: u16 = @as(u16, info.mouse_tracking) & mouse_tracking_mask;
+    if (info.mouse_sgr) mode_flags |= mouse_sgr_flag;
     const hdr: SnapshotHeader = .{
         .pane_id = info.pane_id,
         .generation_lo = @truncate(info.generation),
@@ -207,6 +220,7 @@ pub fn encodeSnapshotHeader(buf: []u8, info: SnapshotInfo) !usize {
         .start_row = info.start_row,
         .row_count = info.row_count,
         .scrollback_delta = info.scrollback_delta,
+        .mode_flags = mode_flags,
     };
     @memcpy(buf[0..snapshot_header_size], std.mem.asBytes(&hdr));
     return snapshot_header_size;
@@ -232,6 +246,8 @@ pub fn decodeSnapshotHeader(payload: []const u8) !SnapshotInfo {
         .row_count = hdr.row_count,
         .final_chunk = hdr.flags & final_chunk_flag != 0,
         .scrollback_delta = hdr.scrollback_delta,
+        .mouse_tracking = @intCast(hdr.mode_flags & mouse_tracking_mask),
+        .mouse_sgr = hdr.mode_flags & mouse_sgr_flag != 0,
     };
 }
 

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -1789,6 +1789,12 @@ fn applyGridSnapshot(ctx: *PtyThreadCtx, payload: []const u8) ?GridApplyResult {
     result.pane.engine.state.cursor_visible = info.cursor_visible;
     result.pane.engine.state.cursor_shape = @enumFromInt(info.cursor_shape);
     result.pane.engine.state.alt_active = info.alt_active;
+    // Mouse mode propagation: in grid-sync the client engine never sees
+    // DECSET 1000/1002/1003/1006, so without this the client thinks the
+    // app isn't tracking mouse and consumes click-drag as native selection
+    // — preventing TUIs (claude code, opencode) from receiving mouse input.
+    result.pane.engine.state.mouse_tracking = @enumFromInt(info.mouse_tracking);
+    result.pane.engine.state.mouse_sgr = info.mouse_sgr;
     return .{ .final_chunk = info.final_chunk, .tab_idx = result.tab_idx, .pane_id = info.pane_id };
 }
 

--- a/src/app/ui/publish.zig
+++ b/src/app/ui/publish.zig
@@ -448,7 +448,15 @@ pub fn publishState(ctx: *PtyThreadCtx) void {
         @intFromBool(ctxEngine(ctx).state.mouse_sgr),
     );
     c.g_scrollback_count = @intCast(ctxEngine(ctx).state.ring.scrollbackCount());
-    c.g_alt_screen = @intFromBool(ctxEngine(ctx).state.alt_active);
+    // Clear native selection on altscreen entry: TUIs (claude code, opencode,
+    // etc.) handle their own selection, and the prior selection's coords no
+    // longer correspond to visible content once the alt buffer takes over.
+    const alt_now = ctxEngine(ctx).state.alt_active;
+    if (alt_now and c.g_alt_screen == 0 and c.g_sel_active != 0) {
+        c.g_sel_active = 0;
+        c.attyx_mark_all_dirty();
+    }
+    c.g_alt_screen = @intFromBool(alt_now);
 
     c.g_cursor_shape = @intFromEnum(ctxEngine(ctx).state.cursor_shape);
     c.g_cursor_visible = @intFromBool(ctxEngine(ctx).state.cursor_visible);


### PR DESCRIPTION
## Summary
- TUIs like claude code and opencode handle their own selection via mouse tracking. With grid-sync (SSR) the daemon ships snapshots instead of raw VT bytes, so the client engine never saw `DECSET 1000/1002/1006`. `mouse_tracking` stayed `.off` on the client and click-drag was consumed as a native Attyx selection instead of being forwarded to the app.
- Pack `mouse_tracking` + `mouse_sgr` into the snapshot header's previously unused `_pad: u16`. Wire size is preserved; old daemons send 0 which decodes to off/false — same as the prior client behavior, so no regression for in-flight sessions.
- `applyGridSnapshot` writes mouse mode back onto the client engine state, so the input handlers' early-return gates fire and events go to the PTY.
- Also clear native selection on altscreen entry so a leftover selection from the main screen doesn't render over the alt buffer.

## Test plan
- [ ] Open a daemon-backed session, run `claude` (or `opencode`), click-drag inside it: the app's own selection responds and no Attyx overlay is drawn.
- [ ] Make a selection in the main shell, then enter an altscreen app: the prior selection disappears.
- [ ] In `less` (altscreen, no mouse tracking) click-drag still produces a native selection.
- [ ] `zig build test` passes.