### PR TITLE
Order sessions by recency and create session directories from the picker

### DIFF
--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -397,6 +397,7 @@ pub const DaemonClient = struct {
     /// Send session list directly from session slots (avoids copying large structs).
     pub fn sendSessionListFromSlots(self: *DaemonClient, sessions: *[32]?DaemonSession) void {
         var entries: [32]protocol.SessionEntry = undefined;
+        var access: [32]i128 = undefined;
         var count: usize = 0;
         for (sessions) |*slot| {
             if (slot.*) |*s| {
@@ -423,9 +424,13 @@ pub const DaemonClient = struct {
                     .working = working,
                     .attention = attention,
                 };
+                access[count] = s.last_accessed;
                 count += 1;
             }
         }
+
+        // Order by recency of access so the client renders most-recent first.
+        protocol.orderEntriesByAccess(entries[0..count], access[0..count]);
 
         var payload_buf: [4096]u8 = undefined;
         const payload = protocol.encodeSessionList(&payload_buf, entries[0..count]) catch return;

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -150,6 +150,7 @@ fn handleAttach(
         return;
     };
     cl.attached_session = attach.session_id;
+    session.last_accessed = std.time.nanoTimestamp();
 
     // Revive dead (recent) sessions by spawning fresh panes.
     if (!session.alive) {

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -254,6 +254,26 @@ pub const SessionEntry = struct {
     attention: u8 = 0,
 };
 
+/// Order entries by recency of access — most recently accessed first.
+/// `access[i]` is the access timestamp for `entries[i]` (parallel arrays).
+/// Stable for equal timestamps (preserves the caller's original order), so
+/// sessions that were never attached fall back to slot order.
+pub fn orderEntriesByAccess(entries: []SessionEntry, access: []i128) void {
+    // Stable insertion sort, descending by access timestamp.
+    var i: usize = 1;
+    while (i < entries.len) : (i += 1) {
+        const entry_tmp = entries[i];
+        const access_tmp = access[i];
+        var j: usize = i;
+        while (j > 0 and access[j - 1] < access_tmp) : (j -= 1) {
+            entries[j] = entries[j - 1];
+            access[j] = access[j - 1];
+        }
+        entries[j] = entry_tmp;
+        access[j] = access_tmp;
+    }
+}
+
 /// Encode SessionList payload: count:u16, entries:[{id:u32, name_len:u16, name:[N]u8, alive:u8}],
 /// then a trailing block of per-entry status tallies [{ready:u8, working:u8, attention:u8}].
 /// The trailing block is appended after all entries so older decoders (which stop
@@ -937,6 +957,34 @@ test "error round-trip" {
     const msg = try decodeError(payload);
     try std.testing.expectEqual(@as(u8, 3), msg.code);
     try std.testing.expectEqualStrings("not found", msg.msg);
+}
+
+test "orderEntriesByAccess: most recent first, stable for ties" {
+    var entries = [_]SessionEntry{
+        .{ .id = 1, .name = "a", .alive = true },
+        .{ .id = 2, .name = "b", .alive = true },
+        .{ .id = 3, .name = "c", .alive = true },
+        .{ .id = 4, .name = "never", .alive = false },
+    };
+    // ids 1,2,3 attached in that order; id 4 never attached (ts 0).
+    var access = [_]i128{ 100, 200, 300, 0 };
+    orderEntriesByAccess(&entries, &access);
+
+    // Descending by timestamp: 3, 2, 1, then the never-attached one last.
+    try std.testing.expectEqual(@as(u32, 3), entries[0].id);
+    try std.testing.expectEqual(@as(u32, 2), entries[1].id);
+    try std.testing.expectEqual(@as(u32, 1), entries[2].id);
+    try std.testing.expectEqual(@as(u32, 4), entries[3].id);
+
+    // Ties preserve original order (stable): two entries with equal ts.
+    var tied = [_]SessionEntry{
+        .{ .id = 10, .name = "x", .alive = true },
+        .{ .id = 11, .name = "y", .alive = true },
+    };
+    var tied_access = [_]i128{ 50, 50 };
+    orderEntriesByAccess(&tied, &tied_access);
+    try std.testing.expectEqual(@as(u32, 10), tied[0].id);
+    try std.testing.expectEqual(@as(u32, 11), tied[1].id);
 }
 
 test "session list round-trip" {

--- a/src/app/daemon/session.zig
+++ b/src/app/daemon/session.zig
@@ -18,6 +18,10 @@ pub const DaemonSession = struct {
     layout_len: u16 = 0,
     alive: bool = true,
 
+    /// Wall-clock nanoseconds of the last attach. Used to order the session
+    /// list by recency of access (most recently attached first).
+    last_accessed: i128 = 0,
+
     /// Session working directory — used as default CWD for new panes.
     cwd: [1024]u8 = .{0} ** 1024,
     cwd_len: u16 = 0,
@@ -47,6 +51,7 @@ pub const DaemonSession = struct {
             .id = id,
             .rows = rows,
             .cols = cols,
+            .last_accessed = std.time.nanoTimestamp(),
         };
         const nlen = @min(name.len, 64);
         @memcpy(session.name[0..nlen], name[0..nlen]);

--- a/src/app/daemon/session_test.zig
+++ b/src/app/daemon/session_test.zig
@@ -51,8 +51,9 @@ test "list sessions returns created sessions" {
     var entries: [32]protocol.DecodedListEntry = undefined;
     const count = try protocol.decodeSessionList(list_payload, &entries);
     try testing.expectEqual(@as(u16, 2), count);
-    try testing.expectEqualStrings("alpha", entries[0].name);
-    try testing.expectEqualStrings("beta", entries[1].name);
+    // Listed most-recently-accessed first: beta was created after alpha.
+    try testing.expectEqualStrings("beta", entries[0].name);
+    try testing.expectEqualStrings("alpha", entries[1].name);
     try testing.expect(entries[0].alive);
     try testing.expect(entries[1].alive);
 }

--- a/src/app/ui/session_picker_ui.zig
+++ b/src/app/ui/session_picker_ui.zig
@@ -285,6 +285,40 @@ fn processAction(ctx: *PtyThreadCtx, state: *SessionPickerState, action: picker_
             ctx.allocator.free(path_copy);
             return true;
         },
+        .create_session_named => |name| {
+            // Copy the name out before tearing down picker state.
+            var name_buf: [64]u8 = undefined;
+            const nlen = @min(name.len, name_buf.len);
+            @memcpy(name_buf[0..nlen], name[0..nlen]);
+
+            const finder = &(g_finder_state orelse {
+                closeSessionPicker(ctx);
+                return true;
+            });
+            const root = finder.getRootPath();
+            var abs_buf: [512]u8 = undefined;
+            const abs_path = std.fmt.bufPrint(&abs_buf, "{s}/{s}", .{ root, name_buf[0..nlen] }) catch {
+                closeSessionPicker(ctx);
+                return true;
+            };
+            // Create the new session directory (ok if it already exists).
+            std.fs.makeDirAbsolute(abs_path) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => {
+                    logging.warn("session-picker", "failed to create dir {s}: {s}", .{ abs_path, @errorName(err) });
+                    closeSessionPicker(ctx);
+                    return true;
+                },
+            };
+            const path_copy = ctx.allocator.dupe(u8, abs_path) catch {
+                closeSessionPicker(ctx);
+                return true;
+            };
+            closeSessionPicker(ctx);
+            session_actions.doSessionCreate(ctx, path_copy);
+            ctx.allocator.free(path_copy);
+            return true;
+        },
         .kill_session => |id| {
             const sc = ctx.session_client orelse return false;
             sc.killSession(id) catch {};

--- a/src/app/ui/win_session_picker.zig
+++ b/src/app/ui/win_session_picker.zig
@@ -230,6 +230,37 @@ fn processAction(ctx: *WinCtx, action: picker_state_mod.PickerAction) bool {
             event_loop.switchSession(ctx);
             return true;
         },
+        .create_session_named => |name| {
+            var name_buf: [64]u8 = undefined;
+            const nlen = @min(name.len, name_buf.len);
+            @memcpy(name_buf[0..nlen], name[0..nlen]);
+
+            const finder = &(g_finder_state orelse {
+                close(ctx);
+                return true;
+            });
+            const root = finder.getRootPath();
+            var abs_buf: [512]u8 = undefined;
+            const sep: []const u8 = if (comptime @import("builtin").os.tag == .windows) "\\" else "/";
+            const abs_path = std.fmt.bufPrint(&abs_buf, "{s}{s}{s}", .{ root, sep, name_buf[0..nlen] }) catch {
+                close(ctx);
+                return true;
+            };
+            std.fs.makeDirAbsolute(abs_path) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                else => {
+                    close(ctx);
+                    return true;
+                },
+            };
+            close(ctx);
+            const ws_stubs = @import("../windows_stubs.zig");
+            const pty_rows: u16 = @intCast(@max(1, @as(i32, ctx.grid_rows) - ws_stubs.g_grid_top_offset - ws_stubs.g_grid_bottom_offset));
+            const sid = smgr.createSession(name_buf[0..nlen], pty_rows, ctx.grid_cols, ctx.theme, ctx.applied_scrollback_lines) catch return true;
+            _ = smgr.switchTo(sid) catch {};
+            event_loop.switchSession(ctx);
+            return true;
+        },
         .kill_session => |sid| {
             smgr.kill(sid) catch {};
             refreshEntries(ctx);

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -201,7 +201,8 @@
 # Enable session management (named sessions with persist/switch).  [restart]
 # enabled = false
 
-# Root directory for the session finder to search.  [restart]
+# Root directory for the session finder. Folders here are offered when creating
+# a session, and "Create <name>" makes a new directory under this root.  [restart]
 # root = "~"
 
 # How many directory levels deep the session finder searches (1-8).  [restart]

--- a/src/overlay/session_picker.zig
+++ b/src/overlay/session_picker.zig
@@ -42,6 +42,9 @@ pub const PickerAction = union(enum) {
     switch_to_default: void,
     create_session: void,
     create_session_at: []const u8,
+    /// Create a brand-new session directory named after the typed filter text
+    /// (under the configured sessions root), then switch to it.
+    create_session_named: []const u8,
     kill_session: u32,
     rename_session: struct { id: u32, name: []const u8 },
     /// "Move tab to session" mode: the user picked the destination session.
@@ -205,12 +208,15 @@ pub const SessionPickerState = struct {
                     }
                     return .none;
                 }
+                const fs_end = self.filtered_count +| self.fs_count;
                 if (self.selected < self.filtered_count) {
                     const e = &self.entries[self.filtered_indices[self.selected]];
                     return .{ .switch_session = e.id };
-                } else if (self.selected < self.filtered_count +| self.fs_count) {
+                } else if (self.selected < fs_end) {
                     const fs_idx = self.selected - self.filtered_count;
                     return .{ .create_session_at = self.fs_results[fs_idx].getPath() };
+                } else if (self.createRowVisible() and self.selected == fs_end) {
+                    return .{ .create_session_named = self.filter_buf[0..self.filter_len] };
                 } else {
                     return .create_session;
                 }
@@ -275,11 +281,37 @@ pub const SessionPickerState = struct {
         }
     }
 
-    /// Total items = filtered sessions + fs results + 1 ("New session" entry).
-    /// In move mode only existing sessions are selectable.
+    /// Total items = filtered sessions + fs results + optional "Create <name>"
+    /// row + 1 ("New session" entry). In move mode only existing sessions are
+    /// selectable.
     pub fn totalCount(self: *const SessionPickerState) u8 {
         if (self.move_mode) return self.filtered_count;
-        return self.filtered_count +| self.fs_count +| 1;
+        const create: u8 = if (self.createRowVisible()) 1 else 0;
+        return self.filtered_count +| self.fs_count +| create +| 1;
+    }
+
+    /// Whether to offer "Create <typed-name>" — a new session directory.
+    /// Shown when the filter text is a valid directory name that doesn't
+    /// already exist as a session or as a folder result.
+    pub fn createRowVisible(self: *const SessionPickerState) bool {
+        if (self.move_mode) return false;
+        const name = self.filter_buf[0..self.filter_len];
+        if (!isValidDirName(name)) return false;
+        // Suppress if an existing session matches the name exactly.
+        for (0..self.filtered_count) |i| {
+            const e = &self.entries[self.filtered_indices[i]];
+            if (std.mem.eql(u8, e.getName(), name)) return false;
+        }
+        // Suppress if a folder result's basename matches the name exactly.
+        for (0..self.fs_count) |i| {
+            const path = self.fs_results[i].getPath();
+            const base = if (std.mem.lastIndexOfScalar(u8, path, '/')) |sep|
+                path[sep + 1 ..]
+            else
+                path;
+            if (std.mem.eql(u8, base, name)) return false;
+        }
+        return true;
     }
 
     /// Update filesystem results from the finder.
@@ -348,6 +380,23 @@ pub fn entryPriority(e: SessionEntry, current_id: ?u32) u8 {
         if (e.id == cid) return 0;
     }
     return if (e.alive) 1 else 2;
+}
+
+/// Validate a name for use as a new session directory. Cross-platform safe:
+/// rejects empty/over-long names, path separators, control characters, the
+/// Windows-reserved set, "."/".." and leading/trailing spaces.
+pub fn isValidDirName(name: []const u8) bool {
+    if (name.len == 0 or name.len > 64) return false;
+    if (std.mem.eql(u8, name, ".") or std.mem.eql(u8, name, "..")) return false;
+    if (name[0] == ' ' or name[name.len - 1] == ' ') return false;
+    for (name) |ch| {
+        if (ch < 0x20) return false;
+        switch (ch) {
+            '/', '\\', ':', '*', '?', '"', '<', '>', '|' => return false,
+            else => {},
+        }
+    }
+    return true;
 }
 
 fn fuzzyMatch(name: []const u8, query: []const u8) bool {
@@ -504,6 +553,74 @@ test "handleCmd: enter on 'New session' returns create_session" {
     state.selected = 1; // "New session" entry
     const action = state.handleCmd(8); // Enter
     switch (action) {
+        .create_session => {},
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "isValidDirName: accepts and rejects" {
+    try std.testing.expect(isValidDirName("my-project"));
+    try std.testing.expect(isValidDirName("proj_2.0"));
+    try std.testing.expect(isValidDirName("a b c"));
+    try std.testing.expect(!isValidDirName(""));
+    try std.testing.expect(!isValidDirName("."));
+    try std.testing.expect(!isValidDirName(".."));
+    try std.testing.expect(!isValidDirName("foo/bar"));
+    try std.testing.expect(!isValidDirName("foo\\bar"));
+    try std.testing.expect(!isValidDirName("a:b"));
+    try std.testing.expect(!isValidDirName(" leading"));
+    try std.testing.expect(!isValidDirName("trailing "));
+}
+
+test "createRowVisible: shown for new valid name, hidden for exact match" {
+    var state = SessionPickerState{};
+    state.entries[0] = .{ .id = 1, .name_len = 3, .alive = true };
+    @memcpy(state.entries[0].name[0..3], "one");
+    state.entry_count = 1;
+
+    // No filter → no create row.
+    state.applyFilter();
+    try std.testing.expect(!state.createRowVisible());
+
+    // Typed a fresh, valid name → create row visible.
+    @memcpy(state.filter_buf[0..3], "two");
+    state.filter_len = 3;
+    state.applyFilter();
+    try std.testing.expect(state.createRowVisible());
+
+    // Typed an exact existing session name → suppressed.
+    @memcpy(state.filter_buf[0..3], "one");
+    state.filter_len = 3;
+    state.applyFilter();
+    try std.testing.expect(!state.createRowVisible());
+
+    // Invalid name → suppressed.
+    @memcpy(state.filter_buf[0..3], "a/b");
+    state.filter_len = 3;
+    state.applyFilter();
+    try std.testing.expect(!state.createRowVisible());
+}
+
+test "handleCmd: enter on 'Create' row returns create_session_named" {
+    var state = SessionPickerState{};
+    state.entries[0] = .{ .id = 1, .name_len = 3, .alive = true };
+    @memcpy(state.entries[0].name[0..3], "one");
+    state.entry_count = 1;
+    @memcpy(state.filter_buf[0..3], "two"); // doesn't match "one"
+    state.filter_len = 3;
+    state.applyFilter();
+
+    // Rows: [create "two"], [New session]. Create is first.
+    try std.testing.expectEqual(@as(u8, 0), state.filtered_count);
+    state.selected = 0;
+    switch (state.handleCmd(8)) {
+        .create_session_named => |name| try std.testing.expectEqualStrings("two", name),
+        else => return error.TestUnexpectedResult,
+    }
+
+    // Last row is still plain "New session".
+    state.selected = 1;
+    switch (state.handleCmd(8)) {
         .create_session => {},
         else => return error.TestUnexpectedResult,
     }

--- a/src/overlay/session_picker_panel.zig
+++ b/src/overlay/session_picker_panel.zig
@@ -114,6 +114,14 @@ pub fn renderSessionPicker(
                 .label = fs_copy,
                 .enabled = true,
             };
+        } else if (state.createRowVisible() and i == state.filtered_count +| state.fs_count) {
+            // "Create <typed-name>" entry — makes a new session directory.
+            const name = state.filter_buf[0..state.filter_len];
+            const label = std.fmt.allocPrint(tmp, "{s} Create \"{s}\"", .{ icons.new, name }) catch "";
+            menu_items[menu_count] = .{
+                .label = label,
+                .enabled = true,
+            };
         } else {
             // "New session" entry
             var new_buf: [64]u8 = undefined;


### PR DESCRIPTION
## Recency ordering

The session list is now ordered by **recency of access** — most recently attached first — instead of slot/creation order. Previously only the current session was pinned to the top.

The daemon stamps each `DaemonSession` with a `last_accessed` timestamp on spawn and on every attach, and emits the list most-recent-first. The picker's existing **current → alive → dead** grouping is stable, so recency order is preserved within each group. No wire-format or client struct changes were needed — recency is computed daemon-side via a pure, unit-tested `orderEntriesByAccess` helper.

## Create session directories

The picker can now create a new folder for a session. When you type a name that doesn't match an existing session or folder, a **`Create "<name>"`** row appears. Selecting it creates a directory under `sessions.root` and switches into a session rooted there.

- Names are validated for cross-platform directory safety (rejects path separators, control chars, the Windows-reserved set, `.`/`..`, and leading/trailing spaces).
- The row is suppressed when the typed name exactly matches an existing session or folder result, or is invalid.
- Reuses the existing `sessions.root` config (the finder root) as the creation base rather than introducing an overlapping option; its doc comment is updated to reflect the dual role.

## Tests

- `orderEntriesByAccess` ordering and tie-stability.
- `isValidDirName` accept/reject cases.
- `createRowVisible` visibility logic and the Enter-on-Create-row flow.
- Updated the daemon session-list test to assert recency order.