### PR TITLE
Route IPC commands to a specific session with -s/--session

### DIFF
--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -222,6 +222,19 @@ pub const DaemonClient = struct {
         self.sendRaw(m);
     }
 
+    /// Reply to a headless ctl_request. Framed as a separate header + status
+    /// byte + body so large get_text bodies don't need a contiguous buffer.
+    pub fn sendCtlResponse(self: *DaemonClient, status: u8, body: []const u8) void {
+        const payload_len: u32 = @intCast(1 + body.len);
+        var hdr: [protocol.header_size]u8 = undefined;
+        protocol.encodeHeader(&hdr, .ctl_response, payload_len);
+        self.sendRaw(&hdr);
+        if (self.dead) return;
+        self.sendRaw(&[_]u8{status});
+        if (self.dead) return;
+        if (body.len > 0) self.sendRaw(body);
+    }
+
     // sendSessionList removed — use sendSessionListFromSlots instead.
 
     /// Send replay data from a pane's ring buffer as pane_output messages.

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -10,6 +10,7 @@ const DaemonPane = @import("pane.zig").DaemonPane;
 const RingBuffer = @import("ring_buffer.zig").RingBuffer;
 const layout_codec = @import("../layout_codec.zig");
 const state_persist = @import("state_persist.zig");
+const handler_ctl = @import("handler_ctl.zig");
 
 const max_sessions: usize = 32;
 const max_clients: usize = 16;
@@ -48,6 +49,10 @@ pub fn handleMessage(
         .move_panes => handleMovePanes(cl, msg.payload, sessions, clients),
         .set_theme_colors => handleSetThemeColors(cl, msg.payload, sessions),
         .get_scrollback_range => handleGetScrollbackRange(cl, msg.payload, sessions),
+
+        // Headless control channel: operate on a target session directly,
+        // independent of attachment (background agents drive their own session).
+        .ctl_request => handler_ctl.handle(cl, msg.payload, sessions, next_pane_id, allocator, clients),
 
         // Ignore server→client messages
         else => {},

--- a/src/app/daemon/handler_ctl.zig
+++ b/src/app/daemon/handler_ctl.zig
@@ -1,0 +1,290 @@
+// Attyx — daemon headless control handler
+//
+// Executes ctl_request ops (write_input, get_text) against a target session
+// directly, with no window attached. This is what lets background agents in
+// different sessions drive their own session over IPC without switching the
+// session any window is showing.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const is_windows = builtin.os.tag == .windows;
+const protocol = @import("protocol.zig");
+const session_mod = @import("session.zig");
+const DaemonSession = session_mod.DaemonSession;
+const DaemonPane = @import("pane.zig").DaemonPane;
+const DaemonClient = @import("client.zig").DaemonClient;
+const platform = @import("../../platform/platform.zig");
+const layout_codec = @import("../layout_codec.zig");
+const handler_ctl_layout = @import("handler_ctl_layout.zig");
+
+const max_sessions: usize = 32;
+const max_clients: usize = 16;
+
+/// Default grid size used when activating a deferred pane that has no real
+/// dimensions yet (e.g. a session created in the background and never viewed).
+const default_rows: u16 = 24;
+const default_cols: u16 = 80;
+
+pub fn handle(
+    cl: *DaemonClient,
+    payload: []const u8,
+    sessions: *[max_sessions]?DaemonSession,
+    next_pane_id: *u32,
+    allocator: std.mem.Allocator,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    const req = protocol.decodeCtlRequest(payload) catch {
+        cl.sendCtlResponse(1, "invalid ctl request");
+        return;
+    };
+    const session = findSession(sessions, req.target_session) orelse {
+        cl.sendCtlResponse(1, "session not found");
+        return;
+    };
+    const op = std.meta.intToEnum(protocol.CtlOp, req.op) catch {
+        cl.sendCtlResponse(1, "unsupported ctl op");
+        return;
+    };
+    switch (op) {
+        .write_input => handleWriteInput(cl, session, req.body),
+        .get_text => handleGetText(cl, session, req.body, allocator),
+        .list => handleList(cl, session, req.body),
+        .tab_create => handler_ctl_layout.tabCreate(cl, session, req.body, next_pane_id, allocator, clients),
+        .tab_select => handler_ctl_layout.tabSelect(cl, session, req.body, clients),
+        .tab_next => handler_ctl_layout.tabStep(cl, session, clients, .next),
+        .tab_prev => handler_ctl_layout.tabStep(cl, session, clients, .prev),
+        .split => handler_ctl_layout.split(cl, session, req.body, next_pane_id, allocator, clients),
+        .pane_close => handler_ctl_layout.paneClose(cl, session, req.body, clients),
+        .pane_rotate => handler_ctl_layout.paneRotate(cl, session, clients),
+        .tab_close => handler_ctl_layout.tabClose(cl, session, req.body, clients),
+        .tab_move => handler_ctl_layout.tabMove(cl, session, req.body, clients),
+        .tab_rename => handler_ctl_layout.tabRename(cl, session, req.body, clients),
+    }
+}
+
+fn handleWriteInput(cl: *DaemonClient, session: *DaemonSession, body: []const u8) void {
+    if (body.len < 4) {
+        cl.sendCtlResponse(1, "missing pane id");
+        return;
+    }
+    const pane_id = std.mem.readInt(u32, body[0..4], .little);
+    const bytes = body[4..];
+    const pane = selectPane(session, pane_id) orelse {
+        cl.sendCtlResponse(1, "pane not found");
+        return;
+    };
+    ensureActive(pane, session);
+    pane.writeInput(bytes) catch {
+        cl.sendCtlResponse(1, "write failed");
+        return;
+    };
+    cl.sendCtlResponse(0, "");
+}
+
+fn handleGetText(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    body: []const u8,
+    allocator: std.mem.Allocator,
+) void {
+    if (body.len < 4) {
+        cl.sendCtlResponse(1, "missing pane id");
+        return;
+    }
+    const pane_id = std.mem.readInt(u32, body[0..4], .little);
+    const lines: u32 = if (body.len >= 8) std.mem.readInt(u32, body[4..8], .little) else 0;
+    const pane = selectPane(session, pane_id) orelse {
+        cl.sendCtlResponse(1, "pane not found");
+        return;
+    };
+    ensureActive(pane, session);
+    const eng = pane.engine orelse {
+        cl.sendCtlResponse(1, "pane has no screen yet");
+        return;
+    };
+
+    // Same row selection + trailing-whitespace trim as the window-side
+    // get-text (handler_query.writeScreenText), but against the daemon's
+    // own engine grid.
+    const ring = &eng.state.ring;
+    const cols = ring.cols;
+    const total_rows: usize = if (lines == 0) ring.screen_rows else @min(@as(usize, lines), ring.count);
+    const start_abs: usize = if (lines == 0) ring.scrollbackCount() else ring.count - total_rows;
+
+    const max_row_bytes = cols * 4 + 1;
+    const buf_size = total_rows * max_row_bytes + 64;
+    const buf = allocator.alloc(u8, buf_size) catch {
+        cl.sendCtlResponse(1, "out of memory");
+        return;
+    };
+    defer allocator.free(buf);
+    var stream = std.io.fixedBufferStream(buf);
+    const w = stream.writer();
+
+    var i: usize = 0;
+    while (i < total_rows) : (i += 1) {
+        const row_cells = ring.getRow(start_abs + i);
+        var last: usize = cols;
+        while (last > 0 and row_cells[last - 1].char == ' ') last -= 1;
+        for (row_cells[0..last]) |cell| {
+            var cp: [4]u8 = undefined;
+            const len = std.unicode.utf8Encode(cell.char, &cp) catch continue;
+            w.writeAll(cp[0..len]) catch break;
+        }
+        w.writeAll("\n") catch break;
+    }
+
+    cl.sendCtlResponse(0, stream.getWritten());
+}
+
+fn handleList(cl: *DaemonClient, session: *DaemonSession, body: []const u8) void {
+    const kind: protocol.CtlListKind = if (body.len >= 1)
+        (std.meta.intToEnum(protocol.CtlListKind, body[0]) catch .all)
+    else
+        .all;
+
+    var buf: [8192]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    const w = stream.writer();
+
+    // Prefer the stored tab/split layout; fall back to a flat pane list for
+    // sessions created but never viewed (no layout blob yet).
+    if (session.layout_len > 0) {
+        if (layout_codec.deserialize(session.layout_data[0..session.layout_len])) |info_const| {
+            var info = info_const;
+            writeFromLayout(w, session, &info, kind);
+            cl.sendCtlResponse(0, stream.getWritten());
+            return;
+        } else |_| {}
+    }
+    writeFlat(w, session, kind);
+    cl.sendCtlResponse(0, stream.getWritten());
+}
+
+fn writeFromLayout(
+    w: anytype,
+    session: *DaemonSession,
+    info: *const layout_codec.LayoutInfo,
+    kind: protocol.CtlListKind,
+) void {
+    for (0..info.tab_count) |ti| {
+        const tab = &info.tabs[ti];
+        var leaf_ids: [layout_codec.max_nodes_per_tab]u32 = undefined;
+        const lc = tabLeaves(tab, &leaf_ids);
+        const active = (ti == info.active_tab);
+        const focused_pane = tabFocusedPane(tab);
+
+        if (kind == .panes) {
+            // Panes of the active tab only — mirrors the window's `list panes`.
+            if (!active) continue;
+            for (leaf_ids[0..lc]) |pid| writePaneLine(w, session, pid, pid == focused_pane, false);
+            continue;
+        }
+
+        const title = tab.getTitle() orelse paneTitle(session, if (lc > 0) leaf_ids[0] else 0);
+        w.print("{d}\t{s}", .{ ti + 1, title }) catch return;
+        if (active) w.writeAll("\t*") catch return;
+        if (lc > 1) w.print("\t{d} panes", .{lc}) catch return;
+        w.writeAll("\n") catch return;
+
+        if (kind == .all and lc > 1) {
+            for (leaf_ids[0..lc]) |pid| writePaneLine(w, session, pid, pid == focused_pane, true);
+        }
+    }
+}
+
+fn writeFlat(w: anytype, session: *DaemonSession, kind: protocol.CtlListKind) void {
+    var ids: [session_mod.max_panes_per_session]u32 = undefined;
+    const n = session.collectPaneIds(&ids);
+    if (n == 0) return;
+
+    if (kind == .panes) {
+        for (ids[0..n]) |pid| writePaneLine(w, session, pid, pid == ids[0], false);
+        return;
+    }
+
+    w.print("1\t{s}\t*", .{paneTitle(session, ids[0])}) catch return;
+    if (n > 1) w.print("\t{d} panes", .{n}) catch return;
+    w.writeAll("\n") catch return;
+
+    if (kind == .all and n > 1) {
+        for (ids[0..n]) |pid| writePaneLine(w, session, pid, pid == ids[0], true);
+    }
+}
+
+fn writePaneLine(w: anytype, session: *DaemonSession, pane_id: u32, focused: bool, indent: bool) void {
+    if (indent) w.writeAll("  ") catch return;
+    w.print("{d}\t{s}", .{ pane_id, paneTitle(session, pane_id) }) catch return;
+    if (focused) w.writeAll("\t*") catch return;
+    w.writeAll("\n") catch return;
+}
+
+/// Collect a tab's leaf pane IDs in node order. Returns the count.
+fn tabLeaves(tab: *const layout_codec.TabLayout, out: *[layout_codec.max_nodes_per_tab]u32) usize {
+    var count: usize = 0;
+    for (0..tab.node_count) |ni| {
+        const node = tab.nodes[ni];
+        if (node.tag == .leaf) {
+            out[count] = node.pane_id;
+            count += 1;
+        }
+    }
+    return count;
+}
+
+/// The pane_id of a tab's focused node, or 0 if its focused node isn't a leaf.
+fn tabFocusedPane(tab: *const layout_codec.TabLayout) u32 {
+    if (tab.focused_idx >= tab.node_count) return 0;
+    const node = tab.nodes[tab.focused_idx];
+    return if (node.tag == .leaf) node.pane_id else 0;
+}
+
+/// Best-effort pane title: live engine title, else cached process name, else
+/// a generic "shell".
+fn paneTitle(session: *DaemonSession, pane_id: u32) []const u8 {
+    const pane = session.findPane(pane_id) orelse return "shell";
+    if (pane.engine) |eng| {
+        if (eng.state.title) |t| {
+            if (t.len > 0) return t;
+        }
+    }
+    if (pane.proc_name_len > 0) return pane.proc_name[0..pane.proc_name_len];
+    return "shell";
+}
+
+/// Resolve the pane a ctl op targets: an explicit id, or the session's first
+/// pane when id is 0.
+fn selectPane(session: *DaemonSession, pane_id: u32) ?*DaemonPane {
+    if (pane_id == 0) return session.firstPane();
+    return session.findPane(pane_id);
+}
+
+/// A session created but never viewed has a deferred initial pane (PTY not
+/// yet spawned, no engine). Activate it at a sensible size so headless ops
+/// have something to read/write. A later window attach resizes it to the real
+/// window dims, so this only affects the very first prompt's width.
+fn ensureActive(pane: *DaemonPane, session: *DaemonSession) void {
+    if (pane.deferred == null) return;
+    const rows: u16 = if (session.rows > 0) session.rows else default_rows;
+    const cols: u16 = if (session.cols > 0) session.cols else default_cols;
+    pane.resize(rows, cols) catch {};
+    if (comptime !is_windows) setNonBlocking(pane.pty.master);
+}
+
+fn findSession(sessions: *[max_sessions]?DaemonSession, id: u32) ?*DaemonSession {
+    for (sessions) |*slot| {
+        if (slot.*) |*s| {
+            if (s.id == id) return s;
+        }
+    }
+    return null;
+}
+
+fn setNonBlocking(fd: std.posix.fd_t) void {
+    if (comptime is_windows) return;
+    if (fd < 0) return;
+    const F_GETFL: i32 = 3;
+    const F_SETFL: i32 = 4;
+    const flags = std.posix.fcntl(fd, F_GETFL, 0) catch return;
+    _ = std.posix.fcntl(fd, F_SETFL, flags | platform.O_NONBLOCK) catch {};
+}

--- a/src/app/daemon/handler_ctl_layout.zig
+++ b/src/app/daemon/handler_ctl_layout.zig
@@ -1,0 +1,453 @@
+// Attyx — daemon headless layout mutations
+//
+// Layout-changing ctl ops (tab create/close/move/rename, split, pane close/
+// rotate). These make the daemon authoritative over a session's tab/split tree
+// for headless control: the daemon spawns/kills the pane, edits the serialized
+// layout, and broadcasts layout_sync so any attached window re-renders live.
+// Pure tree surgery lives in layout_ops.zig.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const is_windows = builtin.os.tag == .windows;
+const session_mod = @import("session.zig");
+const DaemonSession = session_mod.DaemonSession;
+const DaemonClient = @import("client.zig").DaemonClient;
+const RingBuffer = @import("ring_buffer.zig").RingBuffer;
+const layout_codec = @import("../layout_codec.zig");
+const platform = @import("../../platform/platform.zig");
+const ops = @import("layout_ops.zig");
+
+const max_clients: usize = 16;
+const replay_capacity: usize = RingBuffer.default_capacity;
+const default_rows: u16 = 24;
+const default_cols: u16 = 80;
+
+pub const TabStep = enum { next, prev };
+pub const TabMoveDir = enum { left, right };
+
+/// Spawn a new pane as a new tab in `session`. `body` is an optional command to
+/// run in the pane (like `attyx run <cmd>`); empty means a plain shell.
+pub fn tabCreate(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    body: []const u8,
+    next_pane_id: *u32,
+    allocator: std.mem.Allocator,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    if (@as(usize, session.pane_count) + 1 > session_mod.max_panes_per_session) {
+        cl.sendCtlResponse(1, "session is full");
+        return;
+    }
+
+    // Snapshot existing panes before spawning so we can synthesize tabs for
+    // them if the session has no layout blob yet (created but never viewed).
+    var existing: [session_mod.max_panes_per_session]u32 = undefined;
+    const existing_count = session.collectPaneIds(&existing);
+
+    const pane_id = spawnPane(session, allocator, next_pane_id, body) orelse {
+        cl.sendCtlResponse(1, "create pane failed");
+        return;
+    };
+
+    appendTabForPane(session, pane_id, existing[0..existing_count]);
+    broadcastLayout(session, clients);
+
+    var reply_buf: [16]u8 = undefined;
+    const reply = std.fmt.bufPrint(&reply_buf, "{d}", .{pane_id}) catch "";
+    cl.sendCtlResponse(0, reply);
+}
+
+/// Append a single-pane tab for `pane_id` to the session's layout and make it
+/// active. If the session had no layout yet, first synthesize single-pane tabs
+/// for the panes that already existed so they aren't dropped from the view.
+fn appendTabForPane(session: *DaemonSession, pane_id: u32, existing: []const u32) void {
+    var info: layout_codec.LayoutInfo = if (session.layout_len > 0)
+        (layout_codec.deserialize(session.layout_data[0..session.layout_len]) catch layout_codec.LayoutInfo{})
+    else
+        layout_codec.LayoutInfo{};
+
+    if (info.tab_count == 0) {
+        for (existing) |pid| {
+            if (pid == pane_id) continue;
+            if (!ops.appendLeafTab(&info, pid)) break;
+        }
+    }
+
+    if (!ops.appendLeafTab(&info, pane_id)) return;
+    info.active_tab = info.tab_count - 1;
+    info.focused_pane_id = pane_id;
+    persist(session, &info);
+}
+
+/// Spawn a pane in `session` at the session's size (or a default), optionally
+/// running `cmd_body` like `attyx run`. Returns the new pane id, or null on
+/// failure. Bumps next_pane_id on success.
+fn spawnPane(
+    session: *DaemonSession,
+    allocator: std.mem.Allocator,
+    next_pane_id: *u32,
+    cmd_body: []const u8,
+) ?u32 {
+    const rows: u16 = if (session.rows > 0) session.rows else default_rows;
+    const cols: u16 = if (session.cols > 0) session.cols else default_cols;
+
+    // Null-terminate the optional command into a static buffer (matches the
+    // aarch64-Windows stack workaround used elsewhere in the daemon).
+    const CmdBuf = struct {
+        var z: [4097]u8 = undefined;
+    };
+    const cmd_z: ?[*:0]const u8 = if (cmd_body.len > 0 and cmd_body.len < CmdBuf.z.len) blk: {
+        @memcpy(CmdBuf.z[0..cmd_body.len], cmd_body);
+        CmdBuf.z[cmd_body.len] = 0;
+        break :blk @ptrCast(&CmdBuf.z);
+    } else null;
+
+    const pane_id = session.addPaneWithId(allocator, next_pane_id.*, rows, cols, replay_capacity, null, null, cmd_z, false) catch return null;
+    next_pane_id.* += 1;
+    if (session.findPane(pane_id)) |pane| {
+        if (comptime !is_windows) setNonBlocking(pane.pty.master);
+    }
+    return pane_id;
+}
+
+/// Split the active tab's focused pane, spawning a new pane beside it.
+/// `body` = [dir:u8 (0=vertical, 1=horizontal)][cmd...].
+pub fn split(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    body: []const u8,
+    next_pane_id: *u32,
+    allocator: std.mem.Allocator,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    if (body.len < 1) {
+        cl.sendCtlResponse(1, "missing split direction");
+        return;
+    }
+    const dir: layout_codec.SplitDirection = if (body[0] == 1) .horizontal else .vertical;
+    const cmd_body = body[1..];
+
+    if (@as(usize, session.pane_count) + 1 > session_mod.max_panes_per_session) {
+        cl.sendCtlResponse(1, "session is full");
+        return;
+    }
+
+    var info = ensureLayout(session);
+    if (info.tab_count == 0) {
+        cl.sendCtlResponse(1, "no panes to split");
+        return;
+    }
+    const tab = &info.tabs[info.active_tab];
+    // A split converts the focused leaf into a branch with two leaf children,
+    // so it needs two free node slots.
+    if (@as(usize, tab.node_count) + 2 > layout_codec.max_nodes_per_tab) {
+        cl.sendCtlResponse(1, "split limit reached");
+        return;
+    }
+
+    const new_pane = spawnPane(session, allocator, next_pane_id, cmd_body) orelse {
+        cl.sendCtlResponse(1, "create pane failed");
+        return;
+    };
+
+    const li = ops.focusedLeafIdx(tab);
+    const orig_pane = tab.nodes[li].pane_id;
+    const a: u8 = tab.node_count;
+    tab.nodes[a] = .{ .tag = .leaf, .pane_id = orig_pane };
+    const b: u8 = a + 1;
+    tab.nodes[b] = .{ .tag = .leaf, .pane_id = new_pane };
+    tab.node_count += 2;
+    tab.nodes[li] = .{ .tag = .branch, .direction = dir, .ratio_x100 = 50, .child_left = a, .child_right = b };
+    tab.focused_idx = b;
+    info.focused_pane_id = new_pane;
+
+    persist(session, &info);
+    broadcastLayout(session, clients);
+
+    var reply_buf: [16]u8 = undefined;
+    const reply = std.fmt.bufPrint(&reply_buf, "{d}", .{new_pane}) catch "";
+    cl.sendCtlResponse(0, reply);
+}
+
+/// Close a pane. `body` = [pane_id:u32] (0 = the active tab's focused pane).
+/// Removes the leaf (promoting its sibling), or removes the tab if it was the
+/// last pane there, then kills the pane.
+pub fn paneClose(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    body: []const u8,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    var info = ensureLayout(session);
+    if (info.tab_count == 0) {
+        cl.sendCtlResponse(1, "no panes");
+        return;
+    }
+
+    var target: u32 = if (body.len >= 4) std.mem.readInt(u32, body[0..4], .little) else 0;
+    if (target == 0) {
+        target = ops.tabFocusedPane(&info.tabs[info.active_tab]);
+        if (target == 0) {
+            cl.sendCtlResponse(1, "no focused pane");
+            return;
+        }
+    }
+
+    // Locate the tab + node holding the target pane.
+    var tabi: ?usize = null;
+    var ni: usize = 0;
+    for (0..info.tab_count) |t| {
+        if (ops.findLeafInTab(&info.tabs[t], target)) |idx| {
+            tabi = t;
+            ni = idx;
+            break;
+        }
+    }
+    const ti = tabi orelse {
+        cl.sendCtlResponse(1, "pane not found");
+        return;
+    };
+
+    const tab = &info.tabs[ti];
+    if (ops.countLeaves(tab) <= 1) {
+        ops.removeTab(&info, ti);
+    } else {
+        const new_focus = ops.removeLeafPromote(tab, ni);
+        if (info.active_tab == ti) info.focused_pane_id = new_focus;
+    }
+
+    _ = session.removePane(target);
+
+    if (info.tab_count == 0) {
+        session.layout_len = 0;
+    } else {
+        persist(session, &info);
+    }
+    broadcastLayout(session, clients);
+    cl.sendCtlResponse(0, "");
+}
+
+/// Rotate the panes in the active tab by one position. `body` is ignored.
+pub fn paneRotate(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    var info = ensureLayout(session);
+    if (info.tab_count == 0) {
+        cl.sendCtlResponse(0, "");
+        return;
+    }
+    const tab = &info.tabs[info.active_tab];
+    if (ops.countLeaves(tab) < 2) {
+        cl.sendCtlResponse(0, ""); // nothing to rotate
+        return;
+    }
+    ops.rotateLeaves(tab);
+    info.focused_pane_id = ops.tabFocusedPane(tab);
+    persist(session, &info);
+    broadcastLayout(session, clients);
+    cl.sendCtlResponse(0, "");
+}
+
+/// Close a whole tab (killing all its panes). `body` = [tab_idx:u8] where 0xFF
+/// means the active tab and any other value is a 0-based index.
+pub fn tabClose(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    body: []const u8,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    var info = ensureLayout(session);
+    if (info.tab_count == 0) {
+        cl.sendCtlResponse(1, "no tabs");
+        return;
+    }
+    const idx: usize = if (body.len >= 1 and body[0] != 0xFF) body[0] else info.active_tab;
+    if (idx >= info.tab_count) {
+        cl.sendCtlResponse(1, "no such tab");
+        return;
+    }
+
+    var leaves: [layout_codec.max_nodes_per_tab]u32 = undefined;
+    const n = ops.collectLeafPanes(&info.tabs[idx], &leaves);
+    for (0..n) |k| _ = session.removePane(leaves[k]);
+
+    ops.removeTab(&info, idx);
+    if (info.tab_count == 0) {
+        session.layout_len = 0;
+    } else {
+        persist(session, &info);
+    }
+    broadcastLayout(session, clients);
+    cl.sendCtlResponse(0, "");
+}
+
+/// Move the active tab one slot. `body` = [dir:u8 (0=left, 1=right)].
+pub fn tabMove(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    body: []const u8,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    var info = loadInfo(session) orelse {
+        cl.sendCtlResponse(0, ""); // single implicit tab — nothing to move
+        return;
+    };
+    const right = body.len >= 1 and body[0] == 1;
+    if (!ops.moveTab(&info, right)) {
+        cl.sendCtlResponse(0, ""); // already at the edge
+        return;
+    }
+    persist(session, &info);
+    broadcastLayout(session, clients);
+    cl.sendCtlResponse(0, "");
+}
+
+/// Rename a tab. `body` = [tab_idx:u8][name...] where tab_idx 0xFF means the
+/// active tab and any other value is a 0-based index.
+pub fn tabRename(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    body: []const u8,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    if (body.len < 1) {
+        cl.sendCtlResponse(1, "missing tab name");
+        return;
+    }
+    var info = ensureLayout(session);
+    if (info.tab_count == 0) {
+        cl.sendCtlResponse(1, "no tabs");
+        return;
+    }
+    const idx: usize = if (body[0] != 0xFF) body[0] else info.active_tab;
+    if (idx >= info.tab_count) {
+        cl.sendCtlResponse(1, "no such tab");
+        return;
+    }
+    ops.setTabTitle(&info.tabs[idx], body[1..]);
+    persist(session, &info);
+    broadcastLayout(session, clients);
+    cl.sendCtlResponse(0, "");
+}
+
+/// Make tab `index` (1-based) active.
+pub fn tabSelect(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    body: []const u8,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    const idx1: u8 = if (body.len >= 1) body[0] else 0;
+    var info = loadInfo(session) orelse {
+        // No layout blob → a single implicit tab; selecting tab 1 is a no-op.
+        cl.sendCtlResponse(if (idx1 <= 1) @as(u8, 0) else 1, if (idx1 <= 1) "" else "no such tab");
+        return;
+    };
+    if (idx1 == 0 or idx1 > info.tab_count) {
+        cl.sendCtlResponse(1, "no such tab");
+        return;
+    }
+    setActive(session, &info, idx1 - 1, clients);
+    cl.sendCtlResponse(0, "");
+}
+
+/// Activate the next/previous tab, wrapping at the ends.
+pub fn tabStep(
+    cl: *DaemonClient,
+    session: *DaemonSession,
+    clients: *[max_clients]?DaemonClient,
+    step: TabStep,
+) void {
+    var info = loadInfo(session) orelse {
+        cl.sendCtlResponse(0, ""); // single implicit tab — nothing to step to
+        return;
+    };
+    if (info.tab_count <= 1) {
+        cl.sendCtlResponse(0, "");
+        return;
+    }
+    const cur = info.active_tab;
+    const cnt = info.tab_count;
+    const new_active: u8 = switch (step) {
+        .next => (cur + 1) % cnt,
+        .prev => if (cur == 0) cnt - 1 else cur - 1,
+    };
+    setActive(session, &info, new_active, clients);
+    cl.sendCtlResponse(0, "");
+}
+
+// ── Shared session-coupled helpers ──
+
+/// Deserialize the session's layout, synthesizing single-pane tabs for any
+/// existing panes if there's no (or an invalid) layout blob yet.
+fn ensureLayout(session: *DaemonSession) layout_codec.LayoutInfo {
+    if (session.layout_len > 0) {
+        if (layout_codec.deserialize(session.layout_data[0..session.layout_len])) |info| {
+            if (info.tab_count > 0) return info;
+        } else |_| {}
+    }
+    var info = layout_codec.LayoutInfo{};
+    var ids: [session_mod.max_panes_per_session]u32 = undefined;
+    const n = session.collectPaneIds(&ids);
+    for (0..n) |k| {
+        if (!ops.appendLeafTab(&info, ids[k])) break;
+    }
+    if (info.tab_count > 0) {
+        info.active_tab = 0;
+        info.focused_pane_id = ids[0];
+    }
+    return info;
+}
+
+/// Deserialize the session's layout, or null if it has none/invalid.
+fn loadInfo(session: *DaemonSession) ?layout_codec.LayoutInfo {
+    if (session.layout_len == 0) return null;
+    const info = layout_codec.deserialize(session.layout_data[0..session.layout_len]) catch return null;
+    if (info.tab_count == 0) return null;
+    return info;
+}
+
+/// Set the active tab, sync focused_pane_id to that tab's focused pane, persist,
+/// and broadcast to attached windows.
+fn setActive(
+    session: *DaemonSession,
+    info: *layout_codec.LayoutInfo,
+    new_active: u8,
+    clients: *[max_clients]?DaemonClient,
+) void {
+    info.active_tab = new_active;
+    info.focused_pane_id = ops.tabFocusedPane(&info.tabs[new_active]);
+    persist(session, info);
+    broadcastLayout(session, clients);
+}
+
+/// Serialize `info` back into the session's stored layout blob.
+fn persist(session: *DaemonSession, info: *const layout_codec.LayoutInfo) void {
+    if (layout_codec.serialize(info, &session.layout_data)) |len| {
+        session.layout_len = len;
+    } else |_| {}
+}
+
+/// Push the session's current layout to every attached window so the change
+/// appears without a reattach.
+fn broadcastLayout(session: *DaemonSession, clients: *[max_clients]?DaemonClient) void {
+    for (clients) |*cslot| {
+        if (cslot.*) |*other| {
+            if (other.attached_session) |sid| {
+                if (sid == session.id) other.sendLayoutSync(session);
+            }
+        }
+    }
+}
+
+fn setNonBlocking(fd: std.posix.fd_t) void {
+    if (comptime is_windows) return;
+    if (fd < 0) return;
+    const F_GETFL: i32 = 3;
+    const F_SETFL: i32 = 4;
+    const flags = std.posix.fcntl(fd, F_GETFL, 0) catch return;
+    _ = std.posix.fcntl(fd, F_SETFL, flags | platform.O_NONBLOCK) catch {};
+}

--- a/src/app/daemon/layout_ops.zig
+++ b/src/app/daemon/layout_ops.zig
@@ -1,0 +1,276 @@
+// Attyx — pure layout-tree operations
+//
+// Side-effect-free helpers that manipulate a serialized LayoutInfo / TabLayout
+// (the daemon's authoritative view of a session's tab/split tree). No PTYs, no
+// sockets — just tree surgery, so they're trivially testable. The session/
+// client-coupled ctl handlers live in handler_ctl_layout.zig.
+
+const std = @import("std");
+const layout_codec = @import("../layout_codec.zig");
+
+const TabLayout = layout_codec.TabLayout;
+const LayoutInfo = layout_codec.LayoutInfo;
+const LayoutNode = layout_codec.LayoutNode;
+
+/// Append a leaf (single-pane) tab. Returns false if the tab table is full.
+pub fn appendLeafTab(info: *LayoutInfo, pane_id: u32) bool {
+    if (info.tab_count >= layout_codec.max_tabs) return false;
+    const idx = info.tab_count;
+    var t = &info.tabs[idx];
+    t.node_count = 1;
+    t.root_idx = 0;
+    t.focused_idx = 0;
+    t.title_len = 0;
+    t.title_flags = 0;
+    t.nodes[0] = .{ .tag = .leaf, .pane_id = pane_id };
+    info.tab_count += 1;
+    return true;
+}
+
+/// pane_id of a tab's focused node, or its first leaf, or 0.
+pub fn tabFocusedPane(tab: *const TabLayout) u32 {
+    if (tab.focused_idx < tab.node_count and tab.nodes[tab.focused_idx].tag == .leaf) {
+        return tab.nodes[tab.focused_idx].pane_id;
+    }
+    for (0..tab.node_count) |ni| {
+        if (tab.nodes[ni].tag == .leaf) return tab.nodes[ni].pane_id;
+    }
+    return 0;
+}
+
+/// Index of the tab's focused node if it's a leaf, else its first leaf node.
+pub fn focusedLeafIdx(tab: *const TabLayout) u8 {
+    if (tab.focused_idx < tab.node_count and tab.nodes[tab.focused_idx].tag == .leaf) {
+        return tab.focused_idx;
+    }
+    for (0..tab.node_count) |i| {
+        if (tab.nodes[i].tag == .leaf) return @intCast(i);
+    }
+    return 0;
+}
+
+/// Node index of the leaf holding `pane_id`, or null.
+pub fn findLeafInTab(tab: *const TabLayout, pane_id: u32) ?usize {
+    for (0..tab.node_count) |i| {
+        if (tab.nodes[i].tag == .leaf and tab.nodes[i].pane_id == pane_id) return i;
+    }
+    return null;
+}
+
+pub fn countLeaves(tab: *const TabLayout) usize {
+    var n: usize = 0;
+    for (0..tab.node_count) |i| {
+        if (tab.nodes[i].tag == .leaf) n += 1;
+    }
+    return n;
+}
+
+/// Leaf pane_ids of a tab in node order. Returns the count.
+pub fn collectLeafPanes(tab: *const TabLayout, out: *[layout_codec.max_nodes_per_tab]u32) usize {
+    var n: usize = 0;
+    for (0..tab.node_count) |i| {
+        if (tab.nodes[i].tag == .leaf) {
+            out[n] = tab.nodes[i].pane_id;
+            n += 1;
+        }
+    }
+    return n;
+}
+
+/// Cycle the pane assignments among a tab's leaves by one position (the pane in
+/// each leaf slot moves to the next slot, wrapping). The tree shape and focused
+/// slot stay put; only which pane sits where changes.
+pub fn rotateLeaves(tab: *TabLayout) void {
+    var leaf_idx: [layout_codec.max_nodes_per_tab]usize = undefined;
+    var n: usize = 0;
+    for (0..tab.node_count) |i| {
+        if (tab.nodes[i].tag == .leaf) {
+            leaf_idx[n] = i;
+            n += 1;
+        }
+    }
+    if (n < 2) return;
+    const last = tab.nodes[leaf_idx[n - 1]].pane_id;
+    var k: usize = n - 1;
+    while (k > 0) : (k -= 1) {
+        tab.nodes[leaf_idx[k]].pane_id = tab.nodes[leaf_idx[k - 1]].pane_id;
+    }
+    tab.nodes[leaf_idx[0]].pane_id = last;
+}
+
+/// Remove tab `idx`, shifting the rest down and keeping active_tab/focus sane.
+pub fn removeTab(info: *LayoutInfo, idx: usize) void {
+    var k = idx;
+    while (k + 1 < info.tab_count) : (k += 1) info.tabs[k] = info.tabs[k + 1];
+    info.tab_count -= 1;
+    if (info.tab_count == 0) {
+        info.active_tab = 0;
+        info.focused_pane_id = 0;
+        return;
+    }
+    if (info.active_tab > idx) info.active_tab -= 1;
+    if (info.active_tab >= info.tab_count) info.active_tab = info.tab_count - 1;
+    info.focused_pane_id = tabFocusedPane(&info.tabs[info.active_tab]);
+}
+
+/// Swap the active tab with its left (right=false) or right (right=true)
+/// neighbor, following it with active_tab. Returns false if already at the edge.
+pub fn moveTab(info: *LayoutInfo, right: bool) bool {
+    const a = info.active_tab;
+    if (right) {
+        if (a + 1 >= info.tab_count) return false;
+        const tmp = info.tabs[a];
+        info.tabs[a] = info.tabs[a + 1];
+        info.tabs[a + 1] = tmp;
+        info.active_tab = a + 1;
+    } else {
+        if (a == 0) return false;
+        const tmp = info.tabs[a];
+        info.tabs[a] = info.tabs[a - 1];
+        info.tabs[a - 1] = tmp;
+        info.active_tab = a - 1;
+    }
+    return true;
+}
+
+/// Set a tab's explicit title.
+pub fn setTabTitle(tab: *TabLayout, name: []const u8) void {
+    const n: u8 = @intCast(@min(name.len, layout_codec.max_title_len));
+    @memcpy(tab.title[0..n], name[0..n]);
+    tab.title_len = n;
+    tab.title_flags |= layout_codec.title_flag_explicit;
+}
+
+/// Remove leaf `ni` from a multi-pane tab: promote its sibling into the parent
+/// branch's slot, then compact the node array. Returns the surviving focus pane.
+pub fn removeLeafPromote(tab: *TabLayout, ni: usize) u32 {
+    var pi: ?usize = null;
+    var ni_is_left = false;
+    for (0..tab.node_count) |k| {
+        if (tab.nodes[k].tag != .branch) continue;
+        if (tab.nodes[k].child_left == ni) {
+            pi = k;
+            ni_is_left = true;
+            break;
+        }
+        if (tab.nodes[k].child_right == ni) {
+            pi = k;
+            ni_is_left = false;
+            break;
+        }
+    }
+    const p = pi orelse return tabFocusedPane(tab); // shouldn't happen (countLeaves > 1)
+    const si = if (ni_is_left) tab.nodes[p].child_right else tab.nodes[p].child_left;
+    const focus_pane = firstLeafPane(tab, si);
+    tab.nodes[p] = tab.nodes[si]; // promote sibling into the parent slot
+    compactTab(tab, focus_pane);
+    return focus_pane;
+}
+
+/// pane_id of the leftmost leaf under node `idx`.
+pub fn firstLeafPane(tab: *const TabLayout, idx: u8) u32 {
+    var cur = idx;
+    var guard: usize = 0;
+    while (tab.nodes[cur].tag == .branch and guard < layout_codec.max_nodes_per_tab) : (guard += 1) {
+        cur = tab.nodes[cur].child_left;
+    }
+    return tab.nodes[cur].pane_id;
+}
+
+/// Rebuild the tab's node array via DFS from the root so it's compact (no
+/// orphaned nodes), remapping child indices. Sets focused_idx to the leaf
+/// holding `focus_pane`, else the first leaf.
+pub fn compactTab(tab: *TabLayout, focus_pane: u32) void {
+    var out: [layout_codec.max_nodes_per_tab]LayoutNode = undefined;
+    var count: u8 = 0;
+    const new_root = dfsCopy(tab, tab.root_idx, &out, &count);
+    tab.nodes = out;
+    tab.node_count = count;
+    tab.root_idx = new_root;
+    tab.focused_idx = 0;
+    for (0..count) |i| {
+        if (out[i].tag == .leaf and out[i].pane_id == focus_pane) {
+            tab.focused_idx = @intCast(i);
+            return;
+        }
+    }
+    for (0..count) |i| {
+        if (out[i].tag == .leaf) {
+            tab.focused_idx = @intCast(i);
+            return;
+        }
+    }
+}
+
+/// DFS-copy the subtree rooted at `old_idx` into `out`, assigning contiguous
+/// indices. Returns the new index of `old_idx`.
+fn dfsCopy(
+    tab: *const TabLayout,
+    old_idx: u8,
+    out: *[layout_codec.max_nodes_per_tab]LayoutNode,
+    count: *u8,
+) u8 {
+    const my_idx = count.*;
+    out[my_idx] = tab.nodes[old_idx];
+    count.* += 1;
+    if (tab.nodes[old_idx].tag == .branch) {
+        const l = dfsCopy(tab, tab.nodes[old_idx].child_left, out, count);
+        const r = dfsCopy(tab, tab.nodes[old_idx].child_right, out, count);
+        out[my_idx].child_left = l;
+        out[my_idx].child_right = r;
+    }
+    return my_idx;
+}
+
+test "removeLeafPromote collapses parent branch and compacts orphans" {
+    // root(0) = vsplit[ leaf p1 (1), hsplit(2)[ leaf p2 (3), leaf p3 (4) ] ]
+    var tab = TabLayout{};
+    tab.nodes[0] = .{ .tag = .branch, .direction = .vertical, .child_left = 1, .child_right = 2 };
+    tab.nodes[1] = .{ .tag = .leaf, .pane_id = 1 };
+    tab.nodes[2] = .{ .tag = .branch, .direction = .horizontal, .child_left = 3, .child_right = 4 };
+    tab.nodes[3] = .{ .tag = .leaf, .pane_id = 2 };
+    tab.nodes[4] = .{ .tag = .leaf, .pane_id = 3 };
+    tab.node_count = 5;
+    tab.root_idx = 0;
+    tab.focused_idx = 4;
+
+    const focus = removeLeafPromote(&tab, 4);
+
+    try std.testing.expectEqual(@as(u32, 2), focus);
+    try std.testing.expectEqual(@as(u8, 3), tab.node_count);
+
+    var leaves: usize = 0;
+    var seen1 = false;
+    var seen2 = false;
+    var seen3 = false;
+    for (0..tab.node_count) |i| {
+        if (tab.nodes[i].tag == .leaf) {
+            leaves += 1;
+            switch (tab.nodes[i].pane_id) {
+                1 => seen1 = true,
+                2 => seen2 = true,
+                3 => seen3 = true,
+                else => {},
+            }
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 2), leaves);
+    try std.testing.expect(seen1 and seen2 and !seen3);
+    try std.testing.expect(tab.nodes[tab.focused_idx].tag == .leaf);
+    try std.testing.expectEqual(@as(u32, 2), tab.nodes[tab.focused_idx].pane_id);
+}
+
+test "rotateLeaves cycles pane assignments" {
+    var tab = TabLayout{};
+    tab.nodes[0] = .{ .tag = .branch, .direction = .vertical, .child_left = 1, .child_right = 2 };
+    tab.nodes[1] = .{ .tag = .leaf, .pane_id = 10 };
+    tab.nodes[2] = .{ .tag = .branch, .direction = .horizontal, .child_left = 3, .child_right = 4 };
+    tab.nodes[3] = .{ .tag = .leaf, .pane_id = 20 };
+    tab.nodes[4] = .{ .tag = .leaf, .pane_id = 30 };
+    tab.node_count = 5;
+    rotateLeaves(&tab);
+    // leaves in node order were [10,20,30] → rotate → [30,10,20]
+    try std.testing.expectEqual(@as(u32, 30), tab.nodes[1].pane_id);
+    try std.testing.expectEqual(@as(u32, 10), tab.nodes[3].pane_id);
+    try std.testing.expectEqual(@as(u32, 20), tab.nodes[4].pane_id);
+}

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -39,6 +39,11 @@ pub const MessageType = enum(u8) {
     get_scrollback_range = 0x13,
     search_pane = 0x14,
 
+    /// Headless control channel: the CLI drives a specific session directly
+    /// in the daemon, with no window attached. Carries an inner op + target
+    /// session. See CtlOp / encodeCtlRequest.
+    ctl_request = 0x15,
+
     // Daemon → Client
     created = 0x81,
     session_list = 0x82,
@@ -73,6 +78,9 @@ pub const MessageType = enum(u8) {
     /// (OSC 7337;agent-status). Client's engine is passive in grid-sync, so
     /// the status has to be propagated explicitly — same as pane_title.
     pane_agent_status = 0x97,
+
+    /// Reply to a ctl_request: [status:u8 (0=ok, 1=err)][body...].
+    ctl_response = 0x98,
 };
 
 pub const header_size: usize = 5; // 4-byte payload length + 1-byte message type
@@ -166,6 +174,74 @@ pub fn encodeError(buf: []u8, code: u8, msg: []const u8) ![]u8 {
     std.mem.writeInt(u16, buf[1..3], msg_len, .little);
     @memcpy(buf[3 .. 3 + msg_len], msg[0..msg_len]);
     return buf[0..total];
+}
+
+// ── Headless control channel (ctl_request / ctl_response) ──
+//
+// Lets the CLI drive one session directly in the daemon with no window
+// attached, so background agents can read/write their own session
+// independently. Request payload:
+//   [target_session:u32 LE][op:u8][op_body...]
+// Response payload (ctl_response):
+//   [status:u8 (0=ok, 1=err)][body...]
+
+/// Control ops carried inside a ctl_request.
+pub const CtlOp = enum(u8) {
+    /// op_body: [pane_id:u32 LE (0 = first pane)][bytes...] — written to the
+    /// pane's PTY input.
+    write_input = 0x01,
+    /// op_body: [pane_id:u32 LE (0 = first pane)][lines:u32 LE (0 = visible
+    /// screen)] — replies with the rendered screen/scrollback text.
+    get_text = 0x02,
+    /// op_body: [kind:u8] — 0 = tabs+panes, 1 = tabs only, 2 = panes only.
+    /// Replies with a tab/pane listing built from the session's layout.
+    list = 0x03,
+    /// op_body: [cmd...] (optional) — spawns a new pane as a new tab. With a
+    /// command, runs it like `attyx run`; otherwise a plain shell. Replies with
+    /// the new pane's id as decimal text.
+    tab_create = 0x04,
+    /// op_body: [index:u8] (1-based) — make that tab active.
+    tab_select = 0x05,
+    /// op_body: none — activate the next tab (wraps).
+    tab_next = 0x06,
+    /// op_body: none — activate the previous tab (wraps).
+    tab_prev = 0x07,
+    /// op_body: [dir:u8 (0=vertical, 1=horizontal)][cmd...] — split the active
+    /// tab's focused pane, spawning a new pane. Replies with the new pane id.
+    split = 0x08,
+    /// op_body: [pane_id:u32] (0 = focused pane) — close that pane.
+    pane_close = 0x09,
+    /// op_body: none — rotate the active tab's panes by one position.
+    pane_rotate = 0x0A,
+    /// op_body: [tab_idx:u8] (0xFF = active, else 0-based) — close that tab.
+    tab_close = 0x0B,
+    /// op_body: [dir:u8 (0=left, 1=right)] — move the active tab one slot.
+    tab_move = 0x0C,
+    /// op_body: [tab_idx:u8 (0xFF = active)][name...] — rename that tab.
+    tab_rename = 0x0D,
+};
+
+/// `list` ctl op kinds (first byte of op_body).
+pub const CtlListKind = enum(u8) { all = 0, tabs = 1, panes = 2 };
+
+pub const CtlRequest = struct { target_session: u32, op: u8, body: []const u8 };
+
+pub fn encodeCtlRequest(buf: []u8, target_session: u32, op: u8, body: []const u8) ![]u8 {
+    const total = 5 + body.len;
+    if (buf.len < total) return error.BufferTooSmall;
+    std.mem.writeInt(u32, buf[0..4], target_session, .little);
+    buf[4] = op;
+    @memcpy(buf[5 .. 5 + body.len], body);
+    return buf[0..total];
+}
+
+pub fn decodeCtlRequest(payload: []const u8) !CtlRequest {
+    if (payload.len < 5) return error.PayloadTooShort;
+    return .{
+        .target_session = std.mem.readInt(u32, payload[0..4], .little),
+        .op = payload[4],
+        .body = payload[5..],
+    };
 }
 
 // ── Decode helpers ──
@@ -1126,4 +1202,18 @@ test "hello decode accepts legacy payload without caps" {
     const msg = try decodeHello(buf[0 .. 1 + v.len]);
     try std.testing.expectEqualStrings("legacy", msg.version);
     try std.testing.expectEqual(@as(u32, 0), msg.caps);
+}
+
+test "ctl_request round-trip" {
+    var buf: [64]u8 = undefined;
+    const body = [_]u8{ 7, 0, 0, 0, 'h', 'i' }; // pane_id=7, bytes="hi"
+    const payload = try encodeCtlRequest(&buf, 42, @intFromEnum(CtlOp.write_input), &body);
+    const req = try decodeCtlRequest(payload);
+    try std.testing.expectEqual(@as(u32, 42), req.target_session);
+    try std.testing.expectEqual(@intFromEnum(CtlOp.write_input), req.op);
+    try std.testing.expectEqualSlices(u8, &body, req.body);
+}
+
+test "decodeCtlRequest rejects short payload" {
+    try std.testing.expectError(error.PayloadTooShort, decodeCtlRequest(&[_]u8{ 1, 2, 3 }));
 }

--- a/src/app/ui/session_actions.zig
+++ b/src/app/ui/session_actions.zig
@@ -274,8 +274,11 @@ pub fn doSessionCreate(ctx: *PtyThreadCtx, cwd: []const u8) void {
         logging.err("session-picker", "create failed: {}", .{err});
         return;
     };
-    doSessionSwitch(ctx, new_id);
+    // Log before switching: doSessionSwitch re-attaches and can invalidate the
+    // buffer `cwd` aliases (e.g. a pane's daemon fg_cwd), so reading it after
+    // the switch is a use-after-free.
     logging.info("session-picker", "created session {d} in {s}", .{ new_id, cwd });
+    doSessionSwitch(ctx, new_id);
 }
 
 /// Create a new session directly (from keybind, without picker).

--- a/src/config/cli.zig
+++ b/src/config/cli.zig
@@ -388,6 +388,7 @@ fn isIpcSubcommand(arg: []const u8) bool {
         "scroll-to", "list",      "session",    "popup",  "run",
         "--target", // --target <pid> before subcommand
         "--json", // --json before subcommand
+        "-s",      "--session", // -s/--session <id> before subcommand
     };
     for (ipc_subs) |s| {
         if (std.mem.eql(u8, arg, s)) return true;

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -147,55 +147,71 @@ pub fn parse(args: []const [:0]const u8) ?IpcRequest {
     var target_pid: ?u32 = null;
     var json_output: bool = false;
     var target_session: u32 = 0;
-    var start: usize = 1;
 
-    // Parse global flags (--target, --json, --session) before subcommand
-    while (start < args.len) {
-        if (std.mem.eql(u8, args[start], "--target")) {
-            if (start + 1 >= args.len) fatal("--target requires a PID value");
-            target_pid = std.fmt.parseInt(u32, args[start + 1], 10) catch fatal("invalid --target PID");
-            start += 2;
-        } else if (std.mem.eql(u8, args[start], "--session") or std.mem.eql(u8, args[start], "-s")) {
-            if (start + 1 >= args.len) fatal("--session requires a session ID");
-            target_session = std.fmt.parseInt(u32, args[start + 1], 10) catch fatal("invalid --session ID");
-            start += 2;
-        } else if (std.mem.eql(u8, args[start], "--json")) {
+    // Global flags (--target, --json, -s/--session) are position-independent:
+    // strip them from argv wherever they appear, capturing their values, then
+    // dispatch on what's left. This lets `attyx send-text "hi" -s 3` and
+    // `attyx -s 3 send-text "hi"` behave identically.
+    var fbuf: [128][:0]const u8 = undefined;
+    var flen: usize = 0;
+    fbuf[flen] = args[0]; // keep argv[0] (program name)
+    flen += 1;
+    var fi: usize = 1;
+    while (fi < args.len) {
+        const a = args[fi];
+        if (std.mem.eql(u8, a, "--target")) {
+            if (fi + 1 >= args.len) fatal("--target requires a PID value");
+            target_pid = std.fmt.parseInt(u32, args[fi + 1], 10) catch fatal("invalid --target PID");
+            fi += 2;
+        } else if (std.mem.eql(u8, a, "--session") or std.mem.eql(u8, a, "-s")) {
+            if (fi + 1 >= args.len) fatal("--session requires a session ID");
+            target_session = std.fmt.parseInt(u32, args[fi + 1], 10) catch fatal("invalid --session ID");
+            fi += 2;
+        } else if (std.mem.eql(u8, a, "--json")) {
             json_output = true;
-            start += 1;
-        } else break;
+            fi += 1;
+        } else {
+            if (flen < fbuf.len) {
+                fbuf[flen] = a;
+                flen += 1;
+            }
+            fi += 1;
+        }
     }
+    const fargs = fbuf[0..flen];
 
-    if (start >= args.len) {
+    if (fargs.len < 2) {
         printUsage();
         return null;
     }
 
-    const sub = args[start];
+    const start: usize = 1;
+    const sub = fargs[start];
 
     if (isHelp(sub)) showHelp(help.top_level);
 
     const result: ?IpcRequest = blk: {
-        if (std.mem.eql(u8, sub, "tab")) break :blk parseTab(args, start, target_pid, json_output);
-        if (std.mem.eql(u8, sub, "split")) break :blk parseSplit(args, start, target_pid, json_output);
-        if (std.mem.eql(u8, sub, "focus")) break :blk parseFocus(args, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "tab")) break :blk parseTab(fargs, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "split")) break :blk parseSplit(fargs, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "focus")) break :blk parseFocus(fargs, start, target_pid, json_output);
 
         if (std.mem.eql(u8, sub, "send-keys") or std.mem.eql(u8, sub, "send-text")) {
-            if (hasHelp(args, start)) showHelp(help.send_keys);
-            break :blk parseSendText(args, start, target_pid, json_output);
+            if (hasHelp(fargs, start)) showHelp(help.send_keys);
+            break :blk parseSendText(fargs, start, target_pid, json_output);
         }
         if (std.mem.eql(u8, sub, "get-text")) {
-            if (hasHelp(args, start)) showHelp(help.get_text);
+            if (hasHelp(fargs, start)) showHelp(help.get_text);
             var gt_result = IpcRequest{ .command = .get_text, .target_pid = target_pid, .json_output = json_output };
             var gi = start + 1;
-            while (gi < args.len) {
-                if (std.mem.eql(u8, args[gi], "--pane") or std.mem.eql(u8, args[gi], "-p")) {
-                    if (gi + 1 >= args.len) fatal("--pane requires a pane ID");
+            while (gi < fargs.len) {
+                if (std.mem.eql(u8, fargs[gi], "--pane") or std.mem.eql(u8, fargs[gi], "-p")) {
+                    if (gi + 1 >= fargs.len) fatal("--pane requires a pane ID");
                     gi += 1;
-                    parsePaneArg(args[gi], &gt_result);
-                } else if (std.mem.eql(u8, args[gi], "--lines") or std.mem.eql(u8, args[gi], "-n")) {
-                    if (gi + 1 >= args.len) fatal("--lines requires a count");
+                    parsePaneArg(fargs[gi], &gt_result);
+                } else if (std.mem.eql(u8, fargs[gi], "--lines") or std.mem.eql(u8, fargs[gi], "-n")) {
+                    if (gi + 1 >= fargs.len) fatal("--lines requires a count");
                     gi += 1;
-                    const n = std.fmt.parseInt(u32, args[gi], 10) catch fatal("--lines: invalid count");
+                    const n = std.fmt.parseInt(u32, fargs[gi], 10) catch fatal("--lines: invalid count");
                     if (n == 0) fatal("--lines: count must be >= 1");
                     gt_result.lines = n;
                 }
@@ -204,35 +220,35 @@ pub fn parse(args: []const [:0]const u8) ?IpcRequest {
             break :blk gt_result;
         }
         if (std.mem.eql(u8, sub, "reload")) {
-            if (hasHelp(args, start)) showHelp(help.reload);
+            if (hasHelp(fargs, start)) showHelp(help.reload);
             break :blk .{ .command = .config_reload, .target_pid = target_pid, .json_output = json_output };
         }
         if (std.mem.eql(u8, sub, "theme")) {
-            if (hasHelp(args, start)) showHelp(help.theme);
-            if (start + 1 >= args.len) {
+            if (hasHelp(fargs, start)) showHelp(help.theme);
+            if (start + 1 >= fargs.len) {
                 printHelp(help.theme);
                 break :blk null;
             }
-            break :blk .{ .command = .theme_set, .text_arg = args[start + 1], .target_pid = target_pid, .json_output = json_output };
+            break :blk .{ .command = .theme_set, .text_arg = fargs[start + 1], .target_pid = target_pid, .json_output = json_output };
         }
-        if (std.mem.eql(u8, sub, "scroll-to")) break :blk parseScrollTo(args, start, target_pid, json_output);
-        if (std.mem.eql(u8, sub, "popup")) break :blk parsePopup(args, start, target_pid, json_output);
-        if (std.mem.eql(u8, sub, "list")) break :blk parseList(args, start, target_pid, json_output);
-        if (std.mem.eql(u8, sub, "session")) break :blk parseSession(args, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "scroll-to")) break :blk parseScrollTo(fargs, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "popup")) break :blk parsePopup(fargs, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "list")) break :blk parseList(fargs, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "session")) break :blk parseSession(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "run")) {
-            if (hasHelp(args, start)) showHelp(help.run);
-            if (start + 1 >= args.len) {
+            if (hasHelp(fargs, start)) showHelp(help.run);
+            if (start + 1 >= fargs.len) {
                 printHelp(help.run);
                 break :blk null;
             }
             var run_cmd: []const u8 = "";
             var run_wait = false;
             var ri = start + 1;
-            while (ri < args.len) {
-                if (std.mem.eql(u8, args[ri], "--wait") or std.mem.eql(u8, args[ri], "-w")) {
+            while (ri < fargs.len) {
+                if (std.mem.eql(u8, fargs[ri], "--wait") or std.mem.eql(u8, fargs[ri], "-w")) {
                     run_wait = true;
                 } else if (run_cmd.len == 0) {
-                    run_cmd = args[ri];
+                    run_cmd = fargs[ri];
                 }
                 ri += 1;
             }

--- a/src/ipc/client.zig
+++ b/src/ipc/client.zig
@@ -118,7 +118,7 @@ pub fn sendCommand(
     };
 }
 
-fn connectToSocket(path: []const u8) !posix.fd_t {
+pub fn connectToSocket(path: []const u8) !posix.fd_t {
     if (comptime is_windows) {
         return client_win.connectPipe(path);
     } else {
@@ -149,6 +149,16 @@ pub fn run(args: []const [:0]const u8) void {
         // parse() already printed usage/error
         std.process.exit(1);
     };
+
+    // Headless session routing: when -s/--session targets a session, a few
+    // commands run directly against that session in the daemon, regardless of
+    // which window (if any) is attached. This lets background agents drive
+    // their own session without switching what any window shows.
+    const client_daemon = @import("client_daemon.zig");
+    if (parsed.target_session != 0 and client_daemon.isRoutable(parsed.command)) {
+        client_daemon.run(parsed);
+        return;
+    }
 
     // Discover socket early — needed for both paths
     var sock_buf: [256]u8 = undefined;

--- a/src/ipc/client_daemon.zig
+++ b/src/ipc/client_daemon.zig
@@ -169,22 +169,29 @@ fn ctl(
     return .{ .status = resp_buf[0], .body = resp_buf[1..plen] };
 }
 
+const ReadTimeoutError = error{ Timeout, ReadFailed };
+
 /// Like protocol.readExact but bounded: poll for readability before each read
 /// so an unresponsive (or outdated) daemon yields error.Timeout rather than
-/// blocking forever. Falls back to the blocking read on Windows named pipes.
-fn readExactTimeout(fd: std.posix.fd_t, out: []u8, timeout_ms: i32) !void {
-    if (comptime builtin.os.tag == .windows) return io.readExact(fd, out);
+/// blocking forever. Falls back to a blocking read on Windows named pipes (the
+/// explicit error set keeps Timeout in `ctl`'s signature on every platform so
+/// ctlOrExit's switch compiles).
+fn readExactTimeout(fd: std.posix.fd_t, out: []u8, timeout_ms: i32) ReadTimeoutError!void {
+    if (comptime builtin.os.tag == .windows) {
+        io.readExact(fd, out) catch return error.ReadFailed;
+        return;
+    }
     const POLLIN: i16 = 0x0001;
     var total: usize = 0;
     while (total < out.len) {
         var fds = [1]std.posix.pollfd{.{ .fd = fd, .events = POLLIN, .revents = 0 }};
-        const ready = std.posix.poll(&fds, timeout_ms) catch return error.SocketError;
+        const ready = std.posix.poll(&fds, timeout_ms) catch return error.ReadFailed;
         if (ready == 0) return error.Timeout;
         const n = std.posix.read(fd, out[total..]) catch |err| switch (err) {
             error.WouldBlock => continue,
-            else => return err,
+            else => return error.ReadFailed,
         };
-        if (n == 0) return error.ConnectionClosed;
+        if (n == 0) return error.ReadFailed;
         total += n;
     }
 }

--- a/src/ipc/client_daemon.zig
+++ b/src/ipc/client_daemon.zig
@@ -1,0 +1,322 @@
+// Attyx — headless daemon control client
+//
+// Routes a small set of CLI commands (`send-text`, `get-text`) directly to a
+// target session in the daemon when `-s/--session` is given, so they work no
+// matter which window is attached — or whether any window is attached at all.
+// Speaks the daemon protocol's ctl_request/ctl_response over the daemon socket.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const io = @import("protocol.zig"); // protocol-agnostic fd helpers (writeAll/readExact/closeFd)
+const dproto = @import("../app/daemon/protocol.zig");
+const keys = @import("keys.zig");
+const client = @import("client.zig");
+const session_connect = @import("../app/session_connect.zig");
+const cli_ipc = @import("../config/cli_ipc.zig");
+const IpcRequest = cli_ipc.IpcRequest;
+const IpcCommand = cli_ipc.IpcCommand;
+
+const inter_key_delay_ns: u64 = 30_000_000; // 30ms — mirrors the window send path
+
+/// Read timeout (ms) for a ctl_response. A daemon that predates the headless
+/// control channel silently drops the unknown ctl_request, so without this the
+/// CLI would block forever — instead we fail with a clear "restart Attyx" hint.
+const ctl_read_timeout_ms: i32 = 4000;
+
+/// Commands that operate on a single session's I/O or layout view and so can
+/// be served headlessly by the daemon. Mutating layout commands (tab/split/
+/// focus) still need a window and land in a later phase.
+pub fn isRoutable(cmd: IpcCommand) bool {
+    return switch (cmd) {
+        .send_keys, .get_text, .list, .list_tabs, .list_splits => true,
+        .tab_create, .tab_select, .tab_next, .tab_prev => true,
+        .tab_close, .tab_move_left, .tab_move_right, .tab_rename => true,
+        .split_vertical, .split_horizontal, .split_close, .split_rotate => true,
+        // Routed only to emit a clear "not headless" message (see run()).
+        .split_zoom => true,
+        else => false,
+    };
+}
+
+pub fn run(parsed: IpcRequest) void {
+    var sock_buf: [256]u8 = undefined;
+    const sock = session_connect.getSocketPath(&sock_buf) orelse {
+        stderr("error: cannot locate attyx daemon socket\n");
+        std.process.exit(1);
+    };
+    switch (parsed.command) {
+        .send_keys => sendKeys(sock, parsed),
+        .get_text => getText(sock, parsed),
+        .list => list(sock, parsed, .all),
+        .list_tabs => list(sock, parsed, .tabs),
+        .list_splits => list(sock, parsed, .panes),
+        .tab_create => tabCreate(sock, parsed),
+        .tab_select => simpleOk(sock, parsed, .tab_select, &[_]u8{parsed.index_arg}),
+        .tab_next => simpleOk(sock, parsed, .tab_next, ""),
+        .tab_prev => simpleOk(sock, parsed, .tab_prev, ""),
+        .split_vertical => split(sock, parsed, 0),
+        .split_horizontal => split(sock, parsed, 1),
+        .split_close => paneClose(sock, parsed),
+        .split_rotate => simpleOk(sock, parsed, .pane_rotate, ""),
+        .tab_close => simpleOk(sock, parsed, .tab_close, &[_]u8{parsed.tab_idx}),
+        .tab_move_left => simpleOk(sock, parsed, .tab_move, &[_]u8{0}),
+        .tab_move_right => simpleOk(sock, parsed, .tab_move, &[_]u8{1}),
+        .tab_rename => tabRename(sock, parsed),
+        // Zoom is a per-window view state (not part of the session's layout),
+        // so it has no headless meaning.
+        .split_zoom => {
+            stderr("error: 'split zoom' is a window-only view and isn't available with -s\n");
+            std.process.exit(2);
+        },
+        else => unreachable, // guarded by isRoutable
+    }
+}
+
+fn tabRename(sock: []const u8, parsed: IpcRequest) void {
+    // op_body: [tab_idx:u8 (0xFF = active)][name...]
+    var body: [1 + 256]u8 = undefined;
+    body[0] = parsed.tab_idx; // 0xFF when no index was given
+    const n = @min(parsed.text_arg.len, body.len - 1);
+    @memcpy(body[1 .. 1 + n], parsed.text_arg[0..n]);
+    simpleOk(sock, parsed, .tab_rename, body[0 .. 1 + n]);
+}
+
+fn split(sock: []const u8, parsed: IpcRequest, dir: u8) void {
+    if (parsed.wait) {
+        stderr("error: --wait is not supported with -s yet\n");
+        std.process.exit(1);
+    }
+    // op_body: [dir:u8][cmd...]
+    var body: [1 + 4096]u8 = undefined;
+    body[0] = dir;
+    const n = @min(parsed.text_arg.len, body.len - 1);
+    @memcpy(body[1 .. 1 + n], parsed.text_arg[0..n]);
+    var resp_buf: [256]u8 = undefined;
+    const reply = ctlOrExit(sock, parsed.target_session, .split, body[0 .. 1 + n], &resp_buf);
+    if (reply.status != 0) {
+        reportError(reply.body);
+        std.process.exit(1);
+    }
+}
+
+fn paneClose(sock: []const u8, parsed: IpcRequest) void {
+    var body: [4]u8 = undefined;
+    std.mem.writeInt(u32, &body, parsed.pane_id, .little); // 0 = focused
+    simpleOk(sock, parsed, .pane_close, &body);
+}
+
+/// Run a ctl op whose only outcome is success/failure (no body to print).
+fn simpleOk(sock: []const u8, parsed: IpcRequest, op: dproto.CtlOp, op_body: []const u8) void {
+    var resp_buf: [256]u8 = undefined;
+    const reply = ctlOrExit(sock, parsed.target_session, op, op_body, &resp_buf);
+    if (reply.status != 0) {
+        reportError(reply.body);
+        std.process.exit(1);
+    }
+}
+
+fn tabCreate(sock: []const u8, parsed: IpcRequest) void {
+    if (parsed.wait) {
+        stderr("error: --wait is not supported with -s yet\n");
+        std.process.exit(1);
+    }
+    var resp_buf: [256]u8 = undefined;
+    const reply = ctlOrExit(sock, parsed.target_session, .tab_create, parsed.text_arg, &resp_buf);
+    if (reply.status != 0) {
+        reportError(reply.body);
+        std.process.exit(1);
+    }
+    // Stay quiet on success, matching the window-side `tab create`.
+}
+
+fn list(sock: []const u8, parsed: IpcRequest, kind: dproto.CtlListKind) void {
+    const op_body = [_]u8{@intFromEnum(kind)};
+    var resp_buf: [16384]u8 = undefined;
+    const reply = ctlOrExit(sock, parsed.target_session, .list, &op_body, &resp_buf);
+    if (reply.status != 0) {
+        reportError(reply.body);
+        std.process.exit(1);
+    }
+    printBody(reply.body);
+}
+
+const CtlReply = struct { status: u8, body: []const u8 };
+
+/// One ctl_request → ctl_response round-trip over a fresh daemon connection.
+/// The reply body is a slice into `resp_buf`.
+fn ctl(
+    sock: []const u8,
+    target_session: u32,
+    op: dproto.CtlOp,
+    op_body: []const u8,
+    resp_buf: []u8,
+) !CtlReply {
+    var payload_buf: [5 + 8192]u8 = undefined;
+    const payload = try dproto.encodeCtlRequest(&payload_buf, target_session, @intFromEnum(op), op_body);
+    var frame_buf: [dproto.header_size + 5 + 8192]u8 = undefined;
+    const frame = try dproto.encodeMessage(&frame_buf, .ctl_request, payload);
+
+    const fd = try client.connectToSocket(sock);
+    defer io.closeFd(fd);
+    io.writeAll(fd, frame) catch return error.SocketError;
+
+    var hdr: [dproto.header_size]u8 = undefined;
+    try readExactTimeout(fd, &hdr, ctl_read_timeout_ms);
+    const plen = std.mem.readInt(u32, hdr[0..4], .little);
+    if (hdr[4] != @intFromEnum(dproto.MessageType.ctl_response)) return error.InvalidResponse;
+    if (plen == 0 or plen > resp_buf.len) return error.InvalidResponse;
+    try readExactTimeout(fd, resp_buf[0..plen], ctl_read_timeout_ms);
+    return .{ .status = resp_buf[0], .body = resp_buf[1..plen] };
+}
+
+/// Like protocol.readExact but bounded: poll for readability before each read
+/// so an unresponsive (or outdated) daemon yields error.Timeout rather than
+/// blocking forever. Falls back to the blocking read on Windows named pipes.
+fn readExactTimeout(fd: std.posix.fd_t, out: []u8, timeout_ms: i32) !void {
+    if (comptime builtin.os.tag == .windows) return io.readExact(fd, out);
+    const POLLIN: i16 = 0x0001;
+    var total: usize = 0;
+    while (total < out.len) {
+        var fds = [1]std.posix.pollfd{.{ .fd = fd, .events = POLLIN, .revents = 0 }};
+        const ready = std.posix.poll(&fds, timeout_ms) catch return error.SocketError;
+        if (ready == 0) return error.Timeout;
+        const n = std.posix.read(fd, out[total..]) catch |err| switch (err) {
+            error.WouldBlock => continue,
+            else => return err,
+        };
+        if (n == 0) return error.ConnectionClosed;
+        total += n;
+    }
+}
+
+/// Perform a ctl round-trip, printing a clear message and exiting on failure.
+/// Used by the one-shot commands; the wait-stable poll loop uses `ctl` directly
+/// so a transient miss just retries.
+fn ctlOrExit(
+    sock: []const u8,
+    target_session: u32,
+    op: dproto.CtlOp,
+    op_body: []const u8,
+    resp_buf: []u8,
+) CtlReply {
+    return ctl(sock, target_session, op, op_body, resp_buf) catch |err| {
+        switch (err) {
+            error.Timeout => stderr("error: no response from attyx daemon (it may be an older version — restart Attyx)\n"),
+            else => stderr("error: failed to reach attyx daemon\n"),
+        }
+        std.process.exit(1);
+    };
+}
+
+fn sendKeys(sock: []const u8, parsed: IpcRequest) void {
+    var iter = keys.KeyTokenIter{ .input = parsed.text_arg };
+    var tok_buf: [4096]u8 = undefined;
+    var resp_buf: [256]u8 = undefined;
+
+    while (iter.next(&tok_buf)) |token| {
+        const processed = tok_buf[0..token.len];
+        var op_body: [4 + 4096]u8 = undefined;
+        std.mem.writeInt(u32, op_body[0..4], parsed.pane_id, .little);
+        const n = @min(processed.len, op_body.len - 4);
+        @memcpy(op_body[4 .. 4 + n], processed[0..n]);
+
+        const reply = ctlOrExit(sock, parsed.target_session, .write_input, op_body[0 .. 4 + n], &resp_buf);
+        if (reply.status != 0) {
+            reportError(reply.body);
+            std.process.exit(1);
+        }
+        // Pause after named keys so the target TUI can process and redraw
+        // before the next token (e.g. {Down}{Enter} hitting the right item).
+        if (token.is_named_key) std.Thread.sleep(inter_key_delay_ns);
+    }
+
+    if (parsed.wait_stable_ms > 0) waitStable(sock, parsed);
+}
+
+fn getText(sock: []const u8, parsed: IpcRequest) void {
+    var op_body: [8]u8 = undefined;
+    std.mem.writeInt(u32, op_body[0..4], parsed.pane_id, .little);
+    std.mem.writeInt(u32, op_body[4..8], parsed.lines, .little);
+
+    // With --lines the screen + scrollback can be large; heap-allocate.
+    var heap: ?[]u8 = null;
+    defer if (heap) |h| std.heap.page_allocator.free(h);
+    var stack_buf: [65536]u8 = undefined;
+    const resp_buf: []u8 = if (parsed.lines > 0) blk: {
+        const b = std.heap.page_allocator.alloc(u8, 8 * 1024 * 1024) catch {
+            stderr("error: out of memory for response buffer\n");
+            std.process.exit(1);
+        };
+        heap = b;
+        break :blk b;
+    } else stack_buf[0..];
+
+    const reply = ctlOrExit(sock, parsed.target_session, .get_text, &op_body, resp_buf);
+    if (reply.status != 0) {
+        reportError(reply.body);
+        std.process.exit(1);
+    }
+    printBody(reply.body);
+}
+
+/// Poll get-text until the visible screen stops changing for `wait_stable_ms`,
+/// then print it. Hard timeout at 30s. Mirrors client.waitStable.
+fn waitStable(sock: []const u8, parsed: IpcRequest) void {
+    const poll_interval_ms: u64 = 50;
+    const hard_timeout_ms: u64 = 30_000;
+    var elapsed_ms: u64 = 0;
+    var stable_since_ms: u64 = 0;
+    var prev_hash: u64 = 0;
+    var has_prev = false;
+
+    var op_body: [8]u8 = undefined;
+    std.mem.writeInt(u32, op_body[0..4], parsed.pane_id, .little);
+    std.mem.writeInt(u32, op_body[4..8], 0, .little); // visible screen only
+
+    var resp_buf: [65536]u8 = undefined;
+    var last: [65536]u8 = undefined;
+    var last_len: usize = 0;
+
+    while (elapsed_ms < hard_timeout_ms) {
+        std.Thread.sleep(poll_interval_ms * 1_000_000);
+        elapsed_ms += poll_interval_ms;
+
+        const reply = ctl(sock, parsed.target_session, .get_text, &op_body, &resp_buf) catch continue;
+        if (reply.status != 0) continue;
+
+        const hash = std.hash.Wyhash.hash(0, reply.body);
+        if (has_prev and hash == prev_hash) {
+            stable_since_ms += poll_interval_ms;
+            if (stable_since_ms >= parsed.wait_stable_ms) {
+                printBody(reply.body);
+                return;
+            }
+        } else {
+            stable_since_ms = 0;
+            prev_hash = hash;
+            has_prev = true;
+        }
+        @memcpy(last[0..reply.body.len], reply.body);
+        last_len = reply.body.len;
+    }
+
+    stderr("warning: --wait-stable timed out after 30s\n");
+    printBody(last[0..last_len]);
+}
+
+fn printBody(body: []const u8) void {
+    if (body.len == 0) return;
+    const out = std.fs.File.stdout();
+    out.writeAll(body) catch {};
+    if (body[body.len - 1] != '\n') out.writeAll("\n") catch {};
+}
+
+fn reportError(body: []const u8) void {
+    stderr("error: ");
+    std.fs.File.stderr().writeAll(body) catch {};
+    stderr("\n");
+}
+
+fn stderr(msg: []const u8) void {
+    std.fs.File.stderr().writeAll(msg) catch {};
+}


### PR DESCRIPTION
## What

`attyx <cmd> -s <id>` now operates on that session **directly in the daemon**, regardless of which window (if any) is attached. Background agents in different sessions can drive their own session independently — no window switching, and it works even when the session has no window attached at all.

```
attyx send-text "hello" -s 3     # goes to session 3, not the active one
attyx get-text -s 3
attyx -s 3 split vertical         # leading or trailing -s, same result
```

## How

The daemon already owns every session's PTYs and parses their output into an engine continuously, so it can serve I/O and mutate layout with no window present. A new `ctl_request`/`ctl_response` pair carries an op + target session over the daemon socket; the CLI connects there directly when `-s` is set.

For layout changes the daemon becomes **authoritative** over the session's tab/split tree: it spawns/kills the pane, edits the serialized layout, and broadcasts `layout_sync` so attached windows re-render live — the same broadcast path `move_panes` already uses. The pure tree surgery (split/close/rotate/compaction) lives in `layout_ops.zig` and is unit-tested without PTYs or sockets.

`-s`/`--session` (and `--target`/`--json`) are now **position-independent**: global flags are stripped from anywhere in argv before dispatch, so `attyx send-text "hi" -s 3` and `attyx -s 3 send-text "hi"` behave identically.

## Headless commands

`send-text` / `send-keys` · `get-text` · `list` / `tabs` / `panes` · `tab create`/`select`/`next`/`prev`/`close`/`move`/`rename` · `run` · `split vertical`/`horizontal`/`close`/`rotate`

Targeting a pane (`--pane`) and the active/focused pane both work; new panes are independently addressable by id.

## Intentionally not headless

`zoom`, `scroll-to`, `popup`, `reload`, `theme` — these are per-window view/UI state, not part of the session's persisted layout. `split zoom -s N` returns a clear message rather than failing obscurely.

## Compatibility

A daemon that predates this channel silently drops the unknown `ctl_request`. The client now polls with a 4s timeout and reports `no response from attyx daemon (it may be an older version — restart Attyx)` instead of hanging.

## Also included

A separate commit fixes a pre-existing use-after-free: `doSessionCreate` logged `cwd` after `doSessionSwitch` invalidated it, crashing nondeterministically on session create.

## Testing

New unit tests cover the ctl wire encoding and the tree surgery (sibling promotion + compaction, leaf rotation). Each command was exercised end-to-end against an isolated daemon, including two-session isolation (input lands in the targeted session, never the active one) and the full split/close/rotate/move/rename lifecycle.

## Not in this PR

- `focus up/down/left/right` (needs viewport geometry for directional movement)
- headless `session create`/`kill`/`rename`
- `--wait` over `-s`
- Live window reconciliation is verified daemon-side via `list`; watching an attached GUI update during daemon-driven layout changes is still worth a manual pass.
