### PR TITLE
Show agent status counts in the session picker

### DIFF
--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -401,10 +401,27 @@ pub const DaemonClient = struct {
         for (sessions) |*slot| {
             if (slot.*) |*s| {
                 if (count >= 32) break;
+                var ready: u8 = 0;
+                var working: u8 = 0;
+                var attention: u8 = 0;
+                for (&s.panes) |*pslot| {
+                    if (pslot.*) |*p| {
+                        const eng = p.engine orelse continue;
+                        switch (eng.state.agent_status) {
+                            .idle => ready +|= 1,
+                            .working => working +|= 1,
+                            .input => attention +|= 1,
+                            .none => {},
+                        }
+                    }
+                }
                 entries[count] = .{
                     .id = s.id,
                     .name = s.getName(),
                     .alive = s.alive,
+                    .ready = ready,
+                    .working = working,
+                    .attention = attention,
                 };
                 count += 1;
             }

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -248,9 +248,16 @@ pub const SessionEntry = struct {
     id: u32,
     name: []const u8,
     alive: bool,
+    /// Agent status tallies across the session's panes (idle/working/input).
+    ready: u8 = 0,
+    working: u8 = 0,
+    attention: u8 = 0,
 };
 
-/// Encode SessionList payload: count:u16, entries:[{id:u32, name_len:u16, name:[N]u8, alive:u8}]
+/// Encode SessionList payload: count:u16, entries:[{id:u32, name_len:u16, name:[N]u8, alive:u8}],
+/// then a trailing block of per-entry status tallies [{ready:u8, working:u8, attention:u8}].
+/// The trailing block is appended after all entries so older decoders (which stop
+/// after `count` entries) ignore it; newer decoders detect it by payload length.
 pub fn encodeSessionList(buf: []u8, entries: []const SessionEntry) ![]u8 {
     var pos: usize = 0;
     if (buf.len < 2) return error.BufferTooSmall;
@@ -269,6 +276,14 @@ pub fn encodeSessionList(buf: []u8, entries: []const SessionEntry) ![]u8 {
         buf[pos] = if (entry.alive) 1 else 0;
         pos += 1;
     }
+    // Trailing status block — 3 bytes per entry, same order as above.
+    if (pos + entries.len * 3 > buf.len) return error.BufferTooSmall;
+    for (entries) |entry| {
+        buf[pos] = entry.ready;
+        buf[pos + 1] = entry.working;
+        buf[pos + 2] = entry.attention;
+        pos += 3;
+    }
     return buf[0..pos];
 }
 
@@ -277,6 +292,9 @@ pub const DecodedListEntry = struct {
     id: u32,
     name: []const u8,
     alive: bool,
+    ready: u8 = 0,
+    working: u8 = 0,
+    attention: u8 = 0,
 };
 
 /// Decode SessionList payload: count:u16, entries:[{id:u32, name_len:u16, name:[N]u8, alive:u8}]
@@ -300,6 +318,15 @@ pub fn decodeSessionList(payload: []const u8, out: []DecodedListEntry) !u16 {
         pos += 1;
         out[decoded] = .{ .id = id, .name = name, .alive = alive };
         decoded += 1;
+    }
+    // Optional trailing status block: present iff exactly `count` triples remain.
+    if (decoded == count and pos + @as(usize, count) * 3 <= payload.len) {
+        for (0..decoded) |i| {
+            out[i].ready = payload[pos];
+            out[i].working = payload[pos + 1];
+            out[i].attention = payload[pos + 2];
+            pos += 3;
+        }
     }
     return decoded;
 }
@@ -915,8 +942,8 @@ test "error round-trip" {
 test "session list round-trip" {
     var buf: [256]u8 = undefined;
     const entries = [_]SessionEntry{
-        .{ .id = 1, .name = "shell", .alive = true },
-        .{ .id = 2, .name = "vim", .alive = false },
+        .{ .id = 1, .name = "shell", .alive = true, .ready = 2, .working = 1, .attention = 0 },
+        .{ .id = 2, .name = "vim", .alive = false, .ready = 0, .working = 0, .attention = 3 },
     };
     const payload = try encodeSessionList(&buf, &entries);
 
@@ -926,9 +953,38 @@ test "session list round-trip" {
     try std.testing.expectEqual(@as(u32, 1), decoded[0].id);
     try std.testing.expectEqualStrings("shell", decoded[0].name);
     try std.testing.expect(decoded[0].alive);
+    try std.testing.expectEqual(@as(u8, 2), decoded[0].ready);
+    try std.testing.expectEqual(@as(u8, 1), decoded[0].working);
+    try std.testing.expectEqual(@as(u8, 0), decoded[0].attention);
     try std.testing.expectEqual(@as(u32, 2), decoded[1].id);
     try std.testing.expectEqualStrings("vim", decoded[1].name);
     try std.testing.expect(!decoded[1].alive);
+    try std.testing.expectEqual(@as(u8, 3), decoded[1].attention);
+}
+
+test "session list: old-format payload (no status block) decodes with zero counts" {
+    // Encode entries the legacy way: count + entries, no trailing status block.
+    var buf: [256]u8 = undefined;
+    var pos: usize = 0;
+    std.mem.writeInt(u16, buf[0..2], 1, .little);
+    pos = 2;
+    std.mem.writeInt(u32, buf[pos..][0..4], 9, .little);
+    pos += 4;
+    const name = "legacy";
+    std.mem.writeInt(u16, buf[pos..][0..2], name.len, .little);
+    pos += 2;
+    @memcpy(buf[pos .. pos + name.len], name);
+    pos += name.len;
+    buf[pos] = 1; // alive
+    pos += 1;
+
+    var decoded: [8]DecodedListEntry = undefined;
+    const count = try decodeSessionList(buf[0..pos], &decoded);
+    try std.testing.expectEqual(@as(u16, 1), count);
+    try std.testing.expectEqualStrings("legacy", decoded[0].name);
+    try std.testing.expectEqual(@as(u8, 0), decoded[0].ready);
+    try std.testing.expectEqual(@as(u8, 0), decoded[0].working);
+    try std.testing.expectEqual(@as(u8, 0), decoded[0].attention);
 }
 
 test "create_pane round-trip" {

--- a/src/app/session_client.zig
+++ b/src/app/session_client.zig
@@ -38,6 +38,10 @@ pub const ListEntry = struct {
     name_len: u8 = 0,
     alive: bool = false,
     pane_count: u8 = 0,
+    /// Agent status tallies across the session's panes.
+    ready: u8 = 0,
+    working: u8 = 0,
+    attention: u8 = 0,
 
     pub fn getName(self: *const ListEntry) []const u8 {
         return self.name[0..self.name_len];
@@ -681,6 +685,9 @@ pub const SessionClient = struct {
             var entry = &self.pending_list[i];
             entry.id = decoded[i].id;
             entry.alive = decoded[i].alive;
+            entry.ready = decoded[i].ready;
+            entry.working = decoded[i].working;
+            entry.attention = decoded[i].attention;
             const nlen: u8 = @intCast(@min(decoded[i].name.len, 64));
             @memcpy(entry.name[0..nlen], decoded[i].name[0..nlen]);
             entry.name_len = nlen;

--- a/src/app/session_windows.zig
+++ b/src/app/session_windows.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const TabManager = @import("tab_manager.zig").TabManager;
+const split_layout_mod = @import("split_layout.zig");
 const Pane = @import("pane.zig").Pane;
 const publish = @import("ui/publish.zig");
 const theme_registry_mod = @import("../theme/registry.zig");
@@ -44,6 +45,27 @@ pub const WinSession = struct {
             }
         }
         return total;
+    }
+
+    pub const StatusCounts = struct { ready: u8 = 0, working: u8 = 0, attention: u8 = 0 };
+
+    /// Tally agent status across all panes in all tabs of the session.
+    pub fn statusCounts(self: *const WinSession) StatusCounts {
+        var counts: StatusCounts = .{};
+        for (0..self.tab_mgr.count) |i| {
+            const layout = &(self.tab_mgr.tabs[i] orelse continue);
+            var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
+            const lc = layout.collectLeaves(&leaves);
+            for (leaves[0..lc]) |leaf| {
+                switch (leaf.pane.engine.state.agent_status) {
+                    .idle => counts.ready +|= 1,
+                    .working => counts.working +|= 1,
+                    .input => counts.attention +|= 1,
+                    .none => {},
+                }
+            }
+        }
+        return counts;
     }
 };
 

--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -91,6 +91,7 @@ pub const PtyThreadCtx = struct {
     session_icon_active: []const u8 = "(active)",
     session_icon_recent: []const u8 = "",
     session_icon_folder: []const u8 = "\xe2\x96\xb8",
+    session_icon_agent: []const u8 = "\xf3\xb0\x9a\xa9",
     // Session finder config
     session_finder_root: []const u8 = "~",
     session_finder_depth: u8 = 4,
@@ -837,6 +838,7 @@ pub fn run(
         .session_icon_active = config.session_icon_active,
         .session_icon_recent = config.session_icon_recent,
         .session_icon_folder = config.session_icon_folder,
+        .session_icon_agent = config.session_icon_agent,
         .session_finder_root = config.session_finder_root,
         .session_finder_depth = config.session_finder_depth,
         .session_finder_show_hidden = config.session_finder_show_hidden,

--- a/src/app/ui/session_picker_ui.zig
+++ b/src/app/ui/session_picker_ui.zig
@@ -44,6 +44,9 @@ pub fn openSessionPicker(ctx: *PtyThreadCtx) void {
             .id = le.id,
             .name_len = le.name_len,
             .alive = le.alive,
+            .ready = le.ready,
+            .working = le.working,
+            .attention = le.attention,
         };
         @memcpy(state.entries[i].name[0..le.name_len], le.name[0..le.name_len]);
     }
@@ -91,6 +94,9 @@ pub fn openSessionPickerMove(ctx: *PtyThreadCtx) void {
             .id = le.id,
             .name_len = le.name_len,
             .alive = le.alive,
+            .ready = le.ready,
+            .working = le.working,
+            .attention = le.attention,
         };
         @memcpy(state.entries[count].name[0..le.name_len], le.name[0..le.name_len]);
         count += 1;
@@ -312,6 +318,9 @@ fn refreshList(ctx: *PtyThreadCtx, state: *SessionPickerState) void {
             .id = le.id,
             .name_len = le.name_len,
             .alive = le.alive,
+            .ready = le.ready,
+            .working = le.working,
+            .attention = le.attention,
         };
         @memcpy(state.entries[i].name[0..le.name_len], le.name[0..le.name_len]);
     }
@@ -359,6 +368,7 @@ pub fn relayout(ctx: *PtyThreadCtx) void {
         .active = ctx.session_icon_active,
         .recent = ctx.session_icon_recent,
         .folder = ctx.session_icon_folder,
+        .agent = ctx.session_icon_agent,
     };
 
     const result = picker_panel.renderSessionPicker(
@@ -416,6 +426,7 @@ fn renderAndPublish(ctx: *PtyThreadCtx) void {
         .active = ctx.session_icon_active,
         .recent = ctx.session_icon_recent,
         .folder = ctx.session_icon_folder,
+        .agent = ctx.session_icon_agent,
     };
 
     const result = picker_panel.renderSessionPicker(

--- a/src/app/ui/win_session_picker.zig
+++ b/src/app/ui/win_session_picker.zig
@@ -34,10 +34,14 @@ pub fn openSessionPicker(ctx: *WinCtx) void {
     var count: u8 = 0;
     for (0..session_win.max_sessions) |i| {
         if (smgr.sessions[i]) |*s| {
+            const sc = s.statusCounts();
             var entry = SessionEntry{
                 .id = s.id,
                 .alive = s.alive,
                 .name_len = s.name_len,
+                .ready = sc.ready,
+                .working = sc.working,
+                .attention = sc.attention,
             };
             @memcpy(entry.name[0..s.name_len], s.name[0..s.name_len]);
             entries[count] = entry;
@@ -248,10 +252,14 @@ fn refreshEntries(ctx: *WinCtx) void {
     var count: u8 = 0;
     for (0..session_win.max_sessions) |i| {
         if (smgr.sessions[i]) |*s| {
+            const sc = s.statusCounts();
             var entry = SessionEntry{
                 .id = s.id,
                 .alive = s.alive,
                 .name_len = s.name_len,
+                .ready = sc.ready,
+                .working = sc.working,
+                .attention = sc.attention,
             };
             @memcpy(entry.name[0..s.name_len], s.name[0..s.name_len]);
             entries[count] = entry;

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -240,12 +240,14 @@ pub const AppConfig = struct {
     session_icon_active: []const u8 = "\xe2\x97\x8f",
     session_icon_recent: []const u8 = "\xe2\x97\x8b",
     session_icon_folder: []const u8 = "\xe2\x96\xb8",
+    session_icon_agent: []const u8 = "\xf3\xb0\x9a\xa9",
     _owned_session_icon_folder: ?[]const u8 = null,
     _owned_session_icon_filter: ?[]const u8 = null,
     _owned_session_icon_session: ?[]const u8 = null,
     _owned_session_icon_new: ?[]const u8 = null,
     _owned_session_icon_active: ?[]const u8 = null,
     _owned_session_icon_recent: ?[]const u8 = null,
+    _owned_session_icon_agent: ?[]const u8 = null,
 
     // [updates]
     check_updates: bool = true,
@@ -295,6 +297,7 @@ pub const AppConfig = struct {
         if (self._owned_session_icon_new) |s| alloc.free(s);
         if (self._owned_session_icon_active) |s| alloc.free(s);
         if (self._owned_session_icon_recent) |s| alloc.free(s);
+        if (self._owned_session_icon_agent) |s| alloc.free(s);
         if (self._owned_statusbar) {
             if (self.statusbar) |*sb| statusbar_config.deinitStatusbar(alloc, sb);
         }

--- a/src/config/config_parse.zig
+++ b/src/config/config_parse.zig
@@ -681,6 +681,7 @@ pub fn applyToml(allocator: std.mem.Allocator, content: []const u8, path: []cons
         .{ "icon_new", &config.session_icon_new, &config._owned_session_icon_new },
         .{ "icon_active", &config.session_icon_active, &config._owned_session_icon_active },
         .{ "icon_recent", &config.session_icon_recent, &config._owned_session_icon_recent },
+        .{ "icon_agent", &config.session_icon_agent, &config._owned_session_icon_agent },
     }) |kv| {
         if (Lookup.get(root, "sessions", kv[0])) |v| {
             if (v == .string) {

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -217,6 +217,10 @@
 # icon_active = "●"
 # icon_recent = "○"
 # icon_folder = "▸"
+# Leading glyph for the agent status badge shown on each session row (followed
+# by colored ready/working/attention counts). Defaults to a Nerd Font robot;
+# the font stack falls back (e.g. to SF Symbols) if the glyph is missing.
+# icon_agent = "󰚩"
 
 
 # ── Statusbar ────────────────────────────────────────────────────────

--- a/src/overlay/session_picker.zig
+++ b/src/overlay/session_picker.zig
@@ -13,6 +13,11 @@ pub const SessionEntry = struct {
     name: [64]u8 = undefined,
     name_len: u8 = 0,
     alive: bool = false,
+    /// Agent status tallies across the session's panes. Rendered as a
+    /// colored "ready/working/attention" badge on the right of each row.
+    ready: u8 = 0,
+    working: u8 = 0,
+    attention: u8 = 0,
 
     pub fn getName(self: *const SessionEntry) []const u8 {
         return self.name[0..self.name_len];

--- a/src/overlay/session_picker_panel.zig
+++ b/src/overlay/session_picker_panel.zig
@@ -21,6 +21,9 @@ pub const Icons = struct {
     active: []const u8 = "(active)",
     recent: []const u8 = "",
     folder: []const u8 = "\xe2\x96\xb8",
+    /// Leading glyph for the agent status badge — Nerd Font robot (nf-md-robot,
+    /// U+F06A9) by default; the font stack falls back (e.g. to SF Symbols).
+    agent: []const u8 = "\xf3\xb0\x9a\xa9",
 };
 
 const OverlayTheme = ui.OverlayTheme;
@@ -80,6 +83,12 @@ pub fn renderSessionPicker(
             menu_items[menu_count] = .{
                 .label = label_copy,
                 .enabled = e.alive,
+                .status = .{
+                    .ready = e.ready,
+                    .working = e.working,
+                    .attention = e.attention,
+                    .icon = icons.agent,
+                },
             };
         } else if (i < state.filtered_count +| state.fs_count) {
             // Filesystem result entry

--- a/src/overlay/ui.zig
+++ b/src/overlay/ui.zig
@@ -185,6 +185,18 @@ pub const Element = union(enum) {
         label: []const u8,
         hint_text: []const u8 = "",
         enabled: bool = true,
+        /// Optional colored status badge rendered right-aligned as
+        /// "ready/working/attention". Zero counts are dimmed.
+        status: ?StatusBadge = null,
+    };
+
+    pub const StatusBadge = struct {
+        ready: u16 = 0,
+        working: u16 = 0,
+        attention: u16 = 0,
+        /// Optional leading glyph (e.g. a Nerd Font robot) rendered before the
+        /// counts. Empty hides it.
+        icon: []const u8 = "",
     };
 
     pub const Hint = struct {
@@ -208,6 +220,11 @@ pub const OverlayTheme = struct {
     selected_bg: Rgb = .{ .r = 60, .g = 60, .b = 100 },
     selected_fg: Rgb = .{ .r = 255, .g = 255, .b = 255 },
     hint_fg: Rgb = .{ .r = 120, .g = 120, .b = 140 },
+    // Agent status badge colors — mirror the tab-bar dots
+    // (idle=green, working=orange, waiting=purple).
+    agent_ready_fg: Rgb = .{ .r = 96, .g = 208, .b = 120 },
+    agent_working_fg: Rgb = .{ .r = 255, .g = 170, .b = 64 },
+    agent_attention_fg: Rgb = .{ .r = 176, .g = 112, .b = 255 },
 
     pub fn rootStyle(self: OverlayTheme) ResolvedStyle {
         return .{

--- a/src/overlay/ui_render.zig
+++ b/src/overlay/ui_render.zig
@@ -130,6 +130,9 @@ fn measureMenu(m: Element.Menu, max_w: u16) Size {
         if (item.hint_text.len > 0) {
             item_w += @min(utf8Count(item.hint_text) + 2, max_w); // "  hint"
         }
+        if (item.status) |sb| {
+            item_w += @min(statusBadgeWidth(sb) + 2, max_w); // "  r/w/a"
+        }
         max_item_w = @max(max_item_w, item_w);
     }
     const item_count: u16 = @intCast(m.items.len);
@@ -403,7 +406,6 @@ fn renderMenu(
     parent_style: ResolvedStyle,
     theme: OverlayTheme,
 ) RenderResult {
-    _ = theme;
     const rs = parent_style.merge(m.style);
     const item_count: u16 = @intCast(m.items.len);
     const visible = if (m.visible_count) |vc| @min(vc, avail_h) else avail_h;
@@ -440,11 +442,72 @@ fn renderMenu(
                 item_w = avail_w;
             }
         }
+        // Write status badge right-aligned ("ready/working/attention")
+        if (item.status) |sb| {
+            const bw = statusBadgeWidth(sb);
+            if (bw + vis_label + 1 <= avail_w) {
+                const bx = x + avail_w - bw;
+                renderStatusBadge(cells, stride, buf_h, bx, y + row, sb, item_rs, theme);
+                item_w = avail_w;
+            }
+        }
         max_w = @max(max_w, item_w);
         row += 1;
     }
 
     return .{ .width = max_w, .height = row };
+}
+
+/// Column width of a "[icon ]ready/working/attention" badge.
+fn statusBadgeWidth(b: Element.StatusBadge) u16 {
+    const icon_w: u16 = if (b.icon.len > 0) utf8Count(b.icon) + 1 else 0; // glyph + space
+    return icon_w + numWidth(b.ready) + 1 + numWidth(b.working) + 1 + numWidth(b.attention);
+}
+
+fn numWidth(n: u16) u16 {
+    if (n < 10) return 1;
+    if (n < 100) return 2;
+    if (n < 1000) return 3;
+    if (n < 10000) return 4;
+    return 5;
+}
+
+/// Render "ready/working/attention" starting at (x, y). Each count is colored
+/// when non-zero, dimmed when zero; the slash separators are always dimmed.
+fn renderStatusBadge(
+    cells: []StyledCell,
+    stride: u16,
+    buf_h: u16,
+    x: u16,
+    y: u16,
+    b: Element.StatusBadge,
+    item_rs: ResolvedStyle,
+    theme: OverlayTheme,
+) void {
+    const dim = (TextFlags{ .dim = true }).toU8();
+    const normal = item_rs.text_flags.toU8();
+    var cx = x;
+    if (b.icon.len > 0) {
+        writeStr(cells, stride, buf_h, cx, y, b.icon, item_rs.fg, item_rs.bg, item_rs.bg_alpha, normal);
+        cx += utf8Count(b.icon) + 1; // glyph + space
+    }
+    cx = writeNum(cells, stride, buf_h, cx, y, b.ready, if (b.ready > 0) theme.agent_ready_fg else item_rs.fg, item_rs.bg, item_rs.bg_alpha, if (b.ready > 0) normal else dim);
+    cx = writeSep(cells, stride, buf_h, cx, y, item_rs, dim);
+    cx = writeNum(cells, stride, buf_h, cx, y, b.working, if (b.working > 0) theme.agent_working_fg else item_rs.fg, item_rs.bg, item_rs.bg_alpha, if (b.working > 0) normal else dim);
+    cx = writeSep(cells, stride, buf_h, cx, y, item_rs, dim);
+    _ = writeNum(cells, stride, buf_h, cx, y, b.attention, if (b.attention > 0) theme.agent_attention_fg else item_rs.fg, item_rs.bg, item_rs.bg_alpha, if (b.attention > 0) normal else dim);
+}
+
+fn writeNum(cells: []StyledCell, stride: u16, buf_h: u16, x: u16, y: u16, n: u16, fg: Rgb, bg: Rgb, bg_alpha: u8, flags: u8) u16 {
+    var buf: [8]u8 = undefined;
+    const s = std.fmt.bufPrint(&buf, "{d}", .{n}) catch return x;
+    writeStr(cells, stride, buf_h, x, y, s, fg, bg, bg_alpha, flags);
+    return x + @as(u16, @intCast(s.len));
+}
+
+fn writeSep(cells: []StyledCell, stride: u16, buf_h: u16, x: u16, y: u16, item_rs: ResolvedStyle, dim: u8) u16 {
+    writeStr(cells, stride, buf_h, x, y, "/", item_rs.fg, item_rs.bg, item_rs.bg_alpha, dim);
+    return x + 1;
 }
 
 fn renderHint(


### PR DESCRIPTION
## What

The session switcher now shows agent status for every session, not just the focused tab. Each row gets a colored `ready/working/attention` badge on the right, mirroring the agent status dots already shown on tabs:

- **green** — ready / idle
- **orange** — working
- **purple** — needs attention

All three counts are always shown: dimmed when zero, colored when non-zero, with dimmed `/` separators. The badge is led by a configurable Nerd Font robot glyph (`nf-md-robot`), which the font stack falls back on (e.g. to SF Symbols) when the primary font lacks it.

## Why

Status was previously only visible on the current session's tabs. When you have agents running across several sessions, the switcher is where you decide which to jump to — so it's the natural place to see, at a glance, which sessions are working and which are blocked on you.

## How

Agent status lives per-pane. In the daemon (POSIX) architecture the client only runs the VT engine for the *attached* session, so other sessions' statuses aren't available client-side. But the daemon runs an engine for every pane in every session, so it tallies each session's panes (`idle→ready`, `working→working`, `input→attention`) and includes the counts in the session-list response.

The counts ride in a trailing block appended after the existing entries, detected by payload length — older decoders stop after the entries and ignore it, newer ones read it, so it's safe across daemon↔client version skew. The windowed path has all sessions local and computes the same tally directly from its tab managers.

Counts are a snapshot taken when the picker opens (same as the existing name/alive data).

## Config

```toml
[sessions]
# icon_agent = "󰚩"
```

## Tests

Extended the session-list protocol round-trip test with counts and added a backward-compat test (legacy payload decodes to zero counts). Full suite passes; cross-compiles for Windows.