### PR TITLE
Stop dropping daemon messages during the pre-resize drain

### DIFF
--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -996,35 +996,9 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                         }
                     },
                     .replay_end => |pane_id| {
-                        if (findPaneByDaemonId(ctx, pane_id)) |result| {
-                            // Atomic swap: shadow engine (with fully
-                            // replayed state) replaces the live engine in
-                            // one step.  Mark all rows dirty and force a
-                            // full redraw so the renderer lands on the new
-                            // frame on its very next tick — single clean
-                            // transition, no intermediate states visible.
-                            if (result.pane.shadow_engine) |shadow| {
-                                var old_engine = result.pane.engine;
-                                result.pane.engine = shadow;
-                                result.pane.shadow_engine = null;
-                                old_engine.deinit();
-                                result.pane.needs_engine_reinit = false;
-                                result.pane.engine.state.dirty.markAll(result.pane.engine.state.ring.screen_rows);
-                                if (result.tab_idx == ctx.tab_mgr.active) {
-                                    got_data = true;
-                                    actions.g_force_full_redraw = true;
-                                }
-                            }
-                            // Windows still col-nudges to force repaint;
-                            // restore dims here.  POSIX uses SIGWINCH at
-                            // current dims so no restore needed.
-                            if (@import("builtin").os.tag == .windows) {
-                                const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);
-                                const cols: u16 = @intCast(result.pane.engine.state.ring.cols);
-                                if (ctx.session_client) |scc| {
-                                    scc.sendPaneResize(pane_id, rows, cols) catch {};
-                                }
-                            }
+                        if (handleReplayEnd(ctx, pane_id)) {
+                            got_data = true;
+                            actions.g_force_full_redraw = true;
                         }
                     },
                     .layout_sync => |sync| {
@@ -1922,15 +1896,47 @@ fn applyScrollbackChunk(ctx: *PtyThreadCtx, payload: []const u8) u16 {
     return applied;
 }
 
+/// Finalize a scrollback replay for `pane_id`: atomically swap the fully
+/// replayed shadow engine into the live slot, clear the reinit flag, and mark
+/// the new frame dirty.  Returns true when the swapped pane is on the active
+/// tab (caller should force a redraw).  Shared by the main event loop and the
+/// pre-resize drain so a `replay_end` that lands during a resize isn't lost —
+/// dropping it would strand the pane in `needs_engine_reinit`, routing all
+/// future output into the shadow engine and leaving the live pane blank.
+pub fn handleReplayEnd(ctx: *PtyThreadCtx, pane_id: u32) bool {
+    const result = findPaneByDaemonId(ctx, pane_id) orelse return false;
+    var on_active = false;
+    if (result.pane.shadow_engine) |shadow| {
+        var old_engine = result.pane.engine;
+        result.pane.engine = shadow;
+        result.pane.shadow_engine = null;
+        old_engine.deinit();
+        result.pane.needs_engine_reinit = false;
+        result.pane.engine.state.dirty.markAll(result.pane.engine.state.ring.screen_rows);
+        on_active = (result.tab_idx == ctx.tab_mgr.active);
+    }
+    // Windows still col-nudges to force repaint; restore dims here.  POSIX
+    // uses SIGWINCH at current dims so no restore needed.
+    if (@import("builtin").os.tag == .windows) {
+        const rows: u16 = @intCast(result.pane.engine.state.ring.screen_rows);
+        const cols: u16 = @intCast(result.pane.engine.state.ring.cols);
+        if (ctx.session_client) |scc| {
+            scc.sendPaneResize(pane_id, rows, cols) catch {};
+        }
+    }
+    return on_active;
+}
+
 /// Apply a daemon → client "content" message (cells, scrollback, title,
 /// cwd, proc name, byte-stream output) to the appropriate pane. Returns
 /// true if the message was a content message (handled) — false for
 /// loop-control messages (pane_died, replay_end, layout_sync) which
 /// the caller must handle itself.
 ///
-/// Shared between the startup drain loop and the main event loop so
-/// metadata messages that arrive during startup don't get dropped.
-fn applyDaemonContentMessage(ctx: *PtyThreadCtx, msg: @import("../session_client.zig").DaemonMessage) bool {
+/// Shared between the startup drain loop, the main event loop, and the
+/// pre-resize drain so metadata messages that arrive during those windows
+/// don't get dropped.
+pub fn applyDaemonContentMessage(ctx: *PtyThreadCtx, msg: @import("../session_client.zig").DaemonMessage) bool {
     switch (msg) {
         .pane_output => |out| {
             if (findPaneByDaemonId(ctx, out.pane_id)) |result| {

--- a/src/app/ui/resize.zig
+++ b/src/app/ui/resize.zig
@@ -9,6 +9,9 @@ const PtyThreadCtx = terminal.PtyThreadCtx;
 const c = terminal.c;
 const publish = @import("publish.zig");
 const actions = @import("actions.zig");
+const event_loop = @import("event_loop.zig");
+const session_actions = @import("session_actions.zig");
+const SessionClient = @import("../session_client.zig").SessionClient;
 const ai = @import("ai.zig");
 const toast = attyx.overlay_toast;
 const session_picker_ui = @import("session_picker_ui.zig");
@@ -39,26 +42,12 @@ pub fn handleResize(ctx: *PtyThreadCtx, buf: []u8) void {
     const pty_cols: u16 = @intCast(pty_cols_i);
     const left_off_u16: u16 = @intCast(@max(0, terminal.g_grid_left_offset));
 
-    // Drain in-flight daemon data at the OLD grid size for the active
-    // pane BEFORE resizing.  Old-size output must be processed
-    // against old dimensions to avoid cursor/wrapping corruption.
+    // Drain in-flight daemon data at the OLD grid size BEFORE resizing.
+    // Old-size output must be processed against old dimensions to avoid
+    // cursor/wrapping corruption.
     if (ctx.session_client) |sc| {
         _ = sc.recvData();
-        while (sc.readMessage()) |msg| {
-            switch (msg) {
-                .pane_output => |out| {
-                    const rpane = ctx.tab_mgr.activePane();
-                    if (rpane.daemon_pane_id) |dpid| {
-                        if (dpid == out.pane_id) {
-                            ctx.session.appendOutput(out.data);
-                            rpane.engine.feed(out.data);
-                            _ = rpane.engine.state.drainResponse();
-                        }
-                    }
-                },
-                else => {},
-            }
-        }
+        drainPreResize(ctx, sc);
     }
 
     ctx.tab_mgr.resizeAll(pty_rows, pty_cols);
@@ -161,3 +150,33 @@ pub fn handleResize(ctx: *PtyThreadCtx, buf: []u8) void {
     publish.publishState(ctx);
     c.g_viewport_offset = @intCast(publish.ctxEngine(ctx).state.viewport_offset);
 }
+
+/// Drain all buffered daemon messages before a resize, routing each through the
+/// same handling as the main event loop.
+///
+/// Every message in the socket buffer is consumed (`readMessage` is
+/// destructive), so anything not handled here is lost.  The previous version
+/// only acted on `pane_output` and dropped the rest — a focus-reply
+/// `grid_snapshot` (the only thing that fills a freshly-switched session's
+/// empty engine) or a `replay_end` (which swaps the shadow engine in and
+/// clears `needs_engine_reinit`) that happened to land during a resize was
+/// silently discarded, stranding the pane blank.  Resizes fire constantly
+/// during a session switch (WM retile, the switch nudging geometry), so this
+/// was the cause of the "switch + resize → blank screen" bug.
+pub fn drainPreResize(ctx: *PtyThreadCtx, sc: *SessionClient) void {
+    while (sc.readMessage()) |msg| {
+        // Content messages (pane_output → shadow when reinitializing,
+        // grid_snapshot, scrollback, title/cwd/etc.) apply to the pane.
+        if (event_loop.applyDaemonContentMessage(ctx, msg)) continue;
+        // Loop-control messages the helper doesn't own.
+        switch (msg) {
+            .replay_end => |pane_id| _ = event_loop.handleReplayEnd(ctx, pane_id),
+            .layout_sync => |sync| session_actions.handleLayoutSync(ctx, sync.layout),
+            else => {},
+        }
+    }
+}
+
+// Tests live in resize_test.zig. The resize↔event_loop import cycle keeps the
+// usual in-file `test { _ = @import(...) }` from being collected, so the test
+// file is aggregated from main.zig's test block instead.

--- a/src/app/ui/resize_test.zig
+++ b/src/app/ui/resize_test.zig
@@ -1,0 +1,137 @@
+// Attyx — pre-resize drain tests.
+//
+// Regression coverage for the "switch session + resize → blank screen" bug.
+// Before resizing, handleResize drains every buffered daemon message via
+// SessionClient.readMessage (which is destructive). The old drain only acted
+// on pane_output and dropped everything else, so a focus-reply grid_snapshot
+// (the only thing that fills a freshly-switched session's empty engine) or a
+// replay_end (which swaps the shadow engine in and clears needs_engine_reinit)
+// that landed during a resize was silently discarded — leaving the pane blank.
+// drainPreResize now routes each message through the same path as the main
+// event loop. These tests drive buffered messages through it and assert the
+// pane ends up populated, not stranded.
+
+const std = @import("std");
+const testing = std.testing;
+
+const resize = @import("resize.zig");
+const terminal = @import("../terminal.zig");
+const PtyThreadCtx = terminal.PtyThreadCtx;
+
+const TabManager = @import("../tab_manager.zig").TabManager;
+const SplitLayout = @import("../split_layout.zig").SplitLayout;
+const Pane = @import("../pane.zig").Pane;
+const SessionClient = @import("../session_client.zig").SessionClient;
+const protocol = @import("../daemon/protocol.zig");
+const grid_sync = @import("../daemon/grid_sync.zig");
+
+const attyx = @import("attyx");
+const Engine = attyx.Engine;
+const Cell = attyx.Cell;
+
+const scrollback = attyx.RingBuffer.default_max_scrollback;
+
+/// Build a single-tab TabManager around one daemon-backed pane.
+fn makeManager(allocator: std.mem.Allocator, daemon_pane_id: u32, rows: u16, cols: u16) !TabManager {
+    const pane = try allocator.create(Pane);
+    pane.* = try Pane.initDaemonBacked(allocator, rows, cols, scrollback);
+    pane.daemon_pane_id = daemon_pane_id;
+    return TabManager.init(allocator, pane);
+}
+
+/// Minimal ctx: drainPreResize only reaches ctx.tab_mgr (via findPaneByDaemonId)
+/// for the message kinds exercised here. The remaining fields are left
+/// undefined deliberately — touching them would be a bug in the code under test.
+fn makeCtx(tab_mgr: *TabManager) PtyThreadCtx {
+    var ctx: PtyThreadCtx = undefined;
+    ctx.tab_mgr = tab_mgr;
+    ctx.session_client = null;
+    ctx.applied_scrollback_lines = scrollback;
+    return ctx;
+}
+
+fn injectMessage(sc: *SessionClient, msg: []const u8) void {
+    @memcpy(sc.read_buf[sc.read_len..][0..msg.len], msg);
+    sc.read_len += msg.len;
+}
+
+test "drainPreResize finalizes a buffered replay_end (shadow swaps in, reinit clears)" {
+    const allocator = testing.allocator;
+
+    var tab_mgr = try makeManager(allocator, 42, 24, 80);
+    defer tab_mgr.reset();
+    const pane = tab_mgr.activePane();
+
+    // Mid-reinit state: live engine is blank, replay bytes have accumulated in
+    // a shadow engine, and we're waiting on replay_end to swap it in.
+    pane.needs_engine_reinit = true;
+    pane.shadow_engine = try Engine.init(allocator, 24, 80, scrollback);
+    pane.shadow_engine.?.feed("HELLO");
+
+    // Sanity: the visible engine has nothing yet.
+    try testing.expectEqual(@as(u21, ' '), pane.engine.state.ring.getScreenCell(0, 0).char);
+
+    var sc = SessionClient{ .allocator = allocator };
+    var framed: [64]u8 = undefined;
+    var payload: [4]u8 = undefined;
+    std.mem.writeInt(u32, &payload, 42, .little);
+    const msg = try protocol.encodeMessage(&framed, .replay_end, &payload);
+    injectMessage(&sc, msg);
+
+    var ctx = makeCtx(&tab_mgr);
+    resize.drainPreResize(&ctx, &sc);
+
+    // The replay_end was applied, not dropped: shadow swapped into the live
+    // engine and the reinit flag cleared, so future output renders live.
+    try testing.expect(!pane.needs_engine_reinit);
+    try testing.expect(pane.shadow_engine == null);
+    try testing.expectEqual(@as(u21, 'H'), pane.engine.state.ring.getScreenCell(0, 0).char);
+    try testing.expectEqual(@as(u21, 'E'), pane.engine.state.ring.getScreenCell(0, 1).char);
+}
+
+test "drainPreResize applies a buffered grid_snapshot (fills the live engine)" {
+    const allocator = testing.allocator;
+
+    const rows: u16 = 2;
+    const cols: u16 = 4;
+    var tab_mgr = try makeManager(allocator, 7, rows, cols);
+    defer tab_mgr.reset();
+    const pane = tab_mgr.activePane();
+
+    // Build a full-grid snapshot for pane 7: row 0 = "HI", rest blank.
+    const cell_count: usize = @as(usize, rows) * @as(usize, cols);
+    const payload_len = grid_sync.snapshot_header_size + cell_count * @sizeOf(grid_sync.PackedCell);
+    var payload: [256]u8 = undefined;
+    _ = try grid_sync.encodeSnapshotHeader(&payload, .{
+        .pane_id = 7,
+        .generation = 1,
+        .rows = rows,
+        .cols = cols,
+        .cursor_row = 0,
+        .cursor_col = 2,
+        .cursor_visible = true,
+        .cursor_shape = 0,
+        .alt_active = false,
+        .start_row = 0,
+        .row_count = rows,
+        .final_chunk = true,
+        .scrollback_delta = 0,
+    });
+    const cell_bytes = payload[grid_sync.snapshot_header_size..payload_len];
+    const chars = [_]u21{ 'H', 'I', ' ', ' ', ' ', ' ', ' ', ' ' };
+    for (0..cell_count) |i| {
+        grid_sync.writePackedCell(cell_bytes, i, grid_sync.packCell(Cell{ .char = chars[i] }));
+    }
+
+    var sc = SessionClient{ .allocator = allocator };
+    var framed: [512]u8 = undefined;
+    const msg = try protocol.encodeMessage(&framed, .grid_snapshot, payload[0..payload_len]);
+    injectMessage(&sc, msg);
+
+    var ctx = makeCtx(&tab_mgr);
+    resize.drainPreResize(&ctx, &sc);
+
+    // The snapshot was applied, not dropped: the pane is no longer blank.
+    try testing.expectEqual(@as(u21, 'H'), pane.engine.state.ring.getScreenCell(0, 0).char);
+    try testing.expectEqual(@as(u21, 'I'), pane.engine.state.ring.getScreenCell(0, 1).char);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -339,6 +339,9 @@ test {
     _ = @import("ipc/client.zig");
     if (!is_windows) {
         _ = @import("app/daemon/session_test.zig");
+        // resize.zig forms an import cycle with event_loop.zig, which keeps its
+        // in-file `test {}` from being collected; aggregate it here instead.
+        _ = @import("app/ui/resize_test.zig");
     }
 }
 


### PR DESCRIPTION
## Problem

Switching sessions and resizing the window often blanked the screen, sometimes permanently.

Before resizing, `handleResize` drains the daemon socket so old-size output is processed against old dimensions. But the drain only acted on `pane_output` and sent every other buffered message to `else => {}`, silently discarding it. `readMessage` is destructive, so anything dropped there is gone.

When a resize lands during a session switch — which happens constantly (WM retile, the switch itself nudging geometry) — the focus-reply that populates the new session's freshly-rebuilt (empty) panes is exactly what gets eaten:

- **grid-sync mode:** the forced `grid_snapshot` is the only thing that fills the new empty engine. Dropped → the pane stays blank until it next emits PTY output (an idle shell never does), so the blank persists.
- **legacy byte-replay mode:** `replay_end` swaps the populated shadow engine into the live slot and clears `needs_engine_reinit`. Dropped → the flag never clears, so all future output keeps routing into the shadow engine and the live pane is **never updated again** (permanent blank).

## Fix

`drainPreResize` now routes every drained message through the same handling as the main event loop instead of dropping the ones it doesn't recognize:

- content (`pane_output` → shadow when reinitializing, `grid_snapshot`, scrollback, title/cwd/etc.) via the now-shared `applyDaemonContentMessage`
- `replay_end` via a new shared `handleReplayEnd` (the shadow→live swap, extracted from the main loop so both paths stay in lockstep)
- `layout_sync` via `handleLayoutSync`

## Tests

Added `resize_test.zig` with two headless cases that buffer a `replay_end` and a `grid_snapshot` behind `drainPreResize` and assert the pane ends up populated (not blank) and `needs_engine_reinit` clears — both fail against the old drop-everything drain.