### PR TITLE
fix: don't show notification for ConEmu OSC 9 subcommands

### DIFF
--- a/src/term/engine.zig
+++ b/src/term/engine.zig
@@ -167,6 +167,37 @@ test "OSC 2 sets window title" {
     try std.testing.expectEqualStrings("my title", e.state.title.?);
 }
 
+test "OSC 9 ConEmu subcommands are not desktop notifications" {
+    // OSC 9 is overloaded: iTerm2 uses "OSC 9 ; <text>" for a notification,
+    // while ConEmu uses numeric subcommands ("9;4;..." progress, "9;9;<path>"
+    // cwd). Only the iTerm2 free-form text must surface as a notification.
+    const parser = @import("parser.zig");
+    {
+        var p = parser.Parser{};
+        var is_notify = false;
+        for ("\x1b]9;9;/tmp\x07") |b| {
+            if (p.next(b)) |a| is_notify = (a == .notify);
+        }
+        try std.testing.expect(!is_notify);
+    }
+    {
+        var p = parser.Parser{};
+        var is_notify = false;
+        for ("\x1b]9;4;1;50\x07") |b| {
+            if (p.next(b)) |a| is_notify = (a == .notify);
+        }
+        try std.testing.expect(!is_notify);
+    }
+    {
+        var p = parser.Parser{};
+        var is_notify = false;
+        for ("\x1b]9;hello\x07") |b| {
+            if (p.next(b)) |a| is_notify = (a == .notify);
+        }
+        try std.testing.expect(is_notify);
+    }
+}
+
 test "OSC 52 sets clipboard from base64" {
     const alloc = std.testing.allocator;
     var e = try Engine.init(alloc, 4, 20, 100);

--- a/src/term/parser.zig
+++ b/src/term/parser.zig
@@ -495,6 +495,20 @@ pub const Parser = struct {
         return .{ .notify = .{ .title = "", .body = after } };
     }
 
+    /// Parse OSC 9. iTerm2 uses "OSC 9 ; <text>" for a desktop notification,
+    /// but ConEmu overloads it with numeric subcommands: "OSC 9 ; 4 ; ..."
+    /// (progress) and "OSC 9 ; 9 ; <path>" (working directory). Nushell on
+    /// Windows emits the cwd form, which must not surface as a notification
+    /// reading "9;c:\\". Only the free-form iTerm2 text becomes a notification.
+    fn dispatchOsc9(rest: []const u8) Action {
+        if (std.mem.indexOfScalar(u8, rest, ';')) |sep| {
+            if (sep > 0 and (std.fmt.parseInt(u16, rest[0..sep], 10) catch null) != null) {
+                return .nop;
+            }
+        }
+        return .{ .notify = .{ .title = "", .body = rest } };
+    }
+
     fn dispatchOsc7339(rest: []const u8) Action {
         // Format: "xyron:{json}"
         const prefix = "xyron:";
@@ -550,8 +564,8 @@ pub const Parser = struct {
             4 => parseOscPaletteQuery(rest),
             7 => .{ .set_cwd = rest },
             8 => csi.makeOscHyperlink(rest),
-            // OSC 9 — iTerm2-style notification: ESC]9;body BEL
-            9 => .{ .notify = .{ .title = "", .body = rest } },
+            // OSC 9 — iTerm2 notification, or a ConEmu numeric subcommand.
+            9 => dispatchOsc9(rest),
             10 => if (std.mem.eql(u8, rest, "?")) .{ .query_color = .foreground } else .nop,
             11 => if (std.mem.eql(u8, rest, "?")) .{ .query_color = .background } else .nop,
             12 => if (std.mem.eql(u8, rest, "?")) .{ .query_color = .cursor } else .nop,


### PR DESCRIPTION
Fixes #237

## What

Nushell on Windows triggered a spurious desktop-notification popup reading `9;c:\` instead of silently reporting its working directory.

## Why

OSC 9 is overloaded across terminal conventions:

- **iTerm2**: `OSC 9 ; <text>` — desktop notification
- **ConEmu**: `OSC 9 ; 4 ; ...` — progress, `OSC 9 ; 9 ; <path>` — working directory

Nushell on Windows emits `OSC 9;9;<path>` to report the cwd. `dispatchOsc` returned everything after `9;` as notification text, so the ConEmu subcommand (`9`) leaked into the popup — producing `9;c:\`.

## Fix

OSC 9 is now routed through `dispatchOsc9`, which only surfaces the iTerm2 free-form text form as a notification. When the payload begins with a numeric subcommand followed by `;` (the ConEmu forms), it returns `.nop`. Added a parser round-trip test in `engine.zig` covering the ConEmu cwd (`9;9`) and progress (`9;4`) forms plus the iTerm2 text form.