### PR TITLE
feat: move tabs between sessions

### DIFF
--- a/releases/v0.4.3.md
+++ b/releases/v0.4.3.md
@@ -1,0 +1,9 @@
+# Attyx v0.4.3
+
+## Move tabs between sessions
+
+You can now pick up a tab and drop it into another running session — the programs inside keep running the whole time.
+
+### What changed
+
+- **New "Move to session" command** — open the command palette and run **Move to session** to see a picker of your other running sessions. Choose one and the current tab (with all of its split panes) moves there. Attyx then switches you to that session and lands you on the moved tab, so you pick up exactly where you left off. Nothing restarts — your shell, your editor, that long-running build all carry over live.

--- a/src/app/bridge.h
+++ b/src/app/bridge.h
@@ -255,6 +255,9 @@ void attyx_toggle_shell_picker(void);
 extern volatile int g_tab_picker_active;  // 1 = tab picker overlay has focus
 void attyx_toggle_tab_picker(void);
 
+// Move-tab-to-session: reuses the session picker overlay in "move" mode
+void attyx_toggle_move_to_session(void);
+
 // Session picker input: input thread -> PTY thread (Zig-side)
 extern volatile int g_session_picker_active;  // 1 = session picker overlay has focus
 void attyx_picker_insert_char(uint32_t codepoint);

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -429,6 +429,15 @@ pub const DaemonClient = struct {
         self.sendRaw(&buf);
     }
 
+    /// Send the result of a move_panes request (1 = moved, 0 = rejected).
+    pub fn sendMoved(self: *DaemonClient, ok: bool) void {
+        var buf: [protocol.header_size + 1]u8 = undefined;
+        var payload: [1]u8 = undefined;
+        _ = protocol.encodeMoved(&payload, ok) catch return;
+        _ = protocol.encodeMessage(&buf, .moved, &payload) catch return;
+        self.sendRaw(&buf);
+    }
+
     /// Send a PaneOutput message (pane-multiplexed PTY output).
     /// Large payloads are split into multiple messages.
     pub fn sendPaneOutput(self: *DaemonClient, pane_id: u32, pty_data: []const u8) void {

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -3,7 +3,8 @@ const builtin = @import("builtin");
 const is_windows = builtin.os.tag == .windows;
 const attyx = @import("attyx");
 const protocol = @import("protocol.zig");
-const DaemonSession = @import("session.zig").DaemonSession;
+const session_mod = @import("session.zig");
+const DaemonSession = session_mod.DaemonSession;
 const DaemonClient = @import("client.zig").DaemonClient;
 const DaemonPane = @import("pane.zig").DaemonPane;
 const RingBuffer = @import("ring_buffer.zig").RingBuffer;
@@ -44,6 +45,7 @@ pub fn handleMessage(
         .pane_input => handlePaneInput(cl, msg.payload, sessions),
         .pane_resize => handlePaneResize(cl, msg.payload, sessions),
         .save_layout => handleSaveLayout(cl, msg.payload, sessions, clients),
+        .move_panes => handleMovePanes(cl, msg.payload, sessions, clients),
         .set_theme_colors => handleSetThemeColors(cl, msg.payload, sessions),
         .get_scrollback_range => handleGetScrollbackRange(cl, msg.payload, sessions),
 
@@ -488,6 +490,124 @@ fn handleSaveLayout(
             }
         }
     }
+}
+
+/// Move one tab's panes (and their layout subtree) from the client's attached
+/// session into another session. The PTYs/processes are transferred live — no
+/// kill, no respawn. The moved tab is appended to the destination's stored
+/// layout and made active, so the client (which switches to the destination
+/// right after) lands on it.
+fn handleMovePanes(
+    cl: *DaemonClient,
+    payload: []const u8,
+    sessions: *[max_sessions]?DaemonSession,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    const msg = protocol.decodeMovePanes(payload) catch {
+        cl.sendMoved(false);
+        return;
+    };
+    // getAttachedSession already replies with an error if we're not attached.
+    const source = getAttachedSession(cl, sessions) orelse return;
+    const dest = findSession(sessions, msg.dest_session_id) orelse {
+        cl.sendMoved(false);
+        return;
+    };
+    if (dest.id == source.id) {
+        cl.sendMoved(false);
+        return;
+    }
+
+    // Snapshot the destination's existing panes BEFORE we adopt anything.
+    var dest_existing: [session_mod.max_panes_per_session]u32 = undefined;
+    const dest_existing_count = dest.collectPaneIds(&dest_existing);
+
+    // Parse the destination's current layout (empty if it has none yet).
+    var dest_info: layout_codec.LayoutInfo = if (dest.layout_len > 0)
+        (layout_codec.deserialize(dest.layout_data[0..dest.layout_len]) catch layout_codec.LayoutInfo{})
+    else
+        layout_codec.LayoutInfo{};
+
+    // A session created but never attached has no layout blob yet. Synthesize a
+    // single-pane tab for each existing pane so they aren't dropped from the
+    // view once we append the moved tab.
+    if (dest_info.tab_count == 0) {
+        for (0..dest_existing_count) |i| {
+            if (dest_info.tab_count >= layout_codec.max_tabs) break;
+            var t = &dest_info.tabs[dest_info.tab_count];
+            t.node_count = 1;
+            t.root_idx = 0;
+            t.focused_idx = 0;
+            t.title_len = 0;
+            t.title_flags = 0;
+            t.nodes[0] = .{ .tag = .leaf, .pane_id = dest_existing[i] };
+            dest_info.tab_count += 1;
+        }
+    }
+    if (dest_info.tab_count >= layout_codec.max_tabs) {
+        cl.sendMoved(false);
+        return;
+    }
+
+    // Parse the moved tab's layout subtree (a one-tab blob from the client).
+    const moved = layout_codec.deserialize(msg.tab_layout) catch {
+        cl.sendMoved(false);
+        return;
+    };
+    if (moved.tab_count == 0) {
+        cl.sendMoved(false);
+        return;
+    }
+
+    // Validate capacity up-front using the count of panes that actually exist
+    // in the source, so we never leave the move half-applied.
+    var movable: u8 = 0;
+    for (0..msg.count) |i| {
+        if (source.findPane(msg.pane_ids[i]) != null) movable += 1;
+    }
+    if (movable == 0) {
+        cl.sendMoved(false);
+        return;
+    }
+    if (@as(usize, dest.pane_count) + movable > session_mod.max_panes_per_session) {
+        cl.sendMoved(false);
+        return;
+    }
+
+    // Transfer the live panes (no deinit).
+    for (0..msg.count) |i| {
+        if (source.takePaneById(msg.pane_ids[i])) |pane| {
+            dest.adoptPane(pane) catch {
+                // Capacity was validated above, so this shouldn't happen;
+                // if it does, drop the pane rather than corrupt either side.
+                var p = pane;
+                p.deinit();
+            };
+        }
+    }
+
+    // Append the moved tab to the destination layout and make it active.
+    const new_idx = dest_info.tab_count;
+    dest_info.tabs[new_idx] = moved.tabs[0];
+    dest_info.tab_count += 1;
+    dest_info.active_tab = new_idx;
+    dest_info.focused_pane_id = moved.focused_pane_id;
+    if (layout_codec.serialize(&dest_info, &dest.layout_data)) |len| {
+        dest.layout_len = len;
+    } else |_| {}
+
+    // Live-update any other clients viewing the destination session so the
+    // new tab appears without them having to reattach.
+    for (clients) |*cslot| {
+        if (cslot.*) |*other| {
+            if (other == cl) continue;
+            if (other.attached_session) |osid| {
+                if (osid == dest.id) other.sendLayoutSync(dest);
+            }
+        }
+    }
+
+    cl.sendMoved(true);
 }
 
 // ── Session revive ──

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -31,6 +31,8 @@ pub const MessageType = enum(u8) {
     rename = 0x0E,
     hello = 0x0F,
     set_theme_colors = 0x10,
+    /// Move one tab's panes (and their layout subtree) into another session.
+    move_panes = 0x11,
 
     // Client → Daemon (grid-sync, server-side engine). Reserved in Phase 1;
     // encoders/decoders land with the daemon-side engine in Phase 2.
@@ -50,6 +52,8 @@ pub const MessageType = enum(u8) {
     layout_sync = 0x8C,
     hello_ack = 0x8D,
     pane_fg_cwd = 0x8E,
+    /// Result of a move_panes request: 1 byte, 1 = moved, 0 = rejected.
+    moved = 0x8F,
 
     // Daemon → Client (grid-sync). Reserved in Phase 1; payload format
     // (PackedCell layout, dirty-row bitmap, etc.) defined in Phase 2.
@@ -360,6 +364,29 @@ pub fn encodeFocusPanes(buf: []u8, pane_ids: []const u32) ![]u8 {
     return buf[0..total];
 }
 
+/// Encode MovePanes payload:
+///   dest_session_id:u32, count:u8, pane_ids:[count]u32, tab_len:u16, tab_layout:[tab_len]u8
+/// `tab_layout` is a serialized one-tab LayoutInfo blob describing the moved tab's
+/// split structure (the same format the daemon stores per session).
+pub fn encodeMovePanes(buf: []u8, dest_session_id: u32, pane_ids: []const u32, tab_layout: []const u8) ![]u8 {
+    const count: u8 = @intCast(@min(pane_ids.len, 32));
+    const tab_len: u16 = @intCast(@min(tab_layout.len, 4096));
+    const total: usize = 4 + 1 + @as(usize, count) * 4 + 2 + tab_len;
+    if (buf.len < total) return error.BufferTooSmall;
+    std.mem.writeInt(u32, buf[0..4], dest_session_id, .little);
+    buf[4] = count;
+    var pos: usize = 5;
+    for (0..count) |i| {
+        std.mem.writeInt(u32, buf[pos..][0..4], pane_ids[i], .little);
+        pos += 4;
+    }
+    std.mem.writeInt(u16, buf[pos..][0..2], tab_len, .little);
+    pos += 2;
+    if (tab_len > 0) @memcpy(buf[pos .. pos + tab_len], tab_layout[0..tab_len]);
+    pos += tab_len;
+    return buf[0..pos];
+}
+
 /// Encode PaneInput payload: pane_id:u32, bytes:[N]u8
 pub fn encodePaneInput(buf: []u8, pane_id: u32, bytes: []const u8) ![]u8 {
     const total = 4 + bytes.len;
@@ -505,6 +532,36 @@ pub fn decodeFocusPanes(payload: []const u8) !FocusPanesMsg {
     return msg;
 }
 
+pub const MovePanesMsg = struct {
+    dest_session_id: u32,
+    count: u8,
+    pane_ids: [32]u32,
+    tab_layout: []const u8,
+};
+
+pub fn decodeMovePanes(payload: []const u8) !MovePanesMsg {
+    if (payload.len < 5) return error.PayloadTooShort;
+    const dest_session_id = std.mem.readInt(u32, payload[0..4], .little);
+    const count = payload[4];
+    if (count > 32) return error.InvalidCount;
+    var pos: usize = 5;
+    if (payload.len < pos + @as(usize, count) * 4 + 2) return error.PayloadTooShort;
+    var pane_ids: [32]u32 = .{0} ** 32;
+    for (0..count) |i| {
+        pane_ids[i] = std.mem.readInt(u32, payload[pos..][0..4], .little);
+        pos += 4;
+    }
+    const tab_len = std.mem.readInt(u16, payload[pos..][0..2], .little);
+    pos += 2;
+    if (payload.len < pos + @as(usize, tab_len)) return error.PayloadTooShort;
+    return .{
+        .dest_session_id = dest_session_id,
+        .count = count,
+        .pane_ids = pane_ids,
+        .tab_layout = payload[pos .. pos + tab_len],
+    };
+}
+
 pub const PaneInputMsg = struct { pane_id: u32, bytes: []const u8 };
 
 pub fn decodePaneInput(payload: []const u8) !PaneInputMsg {
@@ -529,6 +586,18 @@ pub fn decodePaneResize(payload: []const u8) !PaneResizeMsg {
 pub fn decodePaneCreated(payload: []const u8) !u32 {
     if (payload.len < 4) return error.PayloadTooShort;
     return std.mem.readInt(u32, payload[0..4], .little);
+}
+
+/// Encode Moved result payload: ok:u8 (1 = moved, 0 = rejected).
+pub fn encodeMoved(buf: []u8, ok: bool) ![]u8 {
+    if (buf.len < 1) return error.BufferTooSmall;
+    buf[0] = @intFromBool(ok);
+    return buf[0..1];
+}
+
+pub fn decodeMoved(payload: []const u8) !bool {
+    if (payload.len < 1) return error.PayloadTooShort;
+    return payload[0] != 0;
 }
 
 pub const PaneDiedMsg = struct {

--- a/src/app/daemon/session.zig
+++ b/src/app/daemon/session.zig
@@ -118,6 +118,34 @@ pub const DaemonSession = struct {
         return false;
     }
 
+    /// Remove a pane by ID WITHOUT destroying it, returning the pane value so
+    /// another session can adopt it. Unlike removePane, this does NOT call
+    /// deinit() — the PTY/process/engine stay alive across the move.
+    pub fn takePaneById(self: *DaemonSession, pane_id: u32) ?DaemonPane {
+        for (&self.panes) |*slot| {
+            if (slot.*) |p| {
+                if (p.id == pane_id) {
+                    slot.* = null;
+                    self.pane_count -= 1;
+                    if (self.pane_count == 0) self.alive = false;
+                    return p;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// Adopt an already-spawned pane moved from another session. Takes ownership
+    /// of its PTY/engine without re-spawning. Returns error.TooManyPanes if full.
+    pub fn adoptPane(self: *DaemonSession, pane: DaemonPane) !void {
+        const slot_idx = for (&self.panes, 0..) |*slot, i| {
+            if (slot.* == null) break i;
+        } else return error.TooManyPanes;
+        self.panes[slot_idx] = pane;
+        self.pane_count += 1;
+        self.alive = true;
+    }
+
     /// Find a pane by ID.
     pub fn findPane(self: *DaemonSession, pane_id: u32) ?*DaemonPane {
         for (&self.panes) |*slot| {

--- a/src/app/daemon/session_test.zig
+++ b/src/app/daemon/session_test.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 const posix = std.posix;
 const testing = std.testing;
 const protocol = @import("protocol.zig");
+const layout_codec = @import("../layout_codec.zig");
 const harness = @import("test_harness.zig");
 const setup = harness.setup;
 const teardown = harness.teardown;
@@ -459,6 +460,80 @@ test "two clients see same session list" {
     const count = try protocol.decodeSessionList(list_payload, &entries);
     try testing.expectEqual(@as(u16, 1), count);
     try testing.expectEqualStrings("shared", entries[0].name);
+}
+
+test "move tab transfers pane to another session and empties the source" {
+    var env = try setup();
+    defer teardown(&env);
+
+    var client = try TestClient.connect(env.path());
+    defer client.deinit();
+
+    var buf: [4200]u8 = undefined;
+
+    // Source session A.
+    const cpa = try protocol.encodeCreate(&buf, "src", 24, 80, "/tmp", "");
+    try client.send(.create, cpa);
+    const sid_a = try protocol.decodeCreated(try client.expect(.created, 5000));
+
+    // Destination session B.
+    const cpb = try protocol.encodeCreate(&buf, "dst", 24, 80, "/tmp", "");
+    try client.send(.create, cpb);
+    const sid_b = try protocol.decodeCreated(try client.expect(.created, 5000));
+
+    // Attach A, grab its (only) pane id.
+    const ap = try protocol.encodeAttach(&buf, sid_a, 24, 80);
+    try client.send(.attach, ap);
+    const v2a = try protocol.decodeAttachedV2(try client.expect(.attached, 5000));
+    try testing.expectEqual(@as(u8, 1), v2a.pane_count);
+    const moved_pane = v2a.pane_ids[0];
+
+    // Build a one-tab layout blob describing that pane, then move it to B.
+    var info = layout_codec.LayoutInfo{};
+    info.tab_count = 1;
+    info.active_tab = 0;
+    info.focused_pane_id = moved_pane;
+    info.tabs[0].node_count = 1;
+    info.tabs[0].root_idx = 0;
+    info.tabs[0].focused_idx = 0;
+    info.tabs[0].nodes[0] = .{ .tag = .leaf, .pane_id = moved_pane };
+    var tab_buf: [256]u8 = undefined;
+    const tab_len = try layout_codec.serialize(&info, &tab_buf);
+
+    var mbuf: [512]u8 = undefined;
+    const mp = try protocol.encodeMovePanes(&mbuf, sid_b, &[_]u32{moved_pane}, tab_buf[0..tab_len]);
+    try client.send(.move_panes, mp);
+    posix.nanosleep(0, 50_000_000);
+
+    // Source A lost its only pane → it is now dead. B is still alive.
+    try client.send(.detach, &.{});
+    posix.nanosleep(0, 20_000_000);
+    try client.send(.list, &.{});
+    var entries: [32]protocol.DecodedListEntry = undefined;
+    const count = try protocol.decodeSessionList(try client.expect(.session_list, 5000), &entries);
+    try testing.expectEqual(@as(u16, 2), count);
+    for (entries[0..count]) |e| {
+        if (e.id == sid_a) try testing.expect(!e.alive);
+        if (e.id == sid_b) try testing.expect(e.alive);
+    }
+
+    // Attach B: it now owns its original pane plus the moved one, and its
+    // layout ends on the moved tab.
+    const apb = try protocol.encodeAttach(&buf, sid_b, 24, 80);
+    try client.send(.attach, apb);
+    const v2b = try protocol.decodeAttachedV2(try client.expect(.attached, 5000));
+    try testing.expectEqual(@as(u8, 2), v2b.pane_count);
+
+    var has_moved = false;
+    for (v2b.pane_ids[0..v2b.pane_count]) |pid| {
+        if (pid == moved_pane) has_moved = true;
+    }
+    try testing.expect(has_moved);
+
+    const layout = try layout_codec.deserialize(v2b.layout);
+    try testing.expectEqual(@as(u8, 2), layout.tab_count);
+    try testing.expectEqual(@as(u8, 1), layout.active_tab); // moved tab is last + active
+    try testing.expectEqual(moved_pane, layout.tabs[1].nodes[0].pane_id);
 }
 
 // Restoration & layout tests in session_restore_test.zig

--- a/src/app/main.zig
+++ b/src/app/main.zig
@@ -151,6 +151,8 @@ export fn attyx_toggle_theme_picker() void {}
 export var g_tab_picker_active: i32 = 0;
 export var g_toggle_tab_picker: i32 = 0;
 export fn attyx_toggle_tab_picker() void {}
+export var g_toggle_move_to_session: i32 = 0;
+export fn attyx_toggle_move_to_session() void {}
 
 // Popup terminal stubs (terminal.zig provides the real implementations)
 export var g_popup_active: i32 = 0;

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -293,6 +293,14 @@ pub const SessionClient = struct {
         try self.sendMessage(.close_pane, payload);
     }
 
+    /// Ask the daemon to move one tab's panes (described by `tab_layout`, a
+    /// serialized one-tab layout blob) into another session, live.
+    pub fn sendMovePanes(self: *SessionClient, dest_session_id: u32, pane_ids: []const u32, tab_layout: []const u8) !void {
+        var payload_buf: [4 + 1 + 32 * 4 + 2 + 4096]u8 = undefined;
+        const payload = try protocol.encodeMovePanes(&payload_buf, dest_session_id, pane_ids, tab_layout);
+        try self.sendMessage(.move_panes, payload);
+    }
+
     pub fn sendFocusPanes(self: *SessionClient, pane_ids: []const u32) !void {
         var payload_buf: [129]u8 = undefined;
         const payload = try protocol.encodeFocusPanes(&payload_buf, pane_ids);
@@ -447,6 +455,38 @@ pub const SessionClient = struct {
             elapsed += 100;
         }
         return error.Timeout;
+    }
+
+    /// Wait for the daemon's response to a move_panes request. Returns true if
+    /// the move was applied, false if it was rejected, timed out, or the
+    /// connection dropped (the caller must not destroy local state on false).
+    pub fn waitForMoveResult(self: *SessionClient, timeout_ms: u32) bool {
+        var elapsed: u32 = 0;
+        while (elapsed < timeout_ms) {
+            while (self.availableBytes() >= protocol.header_size) {
+                const buf = self.read_buf[self.read_off..self.read_len];
+                const header = protocol.decodeHeader(buf[0..protocol.header_size]) catch {
+                    self.consumeBytes(1);
+                    continue;
+                };
+                const total = protocol.header_size + header.payload_len;
+                if (self.availableBytes() < total) break;
+                const payload = buf[protocol.header_size..total];
+                if (header.msg_type == .moved) {
+                    const ok = protocol.decodeMoved(payload) catch false;
+                    self.consumeBytes(total);
+                    return ok;
+                }
+                if (header.msg_type == .err) {
+                    self.consumeBytes(total);
+                    return false;
+                }
+                self.consumeOrBuffer(header.msg_type, payload, total);
+            }
+            if (!self.pollAndRecv(100)) return false;
+            elapsed += 100;
+        }
+        return false;
     }
 
     /// Pop the next buffered pane death captured during a blocking wait.

--- a/src/app/tab_manager.zig
+++ b/src/app/tab_manager.zig
@@ -33,6 +33,62 @@ fn writeStoredTabTitle(tab: *layout_codec.TabLayout, explicit: ?[]const u8, fall
     tab.title_flags = 0;
 }
 
+/// Fill a layout_codec.TabLayout from a live SplitLayout: compact the node
+/// pool, resolve the tab title, and copy the split tree (leaf pane IDs use the
+/// daemon pane ID so they round-trip across sessions).
+fn fillTabLayout(lay: *SplitLayout, tab: *layout_codec.TabLayout) void {
+    // Remap pool indices to compact indices (skip empty slots).
+    var remap: [split_layout_mod.max_nodes]u8 = .{0xFF} ** split_layout_mod.max_nodes;
+    var compact_count: u8 = 0;
+    for (lay.pool, 0..) |node, ni| {
+        if (node.tag != .empty) {
+            remap[ni] = compact_count;
+            compact_count += 1;
+        }
+    }
+    tab.node_count = compact_count;
+    tab.root_idx = if (lay.root < split_layout_mod.max_nodes) remap[lay.root] else 0;
+    tab.focused_idx = if (lay.focused < split_layout_mod.max_nodes) remap[lay.focused] else 0;
+
+    const focused_pane = lay.focusedPane();
+    const fallback_title: ?[]const u8 = focused_pane.engine.state.title orelse blk: {
+        if (comptime @import("builtin").os.tag != .windows) {
+            var name_buf: [256]u8 = undefined;
+            if (platform.getForegroundProcessName(focused_pane.pty.master, &name_buf)) |name|
+                break :blk name;
+        }
+        break :blk focused_pane.getDaemonProcName() orelse lay.getHintTitle();
+    };
+    writeStoredTabTitle(tab, lay.getTitle(), fallback_title);
+
+    var ci: u8 = 0;
+    for (lay.pool) |node| {
+        switch (node.tag) {
+            .leaf => {
+                tab.nodes[ci] = .{
+                    .tag = .leaf,
+                    .pane_id = if (node.pane) |p| p.daemon_pane_id orelse 0 else 0,
+                };
+                ci += 1;
+            },
+            .branch => {
+                tab.nodes[ci] = .{
+                    .tag = .branch,
+                    .direction = switch (node.direction) {
+                        .vertical => .vertical,
+                        .horizontal => .horizontal,
+                    },
+                    .ratio_x100 = @intFromFloat(node.ratio * 100.0),
+                    .child_left = if (node.children[0] < split_layout_mod.max_nodes) remap[node.children[0]] else 0xFF,
+                    .child_right = if (node.children[1] < split_layout_mod.max_nodes) remap[node.children[1]] else 0xFF,
+                };
+                ci += 1;
+            },
+            .empty => {},
+        }
+    }
+}
+
 fn restoreTabTitle(layout: *SplitLayout, tab: *const layout_codec.TabLayout) void {
     const title = tab.getTitle() orelse {
         layout.clearTitle();
@@ -467,59 +523,25 @@ pub const TabManager = struct {
 
         for (0..self.count) |ti| {
             if (self.tabs[ti]) |*lay| {
-                var tab = &info.tabs[ti];
-                // Remap pool indices to compact indices (skip empty slots)
-                var remap: [split_layout_mod.max_nodes]u8 = .{0xFF} ** split_layout_mod.max_nodes;
-                var compact_count: u8 = 0;
-                for (lay.pool, 0..) |node, ni| {
-                    if (node.tag != .empty) {
-                        remap[ni] = compact_count;
-                        compact_count += 1;
-                    }
-                }
-                tab.node_count = compact_count;
-                tab.root_idx = if (lay.root < split_layout_mod.max_nodes) remap[lay.root] else 0;
-                tab.focused_idx = if (lay.focused < split_layout_mod.max_nodes) remap[lay.focused] else 0;
-
-                const focused_pane = lay.focusedPane();
-                const fallback_title: ?[]const u8 = focused_pane.engine.state.title orelse blk: {
-                    if (comptime @import("builtin").os.tag != .windows) {
-                        var name_buf: [256]u8 = undefined;
-                        if (platform.getForegroundProcessName(focused_pane.pty.master, &name_buf)) |name|
-                            break :blk name;
-                    }
-                    break :blk focused_pane.getDaemonProcName() orelse lay.getHintTitle();
-                };
-                writeStoredTabTitle(tab, lay.getTitle(), fallback_title);
-
-                var ci: u8 = 0;
-                for (lay.pool) |node| {
-                    switch (node.tag) {
-                        .leaf => {
-                            tab.nodes[ci] = .{
-                                .tag = .leaf,
-                                .pane_id = if (node.pane) |p| p.daemon_pane_id orelse 0 else 0,
-                            };
-                            ci += 1;
-                        },
-                        .branch => {
-                            tab.nodes[ci] = .{
-                                .tag = .branch,
-                                .direction = switch (node.direction) {
-                                    .vertical => .vertical,
-                                    .horizontal => .horizontal,
-                                },
-                                .ratio_x100 = @intFromFloat(node.ratio * 100.0),
-                                .child_left = if (node.children[0] < split_layout_mod.max_nodes) remap[node.children[0]] else 0xFF,
-                                .child_right = if (node.children[1] < split_layout_mod.max_nodes) remap[node.children[1]] else 0xFF,
-                            };
-                            ci += 1;
-                        },
-                        .empty => {},
-                    }
-                }
+                fillTabLayout(lay, &info.tabs[ti]);
             }
         }
+
+        return layout_codec.serialize(&info, buf);
+    }
+
+    /// Serialize just the active tab as a standalone one-tab layout blob.
+    /// Used to ship a tab to another session when moving it. Returns 0 if
+    /// there is no active tab.
+    pub fn serializeActiveTab(self: *TabManager, buf: []u8) !u16 {
+        if (self.count == 0) return 0;
+        const lay = &(self.tabs[self.active] orelse return 0);
+
+        var info = layout_codec.LayoutInfo{};
+        info.tab_count = 1;
+        info.active_tab = 0;
+        info.focused_pane_id = lay.focusedPane().daemon_pane_id orelse 0;
+        fillTabLayout(lay, &info.tabs[0]);
 
         return layout_codec.serialize(&info, buf);
     }

--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -211,6 +211,7 @@ pub export var g_toggle_theme_picker: i32 = 0;
 pub export var g_theme_picker_active: i32 = 0;
 pub export var g_toggle_tab_picker: i32 = 0;
 pub export var g_tab_picker_active: i32 = 0;
+pub export var g_toggle_move_to_session: i32 = 0;
 
 // Ensure keybind, dispatch, and copy mode exports are linked
 comptime {
@@ -265,6 +266,9 @@ export fn attyx_toggle_theme_picker() void {
 }
 export fn attyx_toggle_tab_picker() void {
     @atomicStore(i32, &g_toggle_tab_picker, 1, .seq_cst);
+}
+export fn attyx_toggle_move_to_session() void {
+    @atomicStore(i32, &g_toggle_move_to_session, 1, .seq_cst);
 }
 export fn attyx_create_session_direct() void {
     @atomicStore(i32, &g_create_session_direct, 1, .seq_cst);

--- a/src/app/ui/dispatch.zig
+++ b/src/app/ui/dispatch.zig
@@ -177,6 +177,10 @@ pub export fn attyx_dispatch_action(action_raw: u8) u8 {
             c.attyx_toggle_tab_picker();
             return 1;
         },
+        .move_to_session => {
+            c.attyx_toggle_move_to_session();
+            return 1;
+        },
         .session_create => {
             if (c.g_popup_active != 0) {
                 const b = [_]u8{0x0e}; // Ctrl-N byte

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -419,6 +419,15 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
             }
         }
 
+        // Move-tab-to-session toggle check (reuses the session picker overlay)
+        if (@atomicRmw(i32, &terminal.g_toggle_move_to_session, .Xchg, 0, .seq_cst) != 0) {
+            if (terminal.g_session_picker_active != 0) {
+                session_picker_ui.closeSessionPicker(ctx);
+            } else {
+                session_picker_ui.openSessionPickerMove(ctx);
+            }
+        }
+
         // Direct session create (Ctrl+Shift+N without picker)
         if (@atomicRmw(i32, &terminal.g_create_session_direct, .Xchg, 0, .seq_cst) != 0) {
             session_actions.createSessionDirect(ctx);

--- a/src/app/ui/session_actions.zig
+++ b/src/app/ui/session_actions.zig
@@ -203,6 +203,58 @@ pub fn doSessionSwitch(ctx: *PtyThreadCtx, session_id: u32) void {
     logging.info("session-picker", "switched to session {d}", .{session_id});
 }
 
+/// Move the active tab (and all its split panes) to another session, then
+/// switch to that session and land on the moved tab. The panes keep running —
+/// the daemon transfers them live rather than killing and respawning.
+pub fn doMoveActiveTabToSession(ctx: *PtyThreadCtx, dest_session_id: u32) void {
+    const sc = ctx.session_client orelse return;
+    if (ctx.tab_mgr.count == 0) return;
+    if (sc.attached_session_id) |current| {
+        if (current == dest_session_id) return; // can't move to the same session
+    }
+
+    // Serialize the active tab's split tree into a one-tab blob for the daemon.
+    var tab_buf: [4096]u8 = undefined;
+    const tab_len = ctx.tab_mgr.serializeActiveTab(&tab_buf) catch return;
+    if (tab_len == 0) return;
+
+    // Collect the active tab's daemon-backed pane IDs.
+    var pane_ids: [split_layout_mod.max_panes]u32 = undefined;
+    var pane_count: u8 = 0;
+    if (ctx.tab_mgr.tabs[ctx.tab_mgr.active]) |*lay| {
+        var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
+        const lc = lay.collectLeaves(&leaves);
+        for (leaves[0..lc]) |leaf| {
+            if (leaf.pane.daemon_pane_id) |dpid| {
+                pane_ids[pane_count] = dpid;
+                pane_count += 1;
+            }
+        }
+    }
+    if (pane_count == 0) return;
+
+    // Hand the live panes + the tab layout to the daemon and wait for it to
+    // confirm. We only mutate local state on success, so a rejection (e.g. the
+    // destination is at its tab/pane cap) leaves the tab exactly where it is
+    // rather than orphaning the running processes.
+    sc.sendMovePanes(dest_session_id, pane_ids[0..pane_count], tab_buf[0..tab_len]) catch return;
+    if (!sc.waitForMoveResult(5000)) {
+        logging.info("session-picker", "move to session {d} rejected", .{dest_session_id});
+        return;
+    }
+
+    // Drop the tab locally WITHOUT a close_pane round-trip — the daemon now
+    // owns those panes in the destination session, so closing them would kill
+    // the very processes we just moved.
+    ctx.tab_mgr.closeTab(ctx.tab_mgr.active);
+
+    // Switch to the destination. doSessionSwitch saves the (now tab-less)
+    // source layout, attaches the destination, and reconstructs from its
+    // layout — which the daemon just made end on the moved tab.
+    doSessionSwitch(ctx, dest_session_id);
+    logging.info("session-picker", "moved tab to session {d}", .{dest_session_id});
+}
+
 pub fn doSessionCreate(ctx: *PtyThreadCtx, cwd: []const u8) void {
     const sc = ctx.session_client orelse return;
     const pty_rows: u16 = @intCast(@max(1, @as(i32, ctx.grid_rows) - terminal.g_grid_top_offset - terminal.g_grid_bottom_offset));

--- a/src/app/ui/session_picker_ui.zig
+++ b/src/app/ui/session_picker_ui.zig
@@ -70,6 +70,48 @@ pub fn openSessionPicker(ctx: *PtyThreadCtx) void {
     logging.info("session-picker", "opened overlay picker", .{});
 }
 
+/// Open the session picker in "move tab to session" mode: it lists the other
+/// running sessions and, on Enter, moves the active tab to the chosen one.
+/// No filesystem finder and no create/kill/rename — just pick a destination.
+pub fn openSessionPickerMove(ctx: *PtyThreadCtx) void {
+    if (ctx.popup_state != null) actions.closePopup(ctx);
+
+    const sc = ctx.session_client orelse return;
+    sc.requestListSync(2000) catch return;
+
+    const current_id: ?u32 = sc.attached_session_id;
+
+    var state = SessionPickerState{};
+    var count: u8 = 0;
+    for (sc.pending_list[0..sc.pending_list_count]) |le| {
+        // Only alive sessions, never the one we're already in.
+        if (!le.alive) continue;
+        if (current_id != null and le.id == current_id.?) continue;
+        state.entries[count] = .{
+            .id = le.id,
+            .name_len = le.name_len,
+            .alive = le.alive,
+        };
+        @memcpy(state.entries[count].name[0..le.name_len], le.name[0..le.name_len]);
+        count += 1;
+        if (count >= picker_state_mod.max_entries) break;
+    }
+
+    const panel_h = @as(u16, @intCast(@max(3, ctx.grid_rows))) / 2;
+    const visible = if (panel_h > 5) @as(u8, @intCast(panel_h - 5)) else 3;
+
+    state.load(state.entries[0..count], count, current_id);
+    state.move_mode = true;
+    state.visible_rows = visible;
+    state.adjustScroll();
+
+    g_picker_state = state;
+    @atomicStore(i32, &terminal.g_session_picker_active, 1, .seq_cst);
+
+    renderAndPublish(ctx);
+    logging.info("session-picker", "opened move-to-session picker", .{});
+}
+
 /// Configure finder parameters (called when config is loaded/reloaded).
 pub fn setFinderConfig(root: []const u8, depth: u8, show_hidden: bool) void {
     g_finder_root = root;
@@ -195,6 +237,11 @@ fn processAction(ctx: *PtyThreadCtx, state: *SessionPickerState, action: picker_
         .switch_session => |id| {
             closeSessionPicker(ctx);
             session_actions.doSessionSwitch(ctx, id);
+            return true;
+        },
+        .move_to_session => |id| {
+            closeSessionPicker(ctx);
+            session_actions.doMoveActiveTabToSession(ctx, id);
             return true;
         },
         .switch_to_default => {

--- a/src/app/ui/win_session_picker.zig
+++ b/src/app/ui/win_session_picker.zig
@@ -177,6 +177,12 @@ fn processAction(ctx: *WinCtx, action: picker_state_mod.PickerAction) bool {
             close(ctx);
             return true;
         },
+        // "Move tab to session" is not wired on Windows yet; the picker never
+        // enters move mode here, so this is unreachable in practice.
+        .move_to_session => {
+            close(ctx);
+            return true;
+        },
         .create_session => {
             close(ctx);
             const ws_stubs = @import("../windows_stubs.zig");

--- a/src/config/commands.zig
+++ b/src/config/commands.zig
@@ -85,6 +85,7 @@ pub const registry = [_]CommandDef{
     .{ .action = .copy_mode_enter, .name = "copy_mode", .description = "Enter copy/visual mode", .scope = .global, .mac_hotkey = "ctrl+shift+space", .linux_hotkey = "ctrl+shift+space" },
     .{ .action = .theme_picker_toggle, .name = "theme_picker", .description = "Pick theme", .scope = .global, .mac_hotkey = null, .linux_hotkey = null },
     .{ .action = .tab_picker_toggle, .name = "tab_picker", .description = "Pick tab", .scope = .global, .mac_hotkey = "cmd+shift+t", .linux_hotkey = "ctrl+alt+t" },
+    .{ .action = .move_to_session, .name = "move_to_session", .description = "Move to session", .scope = .global, .mac_hotkey = null, .linux_hotkey = null },
     .{ .action = .open_config, .name = "open_config", .description = "Open config in editor", .scope = .global, .mac_hotkey = "cmd+,", .linux_hotkey = "ctrl+," },
     // Tab select by number
     .{ .action = .tab_select_1, .name = "tab_select_1", .description = "Switch to tab 1", .scope = .global, .mac_hotkey = "cmd+1", .linux_hotkey = "alt+1" },

--- a/src/config/keybinds.zig
+++ b/src/config/keybinds.zig
@@ -126,6 +126,7 @@ pub const Action = enum(u8) {
     close_all_windows = 93,
     shell_picker_toggle = 95,
     tab_rename = 96,
+    move_to_session = 97,
     _,
 
     /// Return the popup index if this is a popup_toggle action.

--- a/src/overlay/session_picker.zig
+++ b/src/overlay/session_picker.zig
@@ -39,6 +39,8 @@ pub const PickerAction = union(enum) {
     create_session_at: []const u8,
     kill_session: u32,
     rename_session: struct { id: u32, name: []const u8 },
+    /// "Move tab to session" mode: the user picked the destination session.
+    move_to_session: u32,
     close: void,
 };
 
@@ -48,6 +50,10 @@ pub const SessionPickerState = struct {
     selected: u8 = 0,
     scroll_offset: u8 = 0,
     mode: PickerMode = .browsing,
+    /// When true, the picker chooses a destination for "Move tab to session"
+    /// instead of switching. Hides the "New session"/filesystem rows and the
+    /// rename/kill/detach shortcuts; Enter emits `.move_to_session`.
+    move_mode: bool = false,
 
     // Filter
     filter_buf: [64]u8 = .{0} ** 64,
@@ -187,6 +193,13 @@ pub const SessionPickerState = struct {
             },
             7 => return .close, // Escape
             8 => { // Enter
+                if (self.move_mode) {
+                    if (self.selected < self.filtered_count) {
+                        const e = &self.entries[self.filtered_indices[self.selected]];
+                        return .{ .move_to_session = e.id };
+                    }
+                    return .none;
+                }
                 if (self.selected < self.filtered_count) {
                     const e = &self.entries[self.filtered_indices[self.selected]];
                     return .{ .switch_session = e.id };
@@ -199,7 +212,8 @@ pub const SessionPickerState = struct {
             },
             9 => self.moveUp(), // Up
             10 => self.moveDown(), // Down
-            11 => { // Ctrl-R — rename
+            11 => { // Ctrl-R — rename (disabled while picking a move target)
+                if (self.move_mode) return .none;
                 if (self.filtered_count > 0 and self.selected < self.filtered_count) {
                     const e = &self.entries[self.filtered_indices[self.selected]];
                     const nlen = e.name_len;
@@ -208,7 +222,8 @@ pub const SessionPickerState = struct {
                     self.mode = .renaming;
                 }
             },
-            12 => { // Ctrl-X — kill (only for alive sessions)
+            12 => { // Ctrl-X — kill (only for alive sessions; disabled in move mode)
+                if (self.move_mode) return .none;
                 if (self.filtered_count > 0 and self.selected < self.filtered_count) {
                     const e = &self.entries[self.filtered_indices[self.selected]];
                     if (e.alive) {
@@ -222,7 +237,10 @@ pub const SessionPickerState = struct {
                 self.selected = 0;
                 self.adjustScroll();
             },
-            14 => return .switch_to_default, // Ctrl-D — switch to hidden "default" session
+            14 => { // Ctrl-D — switch to hidden "default" session (disabled in move mode)
+                if (self.move_mode) return .none;
+                return .switch_to_default;
+            },
             15 => { // Ctrl-W — delete word backward
                 if (self.filter_len > 0) {
                     self.filter_len = deleteWordBackward(&self.filter_buf, self.filter_len);
@@ -253,7 +271,9 @@ pub const SessionPickerState = struct {
     }
 
     /// Total items = filtered sessions + fs results + 1 ("New session" entry).
+    /// In move mode only existing sessions are selectable.
     pub fn totalCount(self: *const SessionPickerState) u8 {
+        if (self.move_mode) return self.filtered_count;
         return self.filtered_count +| self.fs_count +| 1;
     }
 
@@ -440,6 +460,34 @@ test "handleCmd: enter on session returns switch_session" {
         .switch_session => |id| try std.testing.expectEqual(@as(u32, 42), id),
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "move mode: enter returns move_to_session and hides New entry" {
+    var state = SessionPickerState{};
+    state.move_mode = true;
+    state.entries[0] = .{ .id = 11, .name_len = 3, .alive = true };
+    @memcpy(state.entries[0].name[0..3], "one");
+    state.entries[1] = .{ .id = 22, .name_len = 3, .alive = true };
+    @memcpy(state.entries[1].name[0..3], "two");
+    state.entry_count = 2;
+    state.applyFilter();
+
+    // No "New session" row in move mode.
+    try std.testing.expectEqual(@as(u8, 2), state.totalCount());
+
+    state.selected = 1;
+    const action = state.handleCmd(8); // Enter
+    switch (action) {
+        .move_to_session => |id| try std.testing.expectEqual(@as(u32, 22), id),
+        else => return error.TestUnexpectedResult,
+    }
+
+    // Rename/kill/detach shortcuts are disabled while picking a move target.
+    try std.testing.expectEqual(PickerMode.browsing, state.mode);
+    _ = state.handleCmd(11); // Ctrl-R
+    try std.testing.expectEqual(PickerMode.browsing, state.mode);
+    _ = state.handleCmd(12); // Ctrl-X
+    try std.testing.expectEqual(PickerMode.browsing, state.mode);
 }
 
 test "handleCmd: enter on 'New session' returns create_session" {

--- a/src/overlay/session_picker_panel.zig
+++ b/src/overlay/session_picker_panel.zig
@@ -136,7 +136,9 @@ pub fn renderSessionPicker(
         }
         break :blk false;
     };
-    const hint_text: []const u8 = switch (state.mode) {
+    const hint_text: []const u8 = if (state.move_mode)
+        "\xe2\x86\x91\xe2\x86\x93 navigate \xe2\x80\xa2 enter move here \xe2\x80\xa2 esc cancel"
+    else switch (state.mode) {
         .browsing => if (in_default)
             "\xe2\x86\x91\xe2\x86\x93 navigate \xe2\x80\xa2 enter select \xe2\x80\xa2 ^R rename \xe2\x80\xa2 ^X delete \xe2\x80\xa2 esc close"
         else
@@ -228,7 +230,7 @@ pub fn renderSessionPicker(
     } };
 
     const config = PanelConfig{
-        .title = "Sessions",
+        .title = if (state.move_mode) "Move tab to session" else "Sessions",
         .width = .{ .percent = 50 },
         .height = .{ .percent = 50 },
         .border = .rounded,


### PR DESCRIPTION
## What

Adds a **Move to session** command (command palette) that moves the active tab — including all of its split panes — into another running session, then switches to that session and lands on the moved tab.

The panes are transferred **live**: the daemon hands the `DaemonPane` values from the source session to the destination without killing or respawning anything, so your shell, editor, and any long-running process carry over intact. Pane IDs are globally unique across the daemon, so no ID remapping is required.

## Why

Until now a tab was stuck in the session it was born in. Reorganizing work meant killing and recreating panes, losing running state. This lets you reshuffle tabs across sessions freely.

## How it works

1. Pick **Move to session** in the command palette → the session picker opens in a new "move" mode listing your other running sessions.
2. On Enter, the client serializes the active tab's split tree and sends a `move_panes` request to the daemon.
3. The daemon transfers the panes (`takePaneById`/`adoptPane`, no `deinit`), merges the moved tab into the destination's layout and makes it active, then broadcasts `layout_sync` to any other window viewing the destination.
4. The client waits for the daemon's `moved` ack and only then drops the tab locally and switches to the destination — landing on the moved tab.

## Design notes

- **Synchronous confirmation.** Matching the existing new-tab path (`waitForPaneCreated`), the move is confirmed before any local state changes. If the destination is at its tab/pane cap the move is rejected and the tab stays put, so running processes are never orphaned.
- **Reused the session picker** in a `move_mode` rather than adding a new overlay — this inherits the picker's existing per-platform input routing instead of touching every platform input file plus the overlay-id table.
- **Never-attached destinations** (no layout blob yet) get single-pane tabs synthesized for their existing panes before the moved tab is appended, so nothing is hidden.
- Moving the **only** tab in a session leaves that source session empty (dead/revivable).

## Tests

- Daemon integration test: create two sessions, move a pane, assert it survives in the destination, the destination layout ends on the moved tab, and the emptied source goes dead.
- Picker unit test for move mode (Enter emits `move_to_session`, the "New session" row is hidden, rename/kill shortcuts disabled).

All 1093 tests pass.

## Follow-up

Wired for the macOS/Linux session path. Windows uses a separate picker stack (`win_session_picker`/`win_overlays`); the command no-ops there until that path is wired.