### PR TITLE
fix: gate IL/DL on cursor inside scroll region

### DIFF
--- a/src/headless/tests/csi_cursor.zig
+++ b/src/headless/tests/csi_cursor.zig
@@ -318,6 +318,73 @@ test "golden: DL deletes 2 lines" {
         "     \n");
 }
 
+// IL/DL must no-op when the cursor is outside the scroll region. TUIs that
+// keep a fixed footer (prompt, status bar) move the cursor up to redraw
+// content, leaving the cursor above the region; an IL there used to shift
+// rows that were never meant to move.
+
+test "golden: IL no-op when cursor above scroll region" {
+    // 4 rows, scroll region [2,3] (1-based), cursor at row 1, then IL.
+    try expectSnapshot(4, 5,
+        "AAAA\r\nBBBB\r\nCCCC\r\nDDDD" ++
+        "\x1b[2;3r" ++
+        "\x1b[1;1H" ++
+        "\x1b[L",
+        "AAAA \n" ++
+        "BBBB \n" ++
+        "CCCC \n" ++
+        "DDDD \n");
+}
+
+test "golden: IL no-op when cursor below scroll region" {
+    try expectSnapshot(4, 5,
+        "AAAA\r\nBBBB\r\nCCCC\r\nDDDD" ++
+        "\x1b[2;3r" ++
+        "\x1b[4;1H" ++
+        "\x1b[L",
+        "AAAA \n" ++
+        "BBBB \n" ++
+        "CCCC \n" ++
+        "DDDD \n");
+}
+
+test "golden: DL no-op when cursor above scroll region" {
+    try expectSnapshot(4, 5,
+        "AAAA\r\nBBBB\r\nCCCC\r\nDDDD" ++
+        "\x1b[2;3r" ++
+        "\x1b[1;1H" ++
+        "\x1b[M",
+        "AAAA \n" ++
+        "BBBB \n" ++
+        "CCCC \n" ++
+        "DDDD \n");
+}
+
+test "golden: DL no-op when cursor below scroll region" {
+    try expectSnapshot(4, 5,
+        "AAAA\r\nBBBB\r\nCCCC\r\nDDDD" ++
+        "\x1b[2;3r" ++
+        "\x1b[4;1H" ++
+        "\x1b[M",
+        "AAAA \n" ++
+        "BBBB \n" ++
+        "CCCC \n" ++
+        "DDDD \n");
+}
+
+test "golden: IL still works inside scroll region" {
+    // Cursor at row 2 (inside [2,3]), IL pushes BBBB to row 3, drops CCCC.
+    try expectSnapshot(4, 5,
+        "AAAA\r\nBBBB\r\nCCCC\r\nDDDD" ++
+        "\x1b[2;3r" ++
+        "\x1b[2;1H" ++
+        "\x1b[L",
+        "AAAA \n" ++
+        "     \n" ++
+        "BBBB \n" ++
+        "DDDD \n");
+}
+
 // ===========================================================================
 // CSI @ — Insert Characters (ICH)
 // ===========================================================================

--- a/src/term/state.zig
+++ b/src/term/state.zig
@@ -215,11 +215,21 @@ pub const TerminalState = struct {
                 self.dirty.mark(self.cursor.row);
             },
             .insert_lines => |n| {
-                self.ring.scrollDownRegionN(self.cursor.row, self.scroll_bottom, @intCast(n), self.bceCell());
-                self.dirty.markRange(self.cursor.row, self.scroll_bottom);
+                // IL/DL are no-ops when the cursor is outside the scroll
+                // region (xterm/DEC VT). Applying them anyway shifts rows
+                // outside the region — TUIs that emit IL/DL while the
+                // cursor lives in a fixed footer/header expect the region
+                // to stay untouched, and we'd leave residual cells where
+                // the rows shifted from.
+                if (self.cursor.row >= self.scroll_top and self.cursor.row <= self.scroll_bottom) {
+                    self.ring.scrollDownRegionN(self.cursor.row, self.scroll_bottom, @intCast(n), self.bceCell());
+                    self.dirty.markRange(self.cursor.row, self.scroll_bottom);
+                }
             },
             .delete_lines => |n| {
-                if (self.cursor.row == self.scroll_top and self.isFullScreenScroll()) {
+                if (self.cursor.row < self.scroll_top or self.cursor.row > self.scroll_bottom) {
+                    // No-op: cursor outside scroll region.
+                } else if (self.cursor.row == self.scroll_top and self.isFullScreenScroll()) {
                     const count: usize = @min(@as(usize, @intCast(n)), self.scroll_bottom - self.cursor.row + 1);
                     for (0..count) |_| {
                         self.fullScreenScroll();


### PR DESCRIPTION
## Summary

Per the xterm/DEC VT spec, CSI L (insert lines / IL) and CSI M (delete lines / DL) are no-ops when the cursor sits outside `[scroll_top, scroll_bottom]`. We were applying them anyway, shifting rows that weren't part of the region.

TUIs that keep a fixed footer (prompt, status bar) sometimes run IL/DL while the cursor is parked outside the scroll region. The result was residual cells where rows had shifted from — visible as stray characters in otherwise-blank columns mid-altscreen, often in apps like Claude Code.

## Test plan

- [x] `zig build test` — new golden tests pass, full suite green
- [ ] Smoke-check Claude Code in altscreen: scroll/redraw heavily and confirm no stray columns
- [ ] vim/less/htop still scroll cleanly (in-region IL/DL path unchanged)