### PR TITLE
Ship agent status on pane focus in grid-sync mode

### DIFF
--- a/src/app/daemon/agent_status_test.zig
+++ b/src/app/daemon/agent_status_test.zig
@@ -1,0 +1,90 @@
+//! Tests for agent status (OSC 7337;agent-status) propagation across the
+//! daemon ↔ client boundary in grid-sync mode.
+//!
+//! In grid-sync mode the client's engine is passive — it never sees the raw
+//! OSC bytes — so the daemon must ship the agent status explicitly. The dirty
+//! flag broadcast in the poll loop only fires on a *transition*, and only to
+//! clients already focused on the pane. That leaves the focus handler to
+//! re-ship the durable `agent_status` whenever a pane becomes newly active,
+//! so the tab indicator survives a session switch (which re-focuses panes)
+//! and shows up on first focus of a pane whose status fired before the
+//! client's focus round-tripped.
+const std = @import("std");
+const posix = std.posix;
+const testing = std.testing;
+const protocol = @import("protocol.zig");
+const harness = @import("test_harness.zig");
+const setup = harness.setup;
+const teardown = harness.teardown;
+const TestClient = harness.TestClient;
+
+// `.working` is enum value 2 (none, idle, working, input).
+const status_working: u8 = 2;
+
+test "daemon: agent status re-shipped when a pane becomes newly active" {
+    var env = try setup();
+    defer teardown(&env);
+
+    var client = try TestClient.connect(env.path());
+    defer client.deinit();
+
+    var buf: [4200]u8 = undefined;
+    const cp = try protocol.encodeCreate(&buf, "agent-status", 24, 80, "/tmp", "");
+    try client.send(.create, cp);
+    const created = try client.expect(.created, 5000);
+    const sid = try protocol.decodeCreated(created);
+
+    // Grid-sync so the focus handler takes the snapshot path (the byte-replay
+    // path doesn't ship status — there the client's engine sees the OSC bytes).
+    const hp = try protocol.encodeHello(&buf, "test", protocol.Capabilities.GRID_SYNC);
+    try client.send(.hello, hp);
+    _ = try client.expect(.hello_ack, 5000);
+
+    const ap = try protocol.encodeAttach(&buf, sid, 24, 80);
+    try client.send(.attach, ap);
+    const attached = try client.expect(.attached, 5000);
+    const v2 = try protocol.decodeAttachedV2(attached);
+    const pane_a = v2.pane_ids[0];
+
+    // Activate pane A (deferred-spawn until first pane_resize) and focus it.
+    const rp_a = try protocol.encodePaneResize(&buf, pane_a, 24, 80);
+    try client.send(.pane_resize, rp_a);
+    const fp_a = try protocol.encodeFocusPanes(&buf, &.{pane_a});
+    try client.send(.focus_panes, fp_a);
+    posix.nanosleep(0, 400_000_000);
+    client.read_len = 0;
+
+    // A second pane to focus away to, so pane A can later go newly-active again.
+    const pp = try protocol.encodeCreatePane(&buf, 24, 80, "/tmp");
+    try client.send(.create_pane, pp);
+    const pane_created = try client.expect(.pane_created, 5000);
+    const pane_b = try protocol.decodePaneCreated(pane_created);
+
+    // Drive an OSC 7337 agent-status out of pane A's PTY so the daemon-side
+    // engine records the durable status (printf interprets the octal escapes).
+    const ip = try protocol.encodePaneInput(
+        &buf,
+        pane_a,
+        "printf '\\033]7337;agent-status;claude;working\\007'\n",
+    );
+    try client.send(.pane_input, ip);
+    posix.nanosleep(0, 300_000_000);
+    client.read_len = 0;
+
+    // Focus away to B, then back to A. The re-focus marks A newly active,
+    // which must re-ship its durable status — the session-switch path.
+    const fp_b = try protocol.encodeFocusPanes(&buf, &.{pane_b});
+    try client.send(.focus_panes, fp_b);
+    posix.nanosleep(0, 150_000_000);
+    client.read_len = 0;
+
+    const fp_back = try protocol.encodeFocusPanes(&buf, &.{pane_a});
+    try client.send(.focus_panes, fp_back);
+
+    // Look for the status among the focus burst (snapshot/title/cwd/status);
+    // expect() skips past the other message types.
+    const payload = try client.expect(.pane_agent_status, 4000);
+    const msg = try protocol.decodePaneAgentStatus(payload);
+    try testing.expectEqual(@as(u32, pane_a), msg.pane_id);
+    try testing.expectEqual(status_working, msg.status);
+}

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -381,6 +381,13 @@ fn handleFocusPanes(
                     if (pane.engine.?.state.title) |t| {
                         cl.sendPaneTitle(pane.id, t);
                     }
+                    // Ship the current agent status too. The engine is
+                    // passive in grid-sync mode and won't see the OSC 7337
+                    // bytes, so without this the indicator is missing after
+                    // a session switch or on first focus of a busy pane.
+                    if (pane.engine.?.state.agent_status != .none) {
+                        cl.sendPaneAgentStatus(pane.id, @intFromEnum(pane.engine.?.state.agent_status), pane.engine.?.state.agentMsg());
+                    }
                     // And the current OSC 7 cwd so actions like "new tab
                     // from this pane's cwd" work immediately. Prefer the
                     // cached fg_cwd (populated by the periodic tick — which

--- a/src/app/daemon/session_test.zig
+++ b/src/app/daemon/session_test.zig
@@ -548,4 +548,5 @@ comptime {
     _ = @import("session_migration_test.zig");
     _ = @import("migration_stress_test.zig");
     _ = @import("cwd_test.zig");
+    _ = @import("agent_status_test.zig");
 }


### PR DESCRIPTION
## What

Agent state indicators disappeared on session switch and sometimes never showed up on first agent launch. This makes the tab dots reliable in both cases.

## Why

In grid-sync mode the client's terminal engine is passive — it never sees the raw `OSC 7337;agent-status` bytes, so the daemon ships the status explicitly. It did so in only one place: the poll loop, which broadcasts on a status *transition*, and only to clients already focused on the pane, then clears the dirty flag unconditionally.

That left two gaps:

- **Session switch** — switching sessions re-focuses the panes; the focus handler reshipped grid/title/cwd but not agent status, so the dots vanished.
- **First-launch race** — if the agent's first status fired before the client's `focus_panes` round-tripped (or while the pane was unfocused), the broadcast targeted no active client and the dirty flag was cleared and dropped. If the agent then stayed in one state, the dot never appeared.

## Fix

The focus handler already reships title and cwd when a pane becomes newly active. Reship the durable `agent_status` there too. Reading the durable field rather than the transient dirty flag is what closes both cases — even when the transition broadcast was lost, the status is reshipped as soon as focus lands.

## Test

Added a grid-sync daemon test: set a pane to `working`, focus away to a second pane, focus back, and assert the daemon reships `pane_agent_status` for the now-newly-active pane.