### PR TITLE
feat: set X11 class and Wayland app_id

### DIFF
--- a/src/app/platform_linux.c
+++ b/src/app/platform_linux.c
@@ -489,6 +489,14 @@ void attyx_run(AttyxCell* cells, int cols, int rows) {
         glfwWindowHint(GLFW_DECORATED, GLFW_FALSE);
     }
 
+#ifdef GLFW_X11_CLASS_NAME
+    glfwWindowHintString(GLFW_X11_CLASS_NAME,    "attyx");
+    glfwWindowHintString(GLFW_X11_INSTANCE_NAME, "attyx");
+#endif
+#ifdef GLFW_WAYLAND_APP_ID
+    glfwWindowHintString(GLFW_WAYLAND_APP_ID,    "attyx");
+#endif
+
     g_window = glfwCreateWindow(winW, winH, "Attyx", NULL, NULL);
     if (!g_window) {
         ATTYX_LOG_ERR("platform", "failed to create window");


### PR DESCRIPTION
## Summary

On Linux/Wayland the window currently shows up as `bash` (or whatever shell is running) in compositors, taskbars, and window-rule matching, because no `app_id` is set. Same story on X11 with `WM_CLASS`.

Set both before `glfwCreateWindow`:

- `GLFW_X11_CLASS_NAME` / `GLFW_X11_INSTANCE_NAME` → `"attyx"`
- `GLFW_WAYLAND_APP_ID` → `"attyx"`

Guarded with `#ifdef` so the build still works on systems whose GLFW headers predate `GLFW_WAYLAND_APP_ID` (added in 3.4) — that's what was breaking Ubuntu CI on the original PR (#223).

Credit to @jenningsloy318 for the original patch in #223.

Closes #222
Closes #223 
