### PR TITLE
Decouple IPC scroll from the UI

### DIFF
--- a/src/app/daemon/handler_ctl.zig
+++ b/src/app/daemon/handler_ctl.zig
@@ -59,6 +59,7 @@ pub fn handle(
         .tab_close => handler_ctl_layout.tabClose(cl, session, req.body, clients),
         .tab_move => handler_ctl_layout.tabMove(cl, session, req.body, clients),
         .tab_rename => handler_ctl_layout.tabRename(cl, session, req.body, clients),
+        .scroll => handleScroll(cl, session, req.body),
     }
 }
 
@@ -79,6 +80,49 @@ fn handleWriteInput(cl: *DaemonClient, session: *DaemonSession, body: []const u8
         return;
     };
     cl.sendCtlResponse(0, "");
+}
+
+/// Move a pane's IPC-private scroll cursor. body = [pane_id:u32][kind:u8].
+/// This only affects what headless get-text returns — never a window's view.
+fn handleScroll(cl: *DaemonClient, session: *DaemonSession, body: []const u8) void {
+    if (body.len < 5) {
+        cl.sendCtlResponse(1, "invalid scroll request");
+        return;
+    }
+    const pane_id = std.mem.readInt(u32, body[0..4], .little);
+    const kind = std.meta.intToEnum(protocol.CtlScrollKind, body[4]) catch {
+        cl.sendCtlResponse(1, "invalid scroll kind");
+        return;
+    };
+    const pane = selectPane(session, pane_id) orelse {
+        cl.sendCtlResponse(1, "pane not found");
+        return;
+    };
+    ensureActive(pane, session);
+    const eng = pane.engine orelse {
+        cl.sendCtlResponse(1, "pane has no screen yet");
+        return;
+    };
+    const sb = eng.state.ring.scrollbackCount();
+    const page = eng.state.ring.screen_rows;
+    const off = computeScrollOffset(kind, pane.ipc_viewport_offset, sb, page);
+    pane.ipc_viewport_offset = off;
+
+    var reply_buf: [16]u8 = undefined;
+    const reply = std.fmt.bufPrint(&reply_buf, "{d}", .{off}) catch "";
+    cl.sendCtlResponse(0, reply);
+}
+
+/// Pure scroll-offset transition (rows back from the live bottom), clamped to
+/// the available scrollback. `page` is the screen height.
+fn computeScrollOffset(kind: protocol.CtlScrollKind, cur: usize, sb: usize, page: usize) usize {
+    const off = @min(cur, sb);
+    return switch (kind) {
+        .top => sb,
+        .bottom => 0,
+        .page_up => @min(off + page, sb),
+        .page_down => if (off >= page) off - page else 0,
+    };
 }
 
 fn handleGetText(
@@ -105,11 +149,13 @@ fn handleGetText(
 
     // Same row selection + trailing-whitespace trim as the window-side
     // get-text (handler_query.writeScreenText), but against the daemon's
-    // own engine grid.
+    // own engine grid. The visible-screen view (lines == 0) follows the
+    // IPC scroll cursor; an explicit --lines range is always tail-relative.
     const ring = &eng.state.ring;
     const cols = ring.cols;
     const total_rows: usize = if (lines == 0) ring.screen_rows else @min(@as(usize, lines), ring.count);
-    const start_abs: usize = if (lines == 0) ring.scrollbackCount() else ring.count - total_rows;
+    const scroll_off = @min(pane.ipc_viewport_offset, ring.scrollbackCount());
+    const start_abs: usize = if (lines == 0) ring.scrollbackCount() - scroll_off else ring.count - total_rows;
 
     const max_row_bytes = cols * 4 + 1;
     const buf_size = total_rows * max_row_bytes + 64;
@@ -287,4 +333,22 @@ fn setNonBlocking(fd: std.posix.fd_t) void {
     const F_SETFL: i32 = 4;
     const flags = std.posix.fcntl(fd, F_GETFL, 0) catch return;
     _ = std.posix.fcntl(fd, F_SETFL, flags | platform.O_NONBLOCK) catch {};
+}
+
+test "computeScrollOffset transitions and clamps" {
+    const sb: usize = 100;
+    const page: usize = 24;
+    // page-up accumulates and clamps at sb
+    try std.testing.expectEqual(@as(usize, 24), computeScrollOffset(.page_up, 0, sb, page));
+    try std.testing.expectEqual(@as(usize, 48), computeScrollOffset(.page_up, 24, sb, page));
+    try std.testing.expectEqual(sb, computeScrollOffset(.page_up, 90, sb, page));
+    // page-down decrements and floors at 0
+    try std.testing.expectEqual(@as(usize, 0), computeScrollOffset(.page_down, 24, sb, page));
+    try std.testing.expectEqual(@as(usize, 0), computeScrollOffset(.page_down, 10, sb, page));
+    try std.testing.expectEqual(@as(usize, 76), computeScrollOffset(.page_down, 100, sb, page));
+    // top / bottom are absolute
+    try std.testing.expectEqual(sb, computeScrollOffset(.top, 0, sb, page));
+    try std.testing.expectEqual(@as(usize, 0), computeScrollOffset(.bottom, sb, sb, page));
+    // a stale offset beyond sb is clamped to sb before stepping
+    try std.testing.expectEqual(sb, computeScrollOffset(.page_up, 999, sb, page));
 }

--- a/src/app/daemon/pane.zig
+++ b/src/app/daemon/pane.zig
@@ -91,6 +91,12 @@ pub const DaemonPane = struct {
     /// Monotonic counter bumped when engine.feed dirties any row.
     engine_generation: u64 = 0,
 
+    /// Scrollback position for the headless IPC view, in rows back from the
+    /// live bottom (0 = live tail). Driven only by `attyx scroll-to -s N` and
+    /// read only by headless `get-text`; completely separate from any window's
+    /// viewport, so an agent scrolling never disturbs the user's view.
+    ipc_viewport_offset: usize = 0,
+
     /// Pending spawn params. When set, the PTY is inactive and the engine
     /// is null — the actual fork/exec runs on the first `resize()` call,
     /// using the resize dims so the shell's first prompt renders at the

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -219,10 +219,17 @@ pub const CtlOp = enum(u8) {
     tab_move = 0x0C,
     /// op_body: [tab_idx:u8 (0xFF = active)][name...] — rename that tab.
     tab_rename = 0x0D,
+    /// op_body: [pane_id:u32 (0 = first)][kind:u8] — move the IPC-private
+    /// scroll cursor for that pane. See CtlScrollKind. Does not touch any
+    /// window's viewport.
+    scroll = 0x0E,
 };
 
 /// `list` ctl op kinds (first byte of op_body).
 pub const CtlListKind = enum(u8) { all = 0, tabs = 1, panes = 2 };
+
+/// `scroll` ctl op kinds.
+pub const CtlScrollKind = enum(u8) { top = 0, bottom = 1, page_up = 2, page_down = 3 };
 
 pub const CtlRequest = struct { target_session: u32, op: u8, body: []const u8 };
 

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -515,6 +515,8 @@ fn parseScrollTo(args: []const [:0]const u8, start: usize, target_pid: ?u32, jso
     const pos = args[start + 1];
     if (std.mem.eql(u8, pos, "top")) return .{ .command = .scroll_to_top, .target_pid = target_pid, .json_output = json_output };
     if (std.mem.eql(u8, pos, "bottom")) return .{ .command = .scroll_to_bottom, .target_pid = target_pid, .json_output = json_output };
+    if (std.mem.eql(u8, pos, "page-up")) return .{ .command = .scroll_page_up, .target_pid = target_pid, .json_output = json_output };
+    if (std.mem.eql(u8, pos, "page-down")) return .{ .command = .scroll_page_down, .target_pid = target_pid, .json_output = json_output };
     std.debug.print("error: unknown position '{s}'\n\n", .{pos});
     printHelp(help.scroll_to);
     return null;

--- a/src/ipc/client_daemon.zig
+++ b/src/ipc/client_daemon.zig
@@ -32,6 +32,7 @@ pub fn isRoutable(cmd: IpcCommand) bool {
         .tab_create, .tab_select, .tab_next, .tab_prev => true,
         .tab_close, .tab_move_left, .tab_move_right, .tab_rename => true,
         .split_vertical, .split_horizontal, .split_close, .split_rotate => true,
+        .scroll_to_top, .scroll_to_bottom, .scroll_page_up, .scroll_page_down => true,
         // Routed only to emit a clear "not headless" message (see run()).
         .split_zoom => true,
         else => false,
@@ -62,6 +63,10 @@ pub fn run(parsed: IpcRequest) void {
         .tab_move_left => simpleOk(sock, parsed, .tab_move, &[_]u8{0}),
         .tab_move_right => simpleOk(sock, parsed, .tab_move, &[_]u8{1}),
         .tab_rename => tabRename(sock, parsed),
+        .scroll_to_top => scroll(sock, parsed, 0),
+        .scroll_to_bottom => scroll(sock, parsed, 1),
+        .scroll_page_up => scroll(sock, parsed, 2),
+        .scroll_page_down => scroll(sock, parsed, 3),
         // Zoom is a per-window view state (not part of the session's layout),
         // so it has no headless meaning.
         .split_zoom => {
@@ -70,6 +75,15 @@ pub fn run(parsed: IpcRequest) void {
         },
         else => unreachable, // guarded by isRoutable
     }
+}
+
+/// Move the session's IPC-private scroll cursor (kind: 0=top, 1=bottom,
+/// 2=page-up, 3=page-down). Silent on success, like the window-side scroll-to.
+fn scroll(sock: []const u8, parsed: IpcRequest, kind: u8) void {
+    var body: [5]u8 = undefined;
+    std.mem.writeInt(u32, body[0..4], parsed.pane_id, .little); // 0 = first pane
+    body[4] = kind;
+    simpleOk(sock, parsed, .scroll, &body);
 }
 
 fn tabRename(sock: []const u8, parsed: IpcRequest) void {


### PR DESCRIPTION
This pull request adds support for headless (IPC-only) pane scroll control, allowing clients to programmatically move a pane's scrollback position independently of any window's viewport. This enables commands like page-up, page-down, top, and bottom for the IPC view, and ensures that agents or scripts can scroll text without affecting the user's visible window. The implementation includes protocol changes, handler logic, CLI and client support, and unit tests.

**Headless scroll control support:**

* Added a new `.scroll` control operation to the protocol (`CtlOp`) and defined `CtlScrollKind` enum for scroll directions (`top`, `bottom`, `page_up`, `page_down`).
* Introduced the `ipc_viewport_offset` field in `DaemonPane` to track the IPC-private scroll position, separate from any window's viewport.
* Implemented the `handleScroll` function in the daemon to process scroll requests, update the scroll offset, and clamp transitions correctly. Added the corresponding handler case. [[1]](diffhunk://#diff-53dbca3f14a8e80b2b04f2633626e3d2ea2b8cb395e13760e85067bb934fb147R85-R127) [[2]](diffhunk://#diff-53dbca3f14a8e80b2b04f2633626e3d2ea2b8cb395e13760e85067bb934fb147R62)
* Updated `handleGetText` to respect the IPC scroll offset for headless text retrieval when `lines == 0`.
* Added unit tests for `computeScrollOffset` to verify correct and clamped scrolling behavior.

**CLI and client integration:**

* Extended the CLI parser to recognize `page-up` and `page-down` scroll commands.
* Marked the new scroll commands as routable in the IPC client.
* Updated the IPC client to send the correct scroll requests for all supported scroll directions. [[1]](diffhunk://#diff-a9a0c418ddddb1270e893b233ea0b4c524d1384939b4a5d73c1033a6603a6ff9R66-R69) [[2]](diffhunk://#diff-a9a0c418ddddb1270e893b233ea0b4c524d1384939b4a5d73c1033a6603a6ff9R80-R88)