### PR TITLE
Add macOS option_as_alt keyboard setting

### DIFF
--- a/releases/v0.4.4.md
+++ b/releases/v0.4.4.md
@@ -2,11 +2,11 @@
 
 ## Option key on international keyboards
 
-Attyx now lets the macOS Option (⌥) key type the special characters your keyboard layout puts there. On a Spanish layout, Option+ñ types `~` again; on many European layouts Option is how you reach `[`, `]`, `{`, `}`, `\`, `@`, and accented characters — all of those now work.
+You can now tell Attyx to let the macOS Option (⌥) key type the special characters your keyboard layout puts there. On a Spanish layout that means Option+ñ types `~`; on many European layouts Option is how you reach `[`, `]`, `{`, `}`, `\`, `@`, and accented characters.
 
-- **New `[keyboard]` setting `option_as_alt`** — controls whether Option composes characters or acts as Alt/Meta:
-  - `false` (the new default) — Option composes characters using your keyboard layout. If accented or special characters weren't typing, this fixes it.
-  - `true` — Option acts as Alt/Meta and sends ESC-prefixed sequences, for Meta keybindings in vim, emacs, or tmux.
+- **New `[keyboard]` setting `option_as_alt`** — controls whether Option acts as Alt/Meta or composes characters:
+  - `true` (default) — Option acts as Alt/Meta and sends ESC-prefixed sequences, for Meta keybindings in vim, emacs, or tmux.
+  - `false` — Option composes characters using your keyboard layout. Set this if accented or special characters weren't typing.
   - `"left"` / `"right"` — only that one physical Option key acts as Alt; the other one composes.
 
   The setting takes effect immediately on save (Ctrl+Shift+R to reload). Option+←/→ word navigation and your `alt+…` keybindings keep working no matter how it's set. (#245)

--- a/releases/v0.4.4.md
+++ b/releases/v0.4.4.md
@@ -1,0 +1,12 @@
+# Attyx v0.4.4
+
+## Option key on international keyboards
+
+Attyx now lets the macOS Option (⌥) key type the special characters your keyboard layout puts there. On a Spanish layout, Option+ñ types `~` again; on many European layouts Option is how you reach `[`, `]`, `{`, `}`, `\`, `@`, and accented characters — all of those now work.
+
+- **New `[keyboard]` setting `option_as_alt`** — controls whether Option composes characters or acts as Alt/Meta:
+  - `false` (the new default) — Option composes characters using your keyboard layout. If accented or special characters weren't typing, this fixes it.
+  - `true` — Option acts as Alt/Meta and sends ESC-prefixed sequences, for Meta keybindings in vim, emacs, or tmux.
+  - `"left"` / `"right"` — only that one physical Option key acts as Alt; the other one composes.
+
+  The setting takes effect immediately on save (Ctrl+Shift+R to reload). Option+←/→ word navigation and your `alt+…` keybindings keep working no matter how it's set. (#245)

--- a/src/app/macos_input_keyboard.m
+++ b/src/app/macos_input_keyboard.m
@@ -77,6 +77,23 @@ static uint8_t buildMods(NSEventModifierFlags flags) {
     return m;
 }
 
+// Device-dependent modifier bits distinguishing the two physical Option keys.
+#define ATTYX_LEFT_OPTION_MASK  0x20  // NX_DEVICELALTKEYMASK
+#define ATTYX_RIGHT_OPTION_MASK 0x40  // NX_DEVICELRALTKEYMASK
+
+// Whether the Option key in `flags` should act as Alt/Meta (emit an ESC-prefixed
+// sequence) instead of composing a character (e.g. Option+ñ → ~ on a Spanish
+// layout). Controlled by g_macos_option_as_alt: 0=none, 1=both, 2=left, 3=right.
+static BOOL optionActsAsAlt(NSEventModifierFlags flags) {
+    if (!(flags & NSEventModifierFlagOption)) return NO;
+    switch (g_macos_option_as_alt) {
+        case 1:  return YES;
+        case 2:  return (flags & ATTYX_LEFT_OPTION_MASK) != 0;
+        case 3:  return (flags & ATTYX_RIGHT_OPTION_MASK) != 0;
+        default: return NO;
+    }
+}
+
 // Build key + codepoint for keybind matching from an NSEvent.
 static void eventToKeyCombo(NSEvent* event, uint16_t* outKey, uint32_t* outCp) {
     uint16_t mapped = mapKeyCode(event.keyCode);
@@ -310,8 +327,11 @@ static void eventToKeyCombo(NSEvent* event, uint16_t* outKey, uint32_t* outCp) {
         return YES;
     }
 
-    // Ctrl+key or Alt+key with a character
-    if (ctrl || (flags & NSEventModifierFlagOption)) {
+    // Ctrl+key or Alt+key with a character. When Option does NOT act as Alt
+    // (the default), let the key fall through to interpretKeyEvents so macOS
+    // composes the layout's character (e.g. Option+ñ → ~) instead of emitting
+    // an ESC-prefixed Meta sequence.
+    if (ctrl || optionActsAsAlt(flags)) {
         NSString* chars = event.charactersIgnoringModifiers;
         if (chars.length > 0) {
             uint32_t cp = [chars characterAtIndex:0];

--- a/src/app/macos_internal.h
+++ b/src/app/macos_internal.h
@@ -32,6 +32,9 @@ extern volatile int g_mouse_sgr;
 // Kitty keyboard protocol flags
 extern volatile int g_kitty_kbd_flags;
 
+// Option-as-Alt mode: 0=none (compose), 1=both, 2=left option, 3=right option
+extern volatile int g_macos_option_as_alt;
+
 // Hyperlink hover state
 extern volatile uint32_t g_hover_link_id;
 extern volatile int g_hover_row;

--- a/src/app/main.zig
+++ b/src/app/main.zig
@@ -18,7 +18,7 @@ export fn attyx_handle_key(_: u16, _: u8, _: u8, _: u32) void {}
 export fn attyx_get_link_uri(_: u32, _: [*]u8, _: c_int) c_int { return 0; }
 export var g_needs_reload_config: i32 = 0;
 export var g_kitty_kbd_flags: i32 = 0;
-export var g_macos_option_as_alt: i32 = 0;
+export var g_macos_option_as_alt: i32 = 1;
 export var g_needs_font_rebuild: i32 = 0;
 export var g_needs_window_update: i32 = 0;
 export fn attyx_trigger_config_reload() void {}

--- a/src/app/main.zig
+++ b/src/app/main.zig
@@ -18,6 +18,7 @@ export fn attyx_handle_key(_: u16, _: u8, _: u8, _: u32) void {}
 export fn attyx_get_link_uri(_: u32, _: [*]u8, _: c_int) c_int { return 0; }
 export var g_needs_reload_config: i32 = 0;
 export var g_kitty_kbd_flags: i32 = 0;
+export var g_macos_option_as_alt: i32 = 0;
 export var g_needs_font_rebuild: i32 = 0;
 export var g_needs_window_update: i32 = 0;
 export fn attyx_trigger_config_reload() void {}

--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -122,6 +122,8 @@ pub var g_xyron_path: ?[:0]const u8 = null;
 // ---------------------------------------------------------------------------
 pub export var g_needs_reload_config: i32 = 0;
 pub export var g_kitty_kbd_flags: i32 = 0;
+// macOS Option-as-Alt mode: 0=none (compose), 1=both, 2=left, 3=right
+pub export var g_macos_option_as_alt: i32 = 0;
 pub export var g_needs_font_rebuild: i32 = 0;
 pub export var g_needs_window_update: i32 = 0;
 pub export var g_background_opacity: f32 = 1.0;
@@ -347,6 +349,7 @@ pub fn run(
     publish.publishFontConfig(&config);
     c.g_cursor_trail = @intFromBool(config.cursor_trail);
     c.g_font_ligatures = @intFromBool(config.font_ligatures);
+    g_macos_option_as_alt = config.option_as_alt.encode();
     g_background_opacity = config.background_opacity;
     g_background_blur = @intCast(config.background_blur);
     g_window_decorations = if (config.window_decorations) 1 else 0;

--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -123,7 +123,7 @@ pub var g_xyron_path: ?[:0]const u8 = null;
 pub export var g_needs_reload_config: i32 = 0;
 pub export var g_kitty_kbd_flags: i32 = 0;
 // macOS Option-as-Alt mode: 0=none (compose), 1=both, 2=left, 3=right
-pub export var g_macos_option_as_alt: i32 = 0;
+pub export var g_macos_option_as_alt: i32 = 1;
 pub export var g_needs_font_rebuild: i32 = 0;
 pub export var g_needs_window_update: i32 = 0;
 pub export var g_background_opacity: f32 = 1.0;

--- a/src/app/ui/actions.zig
+++ b/src/app/ui/actions.zig
@@ -655,6 +655,7 @@ pub fn doReloadConfig(ctx: *PtyThreadCtx) void {
         c.g_font_ligatures = @intFromBool(new_cfg.font_ligatures);
         ctx.applied_font_ligatures = new_cfg.font_ligatures;
     }
+    terminal.g_macos_option_as_alt = new_cfg.option_as_alt.encode();
 
     // Scrollback
     if (new_cfg.scrollback_lines != ctx.applied_scrollback_lines) {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -92,6 +92,37 @@ pub const TabSide = enum {
     }
 };
 
+/// macOS Option-key behavior. `.none` lets the Option key compose special
+/// characters (the macOS default, e.g. Option+ñ → ~ on a Spanish layout).
+/// The other variants make Option act as Alt/Meta and emit ESC-prefixed
+/// sequences, optionally restricted to one physical Option key.
+pub const OptionAsAlt = enum {
+    none,
+    both,
+    left,
+    right,
+
+    /// Accepts booleans (`true`/`false`) and the strings
+    /// `"true"`/`"false"`/`"both"`/`"left"`/`"right"`.
+    pub fn fromString(s: []const u8) ?OptionAsAlt {
+        if (std.mem.eql(u8, s, "false") or std.mem.eql(u8, s, "none")) return .none;
+        if (std.mem.eql(u8, s, "true") or std.mem.eql(u8, s, "both")) return .both;
+        if (std.mem.eql(u8, s, "left")) return .left;
+        if (std.mem.eql(u8, s, "right")) return .right;
+        return null;
+    }
+
+    /// Encode for the C bridge: 0=none, 1=both, 2=left, 3=right.
+    pub fn encode(self: OptionAsAlt) i32 {
+        return switch (self) {
+            .none => 0,
+            .both => 1,
+            .left => 2,
+            .right => 3,
+        };
+    }
+};
+
 const keybinds = @import("keybinds.zig");
 pub const KeybindOverride = keybinds.KeybindOverride;
 pub const SequenceEntry = keybinds.SequenceEntry;
@@ -177,6 +208,9 @@ pub const AppConfig = struct {
     // [statusbar]
     statusbar: ?StatusbarConfig = null,
     _owned_statusbar: bool = false,
+
+    // [keyboard]
+    option_as_alt: OptionAsAlt = .none,
 
     // [splits]
     split_resize_step: u16 = 4,

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -210,7 +210,7 @@ pub const AppConfig = struct {
     _owned_statusbar: bool = false,
 
     // [keyboard]
-    option_as_alt: OptionAsAlt = .none,
+    option_as_alt: OptionAsAlt = .both,
 
     // [splits]
     split_resize_step: u16 = 4,

--- a/src/config/config_parse.zig
+++ b/src/config/config_parse.zig
@@ -6,6 +6,7 @@ const CursorShapeConfig = config_mod.CursorShapeConfig;
 const CellSize = config_mod.CellSize;
 const TabAppearance = config_mod.TabAppearance;
 const TabSide = config_mod.TabSide;
+const OptionAsAlt = config_mod.OptionAsAlt;
 const PopupConfigEntry = config_mod.PopupConfigEntry;
 const KeybindOverride = config_mod.KeybindOverride;
 const SequenceEntry = config_mod.SequenceEntry;
@@ -353,6 +354,21 @@ pub fn applyToml(allocator: std.mem.Allocator, content: []const u8, path: []cons
             }
         } else {
             std.debug.print("error: {s}: splits.resize_step must be an integer\n", .{path});
+            return error.ConfigValidationError;
+        }
+    }
+
+    // [keyboard]
+    if (Lookup.get(root, "keyboard", "option_as_alt")) |v| {
+        const parsed: ?OptionAsAlt = switch (v) {
+            .bool => |b| if (b) OptionAsAlt.both else OptionAsAlt.none,
+            .string => |s| OptionAsAlt.fromString(s),
+            else => null,
+        };
+        if (parsed) |oaa| {
+            config.option_as_alt = oaa;
+        } else {
+            std.debug.print("error: {s}: keyboard.option_as_alt must be true, false, \"left\", or \"right\"\n", .{path});
             return error.ConfigValidationError;
         }
     }
@@ -825,4 +841,37 @@ test "invalid tabs.appearance rejects" {
     ;
 
     try std.testing.expectError(error.ConfigValidationError, applyToml(alloc, toml_str, "<test>", &cfg));
+}
+
+test "keyboard.option_as_alt parses bool and string" {
+    const alloc = std.testing.allocator;
+
+    // Default is none (Option composes special characters).
+    try std.testing.expectEqual(OptionAsAlt.none, (AppConfig{}).option_as_alt);
+
+    {
+        var cfg = AppConfig{};
+        defer cfg.deinit();
+        try applyToml(alloc, "[keyboard]\noption_as_alt = true\n", "<test>", &cfg);
+        try std.testing.expectEqual(OptionAsAlt.both, cfg.option_as_alt);
+    }
+    {
+        var cfg = AppConfig{};
+        defer cfg.deinit();
+        try applyToml(alloc, "[keyboard]\noption_as_alt = false\n", "<test>", &cfg);
+        try std.testing.expectEqual(OptionAsAlt.none, cfg.option_as_alt);
+    }
+    {
+        var cfg = AppConfig{};
+        defer cfg.deinit();
+        try applyToml(alloc, "[keyboard]\noption_as_alt = \"right\"\n", "<test>", &cfg);
+        try std.testing.expectEqual(OptionAsAlt.right, cfg.option_as_alt);
+    }
+}
+
+test "invalid keyboard.option_as_alt rejects" {
+    const alloc = std.testing.allocator;
+    var cfg = AppConfig{};
+
+    try std.testing.expectError(error.ConfigValidationError, applyToml(alloc, "[keyboard]\noption_as_alt = \"meta\"\n", "<test>", &cfg));
 }

--- a/src/config/config_parse.zig
+++ b/src/config/config_parse.zig
@@ -846,8 +846,8 @@ test "invalid tabs.appearance rejects" {
 test "keyboard.option_as_alt parses bool and string" {
     const alloc = std.testing.allocator;
 
-    // Default is none (Option composes special characters).
-    try std.testing.expectEqual(OptionAsAlt.none, (AppConfig{}).option_as_alt);
+    // Default is both (Option acts as Alt/Meta).
+    try std.testing.expectEqual(OptionAsAlt.both, (AppConfig{}).option_as_alt);
 
     {
         var cfg = AppConfig{};

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -127,15 +127,15 @@
 [keyboard]
 
 # macOS only: how the Option (⌥) key behaves.  [live]
-# - false   Option composes characters using your keyboard layout, e.g.
-#           Option+ñ → ~ on a Spanish layout (the macOS default). Use this
-#           if international/accented characters aren't typing correctly.
 # - true    Option acts as Alt/Meta and sends ESC-prefixed sequences
-#           (e.g. for Meta keybindings in vim, emacs, or tmux).
+#           (e.g. for Meta keybindings in vim, emacs, or tmux). Default.
+# - false   Option composes characters using your keyboard layout, e.g.
+#           Option+ñ → ~ on a Spanish layout. Use this if international or
+#           accented characters aren't typing correctly.
 # - "left"  Only the left Option key acts as Alt; the right one composes.
 # - "right" Only the right Option key acts as Alt; the left one composes.
 # Arrow-key word navigation (Option+←/→) works regardless of this setting.
-# option_as_alt = false
+# option_as_alt = true
 
 
 # ── Tabs ──────────────────────────────────────────────────────────────

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -122,6 +122,22 @@
 # scrollbar = true
 
 
+# ── Keyboard ──────────────────────────────────────────────────────────
+
+[keyboard]
+
+# macOS only: how the Option (⌥) key behaves.  [live]
+# - false   Option composes characters using your keyboard layout, e.g.
+#           Option+ñ → ~ on a Spanish layout (the macOS default). Use this
+#           if international/accented characters aren't typing correctly.
+# - true    Option acts as Alt/Meta and sends ESC-prefixed sequences
+#           (e.g. for Meta keybindings in vim, emacs, or tmux).
+# - "left"  Only the left Option key acts as Alt; the right one composes.
+# - "right" Only the right Option key acts as Alt; the left one composes.
+# Arrow-key word navigation (Option+←/→) works regardless of this setting.
+# option_as_alt = false
+
+
 # ── Tabs ──────────────────────────────────────────────────────────────
 
 [tabs]


### PR DESCRIPTION
## What

Adds a `[keyboard] option_as_alt` config option controlling how the macOS Option (⌥) key behaves.

Closes #238.

## Why

On macOS, Attyx always treated Option as Alt/Meta — every Option+key combo emitted an ESC-prefixed sequence, with no way to opt out. On international keyboard layouts this breaks character composition: on a Spanish layout, Option+ñ should type `~`, but Attyx sent `^[ñ` instead (as the reporter showed with `cat`). Layout-composed characters like `~`, `[`, `]`, `{`, `}`, accents, etc. were unreachable.

Every major macOS terminal (Terminal.app, iTerm2, Ghostty, Alacritty, kitty) exposes this toggle.

## What changed

New `[keyboard]` section with a single option:

```toml
[keyboard]
# true    Option acts as Alt/Meta, sending ESC-prefixed sequences. Default.
# false   Option composes characters via your layout (Option+ñ → ~).
# "left"  Only the left Option key acts as Alt; the right one composes.
# "right" Only the right Option key acts as Alt; the left one composes.
option_as_alt = true
```

- **Default is `true`**, preserving today's Option-as-Meta behaviour — this PR is non-breaking. Users on international layouts (the issue reporter) set `option_as_alt = false` to type composed characters.
- The setting **only gates the text-composition path**. Option+Arrow word navigation (`ESC b`/`ESC f`) and configurable keybindings (`alt+1`, `alt+z`, …) keep working regardless, since arrow/digit keybinds are matched before composition and never conflict with typed characters.
- `"left"`/`"right"` use the device-dependent modifier bits to distinguish the two physical Option keys.
- Live-reloadable (Ctrl+Shift+R).

## Testing

- New parser tests covering bool/string forms and rejection of invalid values.
- Full test suite passes (one unrelated pre-existing flaky test in `dir_walker` excepted).
- macOS app builds clean.