### PR TITLE
Compose Option-key characters on international layouts

### DIFF
--- a/releases/v0.4.8.md
+++ b/releases/v0.4.8.md
@@ -1,0 +1,17 @@
+# Attyx v0.4.8
+
+## Option-key character composition on international layouts
+
+Typing special characters with the Option (⌥) key now works on non-US
+keyboard layouts. Previously, setting `option_as_alt = false` to compose
+characters produced nothing at all — Option+key combinations never reached the
+terminal.
+
+- **Compose layout characters with Option** — on a Spanish layout, `Option+2 → @`,
+  `Option+ç → }`, `Option++ → ]`, `Option+3 → #`, and similar combinations now
+  type the characters they should. Set `option_as_alt = false` in your config
+  under `[keyboard]` to enable layout composition. (#251)
+
+- **Keep your Alt hotkeys** — `alt+…` keybindings and Option+←/→ word navigation
+  keep working regardless of `option_as_alt`, so you no longer have to choose
+  between composing characters and using your Alt shortcuts.

--- a/src/app/macos_input_keyboard.m
+++ b/src/app/macos_input_keyboard.m
@@ -327,10 +327,8 @@ static void eventToKeyCombo(NSEvent* event, uint16_t* outKey, uint32_t* outCp) {
         return YES;
     }
 
-    // Ctrl+key or Alt+key with a character. When Option does NOT act as Alt
-    // (the default), let the key fall through to interpretKeyEvents so macOS
-    // composes the layout's character (e.g. Option+ñ → ~) instead of emitting
-    // an ESC-prefixed Meta sequence.
+    // Ctrl+key or Alt+key with a character: emit the base character so the
+    // encoder can control-map it or prefix it with ESC (Meta).
     if (ctrl || optionActsAsAlt(flags)) {
         NSString* chars = event.charactersIgnoringModifiers;
         if (chars.length > 0) {
@@ -339,6 +337,32 @@ static void eventToKeyCombo(NSEvent* event, uint16_t* outKey, uint32_t* outCp) {
             return YES;
         }
         if (ctrl) return YES;
+    }
+
+    // Option held but NOT acting as Alt: macOS has already composed the layout
+    // character (Option+2 → @, Option+ç → }, … on a Spanish layout). Send the
+    // composed `characters` straight to the PTY. Relying on interpretKeyEvents
+    // here proved unreliable — Option-modified keys produced no insertText: at
+    // all, so nothing reached the terminal. Dead keys (e.g. the tilde on
+    // Option+ñ) report empty `characters`; fall through to interpretKeyEvents so
+    // their marked-text composition still works. Skip when an overlay consumer
+    // (search bar, AI prompt, pickers) is active — those receive text via
+    // insertText: and must not have it diverted to the PTY.
+    if ((flags & NSEventModifierFlagOption) && !cmd && !optionActsAsAlt(flags) &&
+        !g_search_active && !g_ai_prompt_active &&
+        !g_session_picker_active && !g_command_palette_active &&
+        !g_theme_picker_active && !g_tab_picker_active) {
+        NSString* composed = event.characters;
+        NSUInteger blen = [composed lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+        if (blen > 0) {
+            const char* utf8 = [composed UTF8String];
+            if (utf8) {
+                void (*send_fn)(const uint8_t*, int) =
+                    g_popup_active ? attyx_popup_send_input : attyx_send_input;
+                send_fn((const uint8_t*)utf8, (int)blen);
+                return YES;
+            }
+        }
     }
 
     return NO;

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -121,6 +121,16 @@ pub const OptionAsAlt = enum {
             .right => 3,
         };
     }
+
+    /// Render as the canonical config value (for --print-config).
+    pub fn toString(self: OptionAsAlt) []const u8 {
+        return switch (self) {
+            .none => "false",
+            .both => "true",
+            .left => "\"left\"",
+            .right => "\"right\"",
+        };
+    }
 };
 
 const keybinds = @import("keybinds.zig");
@@ -378,6 +388,9 @@ pub const AppConfig = struct {
             \\shape = "{s}"
             \\blink = {s}
             \\
+            \\[keyboard]
+            \\option_as_alt = {s}
+            \\
             \\[program]
             \\shell = "{s}"
             \\
@@ -392,6 +405,7 @@ pub const AppConfig = struct {
             if (self.reflow_enabled) "true" else "false",
             self.cursor_shape.toString(),
             if (self.cursor_blink) "true" else "false",
+            self.option_as_alt.toString(),
             self.program orelse if (comptime @import("builtin").os.tag == .windows) "cmd.exe" else (std.posix.getenv("SHELL") orelse "/bin/sh"),
         });
     }

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -147,7 +147,8 @@
 #           accented characters aren't typing correctly.
 # - "left"  Only the left Option key acts as Alt; the right one composes.
 # - "right" Only the right Option key acts as Alt; the left one composes.
-# Arrow-key word navigation (Option+←/→) works regardless of this setting.
+# Arrow-key word navigation (Option+←/→) and `alt+…` keybindings work
+# regardless of this setting, so you can keep your Alt hotkeys with false.
 # option_as_alt = true
 
 


### PR DESCRIPTION
Fixes #251.

On non-US keyboard layouts, setting `option_as_alt = false` to compose characters produced **nothing** — Option-modified keys fell through to `interpretKeyEvents:`, which never delivered `insertText:` for them, so no character reached the terminal.

This reads the macOS-composed `event.characters` directly and sends it to the PTY. On a Spanish layout: `Option+2 → @`, `Option+ç → }`, `Option++ → ]`, `Option+3 → #`, etc. Dead keys (which report empty `characters`) still fall through to `interpretKeyEvents:` for marked-text composition, and active overlays (search bar, AI prompt, pickers) are skipped so their input isn't diverted to the PTY.

`alt+…` keybindings are matched before this path and are independent of `option_as_alt`, so Alt hotkeys keep working alongside composition — you no longer have to choose between the two.

## Testing needed on a Spanish hardware layout

Please verify in this build:

- [ ] `Option+2 / 3 / ç / +` produce `@ # } ]`
- [ ] `Option+ñ → ~` — if `~` is a dead key on Spanish-ISO, expect a marked `~` that finalizes on the next keypress/space (same as Terminal.app). If it produces **nothing**, the dead key needs explicit `UCKeyTranslate` resolution — flag it.
- [ ] Existing `alt+…` hotkeys still fire with `option_as_alt = false`