### PR TITLE
Expose agent status over IPC/CLI and fix status-detection gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ installer/.zig-cache/
 *.app
 worktrees
 tasks
+/graphify-out

--- a/skills/claude/attyx/SKILL.md
+++ b/skills/claude/attyx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attyx
-description: Control the Attyx terminal via IPC — manage splits, send input, read output, orchestrate panes. Use when the user asks to interact with terminal panes, run commands in splits, or coordinate multi-pane workflows.
+description: Control the Attyx terminal via IPC — manage splits, send input, read output, track and watch agent status, orchestrate panes. Use when the user asks to interact with terminal panes, run commands in splits, monitor AI agents running in panes, or coordinate multi-pane workflows.
 allowed-tools: Bash
 argument-hint: [action] [args...]
 ---
@@ -269,6 +269,72 @@ Without `--pane`, `send-keys` and `get-text` operate on the focused pane:
 2. Do your `send-keys` / `get-text`
 3. Focus back if needed
 
+## Tracking Agents — Status & Watching
+
+Attyx tracks the run state of AI agents (Claude Code, Codex, etc.) running inside panes. An agent reports one of four states:
+
+| State | Meaning |
+|-------|---------|
+| `idle` | Parked, waiting for the next prompt |
+| `working` | Actively processing a request |
+| `input` | Blocked on you (a permission prompt or question) |
+| `none` | No agent running, or the agent's session ended |
+
+### Listing active agents — `list agents`
+`attyx list agents` lists every pane currently running an agent (any state except `none`). Use `--json` for a machine-readable array:
+
+```bash
+attyx list agents
+# pane_id  tab_id  session  pid    state    message
+# 3        3       1        48213  working  Editing parser.zig
+# 8        7       1        48455  input    Approve running tests?
+
+attyx list agents --json
+# [{"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"working","message":"Editing parser.zig"},
+#  {"pane_id":8,"tab_id":7,"session":1,"pid":48455,"state":"input","message":"Approve running tests?"}]
+```
+
+Fields: `pane_id` (stable ID of the agent's pane — use for targeting), `tab_id` (stable ID of the agent's tab; in attyx a tab is identified by its focused pane's id — the same `pane:N` shown by `attyx list` — so for a single-pane tab `tab_id == pane_id`), `session`, `pid` (the agent's foreground process id; `0` when unknown, e.g. daemon-backed panes), `state`, and `message` (the agent's latest status preview, may be empty). Scope is the current instance's panes. For per-session counts across **all** daemon sessions, use `attyx list sessions`.
+
+### Watching for changes — `watch agents`
+`attyx watch agents` opens a long-lived stream and prints one JSON object per line (NDJSON) every time an agent's status changes. On connect it first emits a snapshot of the current active agents, then live changes. It blocks until interrupted — pipe it or run it in the background:
+
+```bash
+attyx watch agents
+# {"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"working","message":"..."}
+# {"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"input","message":"Needs your input"}
+# {"pane_id":8,"tab_id":7,"session":1,"pid":48455,"state":"idle","message":""}
+
+# React to agents that need attention
+attyx watch agents | while read -r line; do
+  echo "$line" | grep -q '"state":"input"' && notify-send "Agent needs input"
+done
+```
+
+Unlike `list agents`, the watch stream **includes** transitions to `state:"none"` so you can tell when an agent's session ends. Use `watch agents` instead of polling `list agents` in a loop — it's push-based and won't miss fast transitions.
+
+### Watching a single agent — `--pane` / `-p`
+To follow just one agent instead of all of them, pass its stable pane ID with `-p`. The snapshot and the live stream are both filtered to that pane:
+```bash
+attyx watch agents -p 3             # only pane 3's agent
+# {"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"working","message":"..."}
+# {"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"idle","message":""}
+
+# Block until a specific agent finishes its current turn
+attyx watch agents -p 3 | while read -r line; do
+  echo "$line" | grep -q '"state":"idle"' && break
+done
+```
+The pane ID is the `pane_id` from `attyx list agents` (or the ID returned when you created the pane). `0`/omitted means all agents.
+
+### Checking a single agent
+To check one pane's agent without streaming, pass its stable pane ID:
+```bash
+attyx list agents -p 3              # just pane 3's agent (one line, or empty if none)
+attyx list agents -p 3 --json      # same, as a JSON array
+```
+`-p`/`--pane` works on both `list agents` and `watch agents`; omit it for all agents.
+
 ## Argument Handling
 
 If the user provides arguments, interpret them as a natural language instruction. Remember to always use `-s <session_id>` (discovered via `attyx list` at start):
@@ -279,5 +345,8 @@ If the user provides arguments, interpret them as a natural language instruction
 - `/attyx create a background session for ~/Projects/api` → `attyx session create ~/Projects/api -b`
 - `/attyx list sessions` → `attyx session list`
 - `/attyx create a tab in session 5` → `attyx -s 5 tab create`
+- `/attyx which agents are running` → `attyx list agents`
+- `/attyx tell me when an agent needs input` → `attyx watch agents` (filter for `"state":"input"`)
+- `/attyx watch the agent in pane 3` → `attyx watch agents -p 3`
 
 If no arguments, ask the user what they'd like to do with the terminal.

--- a/src/app/agent_integration.zig
+++ b/src/app/agent_integration.zig
@@ -47,10 +47,12 @@ const claude_events = [_]EventSpec{
     .{ .name = "SessionEnd", .matcher = null, .state = "none" },
 };
 
-/// Codex hooks (~/.codex/hooks.json) — same JSON shape as Claude. Codex has no
+/// Codex hooks (~/.codex/hooks.json) — same JSON shape and event names as
+/// Claude (SessionStart fires on launch/resume/clear/compact). Codex has no
 /// Notification or SessionEnd events, so there's no idle-prompt or clear-on-exit
-/// signal; the dot rests at idle after a turn.
+/// signal; the dot registers idle on launch and rests at idle after a turn.
 const codex_events = [_]EventSpec{
+    .{ .name = "SessionStart", .matcher = null, .state = "idle" },
     .{ .name = "UserPromptSubmit", .matcher = null, .state = "working" },
     .{ .name = "PreToolUse", .matcher = null, .state = "working" },
     .{ .name = "PermissionRequest", .matcher = null, .state = "input" },
@@ -359,11 +361,14 @@ const emitter_script =
     \\
 ;
 
-/// opencode plugin. `{s}` is the absolute emitter path. opencode has no clean
-/// "turn started" event, so working is derived from tool.execute.before and
-/// assistant message updates; session.idle → idle; permission.asked → input.
-/// Runs the emitter via Node's child_process (env, incl. ATTYX_PID/ATTYX_TTY,
-/// is inherited, so the emitter self-gates and targets the pane tty).
+/// opencode plugin. `{s}` is the absolute emitter path. The plugin-init body
+/// runs once when opencode launches (env, incl. ATTYX_PID/ATTYX_TTY, is
+/// inherited), so we emit idle there to register the agent on launch — the
+/// reliable startup signal, since session.created delivery to plugins is racy.
+/// Thereafter: working is derived from tool.execute.before and assistant
+/// message updates; session.idle → idle; permission.asked → input. Runs the
+/// emitter via Node's child_process so the emitter self-gates and targets the
+/// pane tty.
 const opencode_plugin_fmt =
     \\// Attyx agent status plugin — reports opencode's run state to the
     \\// terminal via the attyx emitter. No-op outside attyx (emitter self-gates).
@@ -373,10 +378,16 @@ const opencode_plugin_fmt =
     \\  try {{ spawnSync(EMIT, [state], {{ stdio: "ignore" }}); }} catch (e) {{}}
     \\}}
     \\const AttyxStatus = async (ctx) => {{
+    \\  // Runs once at opencode launch — register the agent as present-and-idle
+    \\  // immediately, instead of waiting for the first activity event.
+    \\  emit("idle");
     \\  return {{
     \\    event: async ({{ event }}) => {{
     \\      const props = (event && event.properties) || {{}};
     \\      switch (event && event.type) {{
+    \\        case "session.created":
+    \\          emit("idle");
+    \\          break;
     \\        case "tool.execute.before":
     \\          emit("working");
     \\          break;
@@ -512,10 +523,11 @@ test "codex events cover working, input, and idle" {
     var parsed = try std.json.parseFromSlice(std.json.Value, a, "{}", .{});
     try mergeHooks(a, &parsed.value.object, "/E/attyx-agent-status", &codex_events);
     const out = try std.json.Stringify.valueAlloc(a, parsed.value, .{ .whitespace = .indent_2 });
-    for ([_][]const u8{ "UserPromptSubmit", "PreToolUse", "PermissionRequest", "Stop" }) |ev|
+    for ([_][]const u8{ "SessionStart", "UserPromptSubmit", "PreToolUse", "PermissionRequest", "Stop" }) |ev|
         try testing.expect(std.mem.indexOf(u8, out, ev) != null);
     try testing.expect(std.mem.indexOf(u8, out, "Notification") == null); // codex has none
     try testing.expect(std.mem.indexOf(u8, out, "/E/attyx-agent-status input") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "/E/attyx-agent-status idle") != null); // SessionStart/Stop
 }
 
 test "opencode plugin embeds the emitter path and maps key events" {
@@ -527,6 +539,9 @@ test "opencode plugin embeds the emitter path and maps key events" {
     try testing.expect(std.mem.indexOf(u8, plugin, "permission.asked") != null);
     try testing.expect(std.mem.indexOf(u8, plugin, "session.idle") != null);
     try testing.expect(std.mem.indexOf(u8, plugin, "emit(\"working\")") != null);
+    // Launch detection: emit idle from the init body and on session.created.
+    try testing.expect(std.mem.indexOf(u8, plugin, "emit(\"idle\")") != null);
+    try testing.expect(std.mem.indexOf(u8, plugin, "session.created") != null);
 }
 
 test "install generates the emitter and injects hooks into ~/.claude" {

--- a/src/app/agent_integration.zig
+++ b/src/app/agent_integration.zig
@@ -35,6 +35,10 @@ const EventSpec = struct { name: []const u8, matcher: ?[]const u8, state: []cons
 /// prompt shows normally. Notification's `notify` branch classifies the message
 /// into input vs idle.
 const claude_events = [_]EventSpec{
+    // Fires the instant Claude launches (and on resume/clear/compact), so the
+    // agent registers as idle immediately instead of staying invisible until the
+    // first prompt. Without this, no OSC is emitted until UserPromptSubmit/Stop.
+    .{ .name = "SessionStart", .matcher = null, .state = "idle" },
     .{ .name = "UserPromptSubmit", .matcher = null, .state = "working" },
     .{ .name = "PreToolUse", .matcher = "*", .state = "working" },
     .{ .name = "PermissionRequest", .matcher = null, .state = "input" },
@@ -226,13 +230,40 @@ fn groupIsAttyx(group: std.json.Value) bool {
     return false;
 }
 
-/// True when the file already contains every command we'd inject.
+/// True when the file already has our exact command under EVERY event.
+///
+/// This must check per-event, not via a global substring scan: several events
+/// share a command string (SessionStart and Stop both emit `… idle`), so a
+/// plain `indexOf` would report SessionStart as already present whenever Stop is
+/// — and a newly-added event would never be injected on upgrade. We parse and
+/// verify each event's array actually contains the command.
 fn hasAllCommands(a: std.mem.Allocator, content: []const u8, emitter_path: []const u8, events: []const EventSpec) bool {
+    var parsed = std.json.parseFromSlice(std.json.Value, a, content, .{}) catch return false;
+    if (parsed.value != .object) return false;
+    const hooks_v = parsed.value.object.get("hooks") orelse return false;
+    if (hooks_v != .object) return false;
     for (events) |ev| {
+        const arr_v = hooks_v.object.get(ev.name) orelse return false;
+        if (arr_v != .array) return false;
         const command = std.fmt.allocPrint(a, "{s} {s}", .{ emitter_path, ev.state }) catch return false;
-        if (std.mem.indexOf(u8, content, command) == null) return false;
+        if (!eventHasCommand(arr_v.array, command)) return false;
     }
     return true;
+}
+
+/// True when any hook group in `groups` carries the exact command string.
+fn eventHasCommand(groups: std.json.Array, command: []const u8) bool {
+    for (groups.items) |group| {
+        if (group != .object) continue;
+        const ghooks = group.object.get("hooks") orelse continue;
+        if (ghooks != .array) continue;
+        for (ghooks.array.items) |h| {
+            if (h != .object) continue;
+            const cmd = h.object.get("command") orelse continue;
+            if (cmd == .string and std.mem.eql(u8, cmd.string, command)) return true;
+        }
+    }
+    return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -388,16 +419,17 @@ fn mergeToString(a: std.mem.Allocator, input: []const u8, emitter: []const u8) !
     return std.json.Stringify.valueAlloc(a, root.*, .{ .whitespace = .indent_2 });
 }
 
-test "merge into empty settings injects all five hooks" {
+test "merge into empty settings injects all lifecycle hooks" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
     const out = try mergeToString(a, "{}", "/E/attyx-agent-status");
-    for ([_][]const u8{ "UserPromptSubmit", "PreToolUse", "PermissionRequest", "Notification", "Stop", "SessionEnd" }) |ev|
+    for ([_][]const u8{ "SessionStart", "UserPromptSubmit", "PreToolUse", "PermissionRequest", "Notification", "Stop", "SessionEnd" }) |ev|
         try testing.expect(std.mem.indexOf(u8, out, ev) != null);
     try testing.expect(std.mem.indexOf(u8, out, "/E/attyx-agent-status working") != null);
     try testing.expect(std.mem.indexOf(u8, out, "/E/attyx-agent-status notify") != null);
     try testing.expect(std.mem.indexOf(u8, out, "/E/attyx-agent-status input") != null); // PermissionRequest
+    try testing.expect(std.mem.indexOf(u8, out, "/E/attyx-agent-status idle") != null); // SessionStart/Stop
 }
 
 test "merge preserves unrelated settings and existing user hooks" {
@@ -447,6 +479,25 @@ test "hasAllCommands detects a fully-injected file" {
     const out = try mergeToString(a, "{}", "/E/attyx-agent-status");
     try testing.expect(hasAllCommands(a, out, "/E/attyx-agent-status", &claude_events));
     try testing.expect(!hasAllCommands(a, "{}", "/E/attyx-agent-status", &claude_events));
+}
+
+test "hasAllCommands requires the SessionStart event, not just the shared idle command" {
+    // Pre-upgrade file: has Stop (which emits the same `… idle` command) but no
+    // SessionStart. A substring scan would wrongly call this fully-injected and
+    // skip the merge, so SessionStart would never appear — the launch-detection
+    // regression. hasAllCommands must return false here.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const pre_upgrade =
+        \\{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "/E/attyx-agent-status idle" } ] } ] } }
+    ;
+    try testing.expect(!hasAllCommands(a, pre_upgrade, "/E/attyx-agent-status", &claude_events));
+
+    // After a merge, the SessionStart event is present and the check passes.
+    const merged = try mergeToString(a, pre_upgrade, "/E/attyx-agent-status");
+    try testing.expect(hasAllCommands(a, merged, "/E/attyx-agent-status", &claude_events));
+    try testing.expect(std.mem.indexOf(u8, merged, "SessionStart") != null);
 }
 
 test "emitter script self-gates on ATTYX_PID and emits the OSC" {

--- a/src/app/agent_integration.zig
+++ b/src/app/agent_integration.zig
@@ -366,7 +366,9 @@ const emitter_script =
 /// inherited), so we emit idle there to register the agent on launch — the
 /// reliable startup signal, since session.created delivery to plugins is racy.
 /// Thereafter: working is derived from tool.execute.before and assistant
-/// message updates; session.idle → idle; permission.asked → input. Runs the
+/// message updates; session.idle → idle; permission.asked → input and
+/// permission.replied → working (the native resolution signal, so the prompt
+/// state clears even without a keystroke for attyx to infer from). Runs the
 /// emitter via Node's child_process so the emitter self-gates and targets the
 /// pane tty.
 const opencode_plugin_fmt =
@@ -396,6 +398,9 @@ const opencode_plugin_fmt =
     \\          break;
     \\        case "permission.asked":
     \\          emit("input");
+    \\          break;
+    \\        case "permission.replied":
+    \\          emit("working");
     \\          break;
     \\        case "session.idle":
     \\          emit("idle");
@@ -537,6 +542,7 @@ test "opencode plugin embeds the emitter path and maps key events" {
     const plugin = try std.fmt.allocPrint(a, opencode_plugin_fmt, .{"/E/attyx-agent-status"});
     try testing.expect(std.mem.indexOf(u8, plugin, "const EMIT = \"/E/attyx-agent-status\"") != null);
     try testing.expect(std.mem.indexOf(u8, plugin, "permission.asked") != null);
+    try testing.expect(std.mem.indexOf(u8, plugin, "permission.replied") != null);
     try testing.expect(std.mem.indexOf(u8, plugin, "session.idle") != null);
     try testing.expect(std.mem.indexOf(u8, plugin, "emit(\"working\")") != null);
     // Launch detection: emit idle from the init body and on session.created.

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -467,6 +467,11 @@ fn handlePaneInput(
     const msg = protocol.decodePaneInput(payload) catch return;
     const session = getAttachedSession(cl, sessions) orelse return;
     if (session.findPane(msg.pane_id)) |pane| {
+        // Agent harnesses emit no hook on interrupt or when an input prompt is
+        // answered, so infer those status transitions from the input bytes. The
+        // main loop ships the change to every attached client via
+        // pane_agent_status.
+        if (pane.engine) |eng| eng.state.applyAgentInputTransition(msg.bytes);
         pane.writeInput(msg.bytes) catch {};
     }
 }

--- a/src/app/ui/event_loop.zig
+++ b/src/app/ui/event_loop.zig
@@ -32,6 +32,7 @@ const selection = @import("selection.zig");
 const toast = attyx.overlay_toast;
 const ipc_queue = @import("../../ipc/queue.zig");
 const ipc_handler = @import("../../ipc/handler.zig");
+const ipc_watch = @import("../../ipc/watch.zig");
 const grid_sync = @import("../daemon/grid_sync.zig");
 
 /// Re-export from actions module for external access.
@@ -1185,6 +1186,7 @@ pub fn ptyReaderThread(ctx: *PtyThreadCtx) void {
                         leaf.pane.engine.state.agent_status_changed = false;
                         title_changed = true;
                         maybeNotifyAgent(ctx, leaf.pane, ti);
+                        ipc_watch.broadcastAgent(ctx, leaf.pane, lay.focusedPane().ipc_id);
                     }
                 }
             }

--- a/src/app/ui/input.zig
+++ b/src/app/ui/input.zig
@@ -575,12 +575,17 @@ pub fn handleKey(key_raw: u16, mods_raw: u8, event_type_raw: u8, codepoint_raw: 
     );
 
     if (encoded.len > 0) {
-        // Session mode: route through daemon to active pane
+        // Session mode: route through daemon to active pane. The daemon owns the
+        // authoritative engine, so interrupt→idle is handled daemon-side (it also
+        // broadcasts the change to every attached client).
         if (terminal.g_session_client) |sc| {
             sc.sendPaneInput(terminal.g_active_daemon_pane_id, encoded) catch {};
             return;
         }
         if (terminal.g_pty_master >= 0) {
+            // Agent harnesses emit no hook on interrupt or when an input prompt
+            // is answered, so infer those status transitions from the keystroke.
+            eng.state.applyAgentInputTransition(encoded);
             _ = posix.write(terminal.g_pty_master, encoded) catch {};
         }
     }

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -43,6 +43,8 @@ pub const IpcCommand = enum {
     list,
     list_tabs,
     list_splits,
+    list_agents,
+    watch_agents,
     popup,
     session_list,
     session_create,
@@ -234,6 +236,7 @@ pub fn parse(args: []const [:0]const u8) ?IpcRequest {
         if (std.mem.eql(u8, sub, "scroll-to")) break :blk parseScrollTo(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "popup")) break :blk parsePopup(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "list")) break :blk parseList(fargs, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "watch")) break :blk parseWatch(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "session")) break :blk parseSession(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "run")) {
             if (hasHelp(fargs, start)) showHelp(help.run);
@@ -606,9 +609,52 @@ fn parseList(args: []const [:0]const u8, start: usize, target_pid: ?u32, json_ou
         return .{ .command = .list_tabs, .target_pid = target_pid, .json_output = json_output };
     } else if (std.mem.eql(u8, sub, "splits") or std.mem.eql(u8, sub, "panes")) {
         return .{ .command = .list_splits, .target_pid = target_pid, .json_output = json_output };
+    } else if (std.mem.eql(u8, sub, "agents")) {
+        // Optional --pane/-p <id> restricts the list to one agent's pane.
+        var result = IpcRequest{ .command = .list_agents, .target_pid = target_pid, .json_output = json_output };
+        var i = start + 2;
+        while (i < args.len) {
+            if (std.mem.eql(u8, args[i], "--pane") or std.mem.eql(u8, args[i], "-p")) {
+                if (i + 1 >= args.len) fatal("--pane requires a pane ID");
+                i += 1;
+                parsePaneArg(args[i], &result);
+            }
+            i += 1;
+        }
+        return result;
     }
     std.debug.print("error: unknown list target '{s}'\n\n", .{sub});
     printHelp(help.list);
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Watch
+// ---------------------------------------------------------------------------
+
+fn parseWatch(args: []const [:0]const u8, start: usize, target_pid: ?u32, json_output: bool) ?IpcRequest {
+    if (start + 1 >= args.len or isHelp(args[start + 1])) {
+        if (start + 1 < args.len and isHelp(args[start + 1])) showHelp(help.watch);
+        printHelp(help.watch);
+        return null;
+    }
+    const target = args[start + 1];
+    if (std.mem.eql(u8, target, "agents")) {
+        // Optional --pane/-p <id> restricts the stream to one agent's pane.
+        var result = IpcRequest{ .command = .watch_agents, .target_pid = target_pid, .json_output = json_output };
+        var i = start + 2;
+        while (i < args.len) {
+            if (std.mem.eql(u8, args[i], "--pane") or std.mem.eql(u8, args[i], "-p")) {
+                if (i + 1 >= args.len) fatal("--pane requires a pane ID");
+                i += 1;
+                parsePaneArg(args[i], &result);
+            }
+            i += 1;
+        }
+        return result;
+    }
+    std.debug.print("error: unknown watch target '{s}'\n\n", .{target});
+    printHelp(help.watch);
     return null;
 }
 
@@ -703,4 +749,31 @@ test "tab close parses user numbering to zero-based tab index" {
 
     try std.testing.expectEqual(IpcCommand.tab_close, parsed.command);
     try std.testing.expectEqual(@as(u8, 2), parsed.tab_idx);
+}
+
+test "list agents maps to list_agents and carries --json" {
+    const args = [_][:0]const u8{ "attyx", "list", "agents", "--json" };
+    const parsed = parse(&args).?;
+    try std.testing.expectEqual(IpcCommand.list_agents, parsed.command);
+    try std.testing.expect(parsed.json_output);
+}
+
+test "watch agents maps to watch_agents" {
+    const args = [_][:0]const u8{ "attyx", "watch", "agents" };
+    const parsed = parse(&args).?;
+    try std.testing.expectEqual(IpcCommand.watch_agents, parsed.command);
+}
+
+test "list agents -p sets pane filter" {
+    const args = [_][:0]const u8{ "attyx", "list", "agents", "-p", "3" };
+    const parsed = parse(&args).?;
+    try std.testing.expectEqual(IpcCommand.list_agents, parsed.command);
+    try std.testing.expectEqual(@as(u32, 3), parsed.pane_id);
+}
+
+test "watch agents -p sets pane filter" {
+    const args = [_][:0]const u8{ "attyx", "watch", "agents", "-p", "7" };
+    const parsed = parse(&args).?;
+    try std.testing.expectEqual(IpcCommand.watch_agents, parsed.command);
+    try std.testing.expectEqual(@as(u32, 7), parsed.pane_id);
 }

--- a/src/config/cli_ipc_help.zig
+++ b/src/config/cli_ipc_help.zig
@@ -24,7 +24,8 @@ pub const top_level =
     \\  reload       Reload configuration from disk
     \\  theme        Switch to a named theme
     \\  scroll-to    Scroll the viewport (top, bottom, page-up, page-down)
-    \\  list         Query tabs, panes, and sessions (supports --json)
+    \\  list         Query tabs, panes, sessions, and agents (supports --json)
+    \\  watch        Stream agent status changes as they happen (NDJSON)
     \\  popup        Open a popup terminal overlay
     \\  run          Open a new tab with a command (shorthand for tab create --cmd)
     \\
@@ -45,6 +46,8 @@ pub const top_level =
     \\  attyx get-text                    Read what's on screen
     \\  attyx get-text --pane 5           Read from pane 5
     \\  attyx list --json                 Get structured tab/pane info
+    \\  attyx list agents --json          List panes running an agent
+    \\  attyx watch agents                Stream agent status changes
     \\  attyx reload                      Hot-reload config from disk
     \\
     \\Pane targeting:
@@ -472,6 +475,7 @@ pub const list =
     \\  tabs       List tabs only
     \\  splits     List panes in the active tab
     \\  sessions   List daemon sessions
+    \\  agents     List panes currently running an agent
     \\
     \\Aliases:
     \\  panes      Same as splits
@@ -480,13 +484,56 @@ pub const list =
     \\Active items are marked with * in the third column.
     \\Use --json for structured output that's easier to parse.
     \\
+    \\The 'agents' target lists panes running an agent (state idle/working/
+    \\input). Fields: pane_id, tab_id, session, pid, state, message. tab_id is
+    \\the agent's tab's stable handle (its focused pane's id, the same pane:N
+    \\shown by 'attyx list'); for a single-pane tab it equals pane_id. pid is the
+    \\agent's foreground process id (0 = unknown, e.g. daemon-backed panes). Pass
+    \\--pane/-p <id> to list just one agent's pane. With --json it returns a JSON
+    \\array; otherwise tab-separated rows. Scope is this instance's panes — use
+    \\'list sessions' for per-session counts across all daemon sessions, or
+    \\'watch agents' to stream changes.
+    \\
     \\Examples:
     \\  attyx list                   Full tab/pane tree
     \\  attyx list tabs              Just tab names and IDs
     \\  attyx list splits            Panes in the active tab
     \\  attyx list sessions          All daemon sessions
+    \\  attyx list agents            Panes running an agent
+    \\  attyx list agents -p 3       Just pane 3's agent
+    \\  attyx list agents --json     Agents as a JSON array
     \\  attyx list --json            Full tree as JSON
     \\  attyx list tabs --json       Tabs as JSON
+    \\
+;
+
+pub const watch =
+    \\Stream agent status changes from a running Attyx instance.
+    \\
+    \\Usage: attyx watch agents [--pane <id>]
+    \\
+    \\Opens a long-lived connection and prints one JSON object per line
+    \\(NDJSON) every time a pane's agent status changes. On connect, the
+    \\current set of active agents is emitted first as a snapshot, then live
+    \\changes follow. Blocks until interrupted (Ctrl-C) or the instance exits.
+    \\
+    \\Each line: {"pane_id":N,"tab_id":N,"session":N,"pid":N,"state":"...","message":"..."}
+    \\  tab_id   the tab's stable handle (its focused pane's id)
+    \\  pid      the agent's foreground process id (0 = unknown)
+    \\  state    one of: idle, working, input, none ("none" = agent ended)
+    \\  message  the agent's latest status preview (may be empty)
+    \\
+    \\Options:
+    \\  --pane, -p <id>   Watch only the agent in this pane (by stable pane ID
+    \\                    from 'attyx list agents'). Default: all agents.
+    \\
+    \\Scope is this instance's panes (the attached or local session). Frames
+    \\for a slow/stuck reader are dropped rather than stalling the terminal.
+    \\
+    \\Examples:
+    \\  attyx watch agents                 Stream changes for every agent
+    \\  attyx watch agents -p 3            Stream only pane 3's agent
+    \\  attyx watch agents | while read l; do notify-send "$l"; done
     \\
 ;
 

--- a/src/ipc/agents.zig
+++ b/src/ipc/agents.zig
@@ -1,0 +1,107 @@
+// Attyx — agent status serialization
+//
+// Shared formatting for agent status records, used by both the one-shot
+// `list agents` query (handler_query) and the streaming `watch agents`
+// subscription (watch.zig). Keeping it here avoids duplicating the JSON/TSV
+// shape in two places so the two surfaces never drift.
+
+const std = @import("std");
+const actions = @import("attyx").actions;
+const platform = @import("../platform/platform.zig");
+
+pub const AgentStatus = actions.AgentStatus;
+
+/// Stable string name for a status — the wire/CLI vocabulary.
+pub fn stateStr(status: AgentStatus) []const u8 {
+    return switch (status) {
+        .none => "none",
+        .idle => "idle",
+        .working => "working",
+        .input => "input",
+    };
+}
+
+/// One agent record as a JSON object (no trailing newline). Caller joins
+/// objects into an array (list) or frames them individually (watch).
+/// `pid` is the agent's foreground process id (0 = unknown, e.g. daemon-backed
+/// panes where the PID lives on the daemon side and isn't shipped to clients).
+pub fn writeAgentJson(
+    w: anytype,
+    pane_id: u32,
+    tab_id: u32,
+    session: u32,
+    pid: u32,
+    status: AgentStatus,
+    message: []const u8,
+) !void {
+    try w.print(
+        "{{\"pane_id\":{d},\"tab_id\":{d},\"session\":{d},\"pid\":{d},\"state\":\"{s}\",\"message\":\"",
+        .{ pane_id, tab_id, session, pid, stateStr(status) },
+    );
+    try writeJsonEscaped(w, message);
+    try w.writeAll("\"}");
+}
+
+/// One agent record as a tab-separated row terminated by a newline:
+///   pane_id \t tab_id \t session \t pid \t state \t message
+/// Newlines in the message are folded to spaces so each entry stays on one line.
+pub fn writeAgentTsv(
+    w: anytype,
+    pane_id: u32,
+    tab_id: u32,
+    session: u32,
+    pid: u32,
+    status: AgentStatus,
+    message: []const u8,
+) !void {
+    try w.print("{d}\t{d}\t{d}\t{d}\t{s}\t", .{ pane_id, tab_id, session, pid, stateStr(status) });
+    for (message) |ch| {
+        try w.writeByte(if (ch == '\n' or ch == '\r') ' ' else ch);
+    }
+    try w.writeByte('\n');
+}
+
+/// Foreground PID of the process running in a pane, or 0 if unknown.
+/// `master_fd` is the pane's PTY master fd (`pane.pty.master`); it's < 0 for
+/// daemon-backed panes, where no PID is available client-side.
+pub fn panePid(master_fd: std.posix.fd_t) u32 {
+    const pid = platform.getForegroundProcessId(master_fd) orelse return 0;
+    return if (pid > 0) @intCast(pid) else 0;
+}
+
+/// Escape a string for embedding inside a JSON string literal.
+pub fn writeJsonEscaped(w: anytype, s: []const u8) !void {
+    for (s) |ch| {
+        switch (ch) {
+            '"' => try w.writeAll("\\\""),
+            '\\' => try w.writeAll("\\\\"),
+            '\n' => try w.writeAll("\\n"),
+            '\r' => try w.writeAll("\\r"),
+            '\t' => try w.writeAll("\\t"),
+            else => {
+                if (ch < 0x20) {
+                    try w.print("\\u{x:0>4}", .{ch});
+                } else {
+                    try w.writeByte(ch);
+                }
+            },
+        }
+    }
+}
+
+test "writeAgentJson escapes message" {
+    var buf: [256]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    try writeAgentJson(stream.writer(), 3, 1, 2, 4242, .working, "say \"hi\"\nnow");
+    try std.testing.expectEqualStrings(
+        "{\"pane_id\":3,\"tab_id\":1,\"session\":2,\"pid\":4242,\"state\":\"working\",\"message\":\"say \\\"hi\\\"\\nnow\"}",
+        stream.getWritten(),
+    );
+}
+
+test "writeAgentTsv folds newlines" {
+    var buf: [128]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    try writeAgentTsv(stream.writer(), 7, 2, 0, 0, .input, "needs\ninput");
+    try std.testing.expectEqualStrings("7\t2\t0\t0\tinput\tneeds input\n", stream.getWritten());
+}

--- a/src/ipc/client.zig
+++ b/src/ipc/client.zig
@@ -173,6 +173,12 @@ pub fn run(args: []const [:0]const u8) void {
         return;
     }
 
+    // For watch: hold the connection open and stream frames until EOF.
+    if (parsed.command == .watch_agents) {
+        @import("client_watch.zig").run(socket_path, parsed);
+        return;
+    }
+
     // Build the request message
     var req_buf: [protocol.header_size + 4096]u8 = undefined;
     var request = buildRequest(&req_buf, parsed) catch {
@@ -428,6 +434,15 @@ fn buildRequest(buf: []u8, parsed: @import("../config/cli_ipc.zig").IpcRequest) 
         .list => protocol.encodeMessage(buf, .list, ""),
         .list_tabs => protocol.encodeMessage(buf, .list_tabs, ""),
         .list_splits => protocol.encodeMessage(buf, .list_splits, ""),
+        // Payload: [format:u8][pane_filter:u32 LE]. format 1 = JSON, else TSV;
+        // pane_filter 0 = all agents.
+        .list_agents => blk: {
+            var payload: [5]u8 = undefined;
+            payload[0] = if (parsed.json_output) 1 else 0;
+            std.mem.writeInt(u32, payload[1..5], parsed.pane_id, .little);
+            break :blk protocol.encodeMessage(buf, .list_agents, &payload);
+        },
+        .watch_agents => protocol.encodeMessage(buf, .watch_agents, ""),
         .popup => blk: {
             // Payload: [width_pct:u8][height_pct:u8][border_style:u8][command...]
             // Clamp command to max_payload - 3 bytes for the option header
@@ -602,6 +617,21 @@ fn writeJsonEscaped(file: std.fs.File, s: []const u8) void {
             },
         }
     }
+}
+
+test "list_agents request encodes json format byte and pane filter" {
+    var buf: [64]u8 = undefined;
+    const parsed = @import("../config/cli_ipc.zig").IpcRequest{
+        .command = .list_agents,
+        .json_output = true,
+        .pane_id = 3,
+    };
+    const req = try buildRequest(&buf, parsed);
+    const header = try protocol.decodeHeader(req[0..protocol.header_size]);
+    try std.testing.expectEqual(protocol.MessageType.list_agents, header.msg_type);
+    try std.testing.expectEqual(@as(u32, 5), header.payload_len);
+    try std.testing.expectEqual(@as(u8, 1), req[protocol.header_size]);
+    try std.testing.expectEqual(@as(u32, 3), std.mem.readInt(u32, req[protocol.header_size + 1 ..][0..4], .little));
 }
 
 test "targeted tab close request preserves zero-based index" {

--- a/src/ipc/client_watch.zig
+++ b/src/ipc/client_watch.zig
@@ -1,0 +1,111 @@
+// Attyx — streaming watch client
+//
+// The `attyx watch agents` command, split out from client.zig (one-shot
+// request/response) because it has a fundamentally different lifecycle: it
+// holds the connection open and reads framed NDJSON responses until the
+// instance closes the stream. Blocks indefinitely — the user Ctrl-Cs or pipes
+// it into another tool.
+
+const std = @import("std");
+const protocol = @import("protocol.zig");
+const client = @import("client.zig");
+const IpcRequest = @import("../config/cli_ipc.zig").IpcRequest;
+
+const max_payload = 65536;
+
+pub fn run(socket_path: []const u8, parsed: IpcRequest) void {
+    // The watch request payload is [pane_filter:u32 LE] (0 = all agents);
+    // wrap it in a session envelope when -s targeted a specific session.
+    var req_buf: [protocol.header_size + 16]u8 = undefined;
+    const request = buildRequest(&req_buf, parsed.command, parsed.pane_id, parsed.target_session) catch {
+        writeStderr("error: failed to build request\n");
+        std.process.exit(1);
+    };
+
+    const fd = client.connectToSocket(socket_path) catch {
+        writeStderr("error: no running Attyx instance found\n");
+        std.process.exit(1);
+    };
+    defer protocol.closeFd(fd);
+
+    protocol.writeAll(fd, request) catch {
+        writeStderr("error: failed to communicate with Attyx instance\n");
+        std.process.exit(1);
+    };
+
+    const stdout = std.fs.File.stdout();
+    var hdr: [protocol.header_size]u8 = undefined;
+    var payload_buf: [max_payload]u8 = undefined;
+    while (true) {
+        // EOF / disconnect ends the stream cleanly.
+        protocol.readExact(fd, &hdr) catch return;
+        const h = protocol.decodeHeader(&hdr) catch return;
+        if (h.payload_len > payload_buf.len) return;
+        if (h.payload_len > 0) {
+            protocol.readExact(fd, payload_buf[0..h.payload_len]) catch return;
+        }
+        switch (h.msg_type) {
+            .success => {
+                if (h.payload_len > 0) {
+                    stdout.writeAll(payload_buf[0..h.payload_len]) catch return;
+                    if (payload_buf[h.payload_len - 1] != '\n') stdout.writeAll("\n") catch return;
+                }
+            },
+            .err => {
+                writeStderr("error: ");
+                std.fs.File.stderr().writeAll(payload_buf[0..h.payload_len]) catch {};
+                std.fs.File.stderr().writeAll("\n") catch {};
+                std.process.exit(1);
+            },
+            else => {},
+        }
+    }
+}
+
+/// Encode the watch request. Inner payload is [pane_filter:u32 LE] (0 = all).
+/// When a session is targeted, wrap it in a session envelope:
+///   session_envelope([session_id:u32 LE][inner_msg_type:u8][pane_filter:u32 LE])
+fn buildRequest(buf: []u8, command: @import("../config/cli_ipc.zig").IpcCommand, pane_filter: u32, target_session: u32) ![]u8 {
+    const msg_type: protocol.MessageType = switch (command) {
+        .watch_agents => .watch_agents,
+        else => return error.UnsupportedCommand,
+    };
+    var inner_payload: [4]u8 = undefined;
+    std.mem.writeInt(u32, &inner_payload, pane_filter, .little);
+
+    if (target_session == 0) {
+        return protocol.encodeMessage(buf, msg_type, &inner_payload);
+    }
+    // Envelope: [4B len][session_envelope][session_id:u32][inner_type:u8][inner_payload...]
+    const payload_len: usize = 4 + 1 + inner_payload.len;
+    if (buf.len < protocol.header_size + payload_len) return error.BufferTooSmall;
+    protocol.encodeHeader(buf[0..protocol.header_size], .session_envelope, @intCast(payload_len));
+    std.mem.writeInt(u32, buf[protocol.header_size..][0..4], target_session, .little);
+    buf[protocol.header_size + 4] = @intFromEnum(msg_type);
+    @memcpy(buf[protocol.header_size + 5 ..][0..inner_payload.len], &inner_payload);
+    return buf[0 .. protocol.header_size + payload_len];
+}
+
+fn writeStderr(msg: []const u8) void {
+    std.fs.File.stderr().writeAll(msg) catch {};
+}
+
+test "watch request carries pane filter" {
+    var buf: [32]u8 = undefined;
+    const req = try buildRequest(&buf, .watch_agents, 5, 0);
+    const h = try protocol.decodeHeader(req[0..protocol.header_size]);
+    try std.testing.expectEqual(protocol.MessageType.watch_agents, h.msg_type);
+    try std.testing.expectEqual(@as(u32, 4), h.payload_len);
+    try std.testing.expectEqual(@as(u32, 5), std.mem.readInt(u32, req[protocol.header_size..][0..4], .little));
+}
+
+test "watch request with session wraps filter in envelope" {
+    var buf: [32]u8 = undefined;
+    const req = try buildRequest(&buf, .watch_agents, 5, 7);
+    const h = try protocol.decodeHeader(req[0..protocol.header_size]);
+    try std.testing.expectEqual(protocol.MessageType.session_envelope, h.msg_type);
+    const sid = std.mem.readInt(u32, req[protocol.header_size..][0..4], .little);
+    try std.testing.expectEqual(@as(u32, 7), sid);
+    try std.testing.expectEqual(@intFromEnum(protocol.MessageType.watch_agents), req[protocol.header_size + 4]);
+    try std.testing.expectEqual(@as(u32, 5), std.mem.readInt(u32, req[protocol.header_size + 5 ..][0..4], .little));
+}

--- a/src/ipc/handler.zig
+++ b/src/ipc/handler.zig
@@ -16,6 +16,7 @@ const actions = @import("../app/ui/actions.zig");
 
 const handler_cmd = @import("handler_cmd.zig");
 const handler_query = @import("handler_query.zig");
+const watch = @import("watch.zig");
 const tab_rename = @import("tab_rename.zig");
 
 /// Process one IPC command. Writes response to cmd.response_fd, then
@@ -220,6 +221,9 @@ pub fn handle(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
         .list => handler_query.buildList(cmd, ctx),
         .list_tabs => handler_query.buildTabList(cmd, ctx),
         .list_splits => handler_query.buildSplitList(cmd, ctx),
+        .list_agents => handler_query.buildAgentList(cmd, ctx),
+        // watch_agents parks the fd instead of closing it — see watch.zig.
+        .watch_agents => watch.handleWatchAgents(cmd, ctx),
 
         // ── Session commands ──
         .session_list => handler_query.handleSessionList(cmd, ctx),

--- a/src/ipc/handler_query.zig
+++ b/src/ipc/handler_query.zig
@@ -12,6 +12,8 @@ const PtyThreadCtx = terminal.PtyThreadCtx;
 const split_layout_mod = @import("../app/split_layout.zig");
 const platform = @import("../platform/platform.zig");
 
+const agents = @import("agents.zig");
+
 const handler = @import("handler.zig");
 const sendOk = handler.sendOk;
 const sendError = handler.sendError;
@@ -118,6 +120,55 @@ pub fn buildSplitList(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
         w.print("\t{d}x{d}", .{ leaf.rect.cols, leaf.rect.rows }) catch break;
         w.writeAll("\n") catch break;
     }
+
+    sendOk(cmd, stream.getWritten());
+}
+
+/// List every pane currently running an agent (status != none).
+/// Payload: [format:u8][pane_filter:u32 LE]. format 1 = JSON array, else
+/// tab-separated rows. pane_filter != 0 restricts output to that pane.
+/// Columns/fields: pane_id, tab_id, session, pid, state, message.
+/// Scope is this instance's panes (the attached or local session); cross-
+/// session tallies remain available via `list sessions`.
+pub fn buildAgentList(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
+    const as_json = cmd.payload_len >= 1 and cmd.payload[0] == 1;
+    const pane_filter: u32 = if (cmd.payload_len >= 5)
+        std.mem.readInt(u32, cmd.payload[1..5], .little)
+    else
+        0;
+
+    var buf: [8192]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    const w = stream.writer();
+
+    const session_id: u32 = if (ctx.session_client) |sc| (sc.attached_session_id orelse 0) else 0;
+
+    if (as_json) w.writeAll("[") catch {};
+    var first = true;
+    const mgr = ctx.tab_mgr;
+    for (0..mgr.count) |i| {
+        const layout = &(mgr.tabs[i] orelse continue);
+        // A tab's stable handle is its focused pane's IPC id — the same `pane:N`
+        // value `attyx list` prints on each tab line.
+        const tab_id = layout.focusedPane().ipc_id;
+        var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
+        const lc = layout.collectLeaves(&leaves);
+        for (leaves[0..lc]) |leaf| {
+            const status = leaf.pane.engine.state.agent_status;
+            if (status == .none) continue;
+            if (pane_filter != 0 and pane_filter != leaf.pane.ipc_id) continue;
+            const msg = leaf.pane.engine.state.agentMsg();
+            const pid = agents.panePid(leaf.pane.pty.master);
+            if (as_json) {
+                if (!first) w.writeAll(",") catch break;
+                agents.writeAgentJson(w, leaf.pane.ipc_id, tab_id, session_id, pid, status, msg) catch break;
+            } else {
+                agents.writeAgentTsv(w, leaf.pane.ipc_id, tab_id, session_id, pid, status, msg) catch break;
+            }
+            first = false;
+        }
+    }
+    if (as_json) w.writeAll("]") catch {};
 
     sendOk(cmd, stream.getWritten());
 }

--- a/src/ipc/handler_windows.zig
+++ b/src/ipc/handler_windows.zig
@@ -9,6 +9,7 @@ const queue = @import("queue.zig");
 const keybinds = @import("../config/keybinds.zig");
 const Action = keybinds.Action;
 const split_layout_mod = @import("../app/split_layout.zig");
+const agents = @import("agents.zig");
 const event_loop = @import("../app/ui/event_loop_windows.zig");
 const WinCtx = event_loop.WinCtx;
 const Pane = @import("../app/pane.zig").Pane;
@@ -176,6 +177,9 @@ pub fn handle(cmd: *queue.IpcCommand, ctx: *WinCtx) void {
         .list => buildList(cmd, ctx),
         .list_tabs => buildTabList(cmd, ctx),
         .list_splits => buildSplitList(cmd, ctx),
+        .list_agents => buildAgentList(cmd, ctx),
+        // Streaming watch needs the POSIX fd model; not supported on Windows pipes.
+        .watch_agents => sendError(cmd, "watch is not supported on this platform"),
 
         // ── Wait variants (hold response until process exits) ──
         .tab_create_wait => {
@@ -452,6 +456,49 @@ fn buildTabList(cmd: *queue.IpcCommand, ctx: *WinCtx) void {
         if (layout.isZoomed()) w.writeAll("\tzoomed") catch break;
         w.writeAll("\n") catch break;
     }
+    sendOk(cmd, stream.getWritten());
+}
+
+/// List panes running an agent. Payload: [format:u8][pane_filter:u32 LE].
+/// Mirrors the POSIX buildAgentList; pid is always 0 on Windows (no foreground
+/// PID support), and session is the active session id.
+fn buildAgentList(cmd: *queue.IpcCommand, ctx: *WinCtx) void {
+    const as_json = cmd.payload_len >= 1 and cmd.payload[0] == 1;
+    const pane_filter: u32 = if (cmd.payload_len >= 5)
+        std.mem.readInt(u32, cmd.payload[1..5], .little)
+    else
+        0;
+
+    var buf: [8192]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    const w = stream.writer();
+
+    const session_id: u32 = if (ctx.session_mgr) |smgr| smgr.activeSession().id else 0;
+
+    if (as_json) w.writeAll("[") catch {};
+    var first = true;
+    const mgr = ctx.tab_mgr;
+    for (0..mgr.count) |i| {
+        const layout = &(mgr.tabs[i] orelse continue);
+        const tab_id = layout.focusedPane().ipc_id;
+        var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
+        const lc = layout.collectLeaves(&leaves);
+        for (leaves[0..lc]) |leaf| {
+            const status = leaf.pane.engine.state.agent_status;
+            if (status == .none) continue;
+            if (pane_filter != 0 and pane_filter != leaf.pane.ipc_id) continue;
+            const msg = leaf.pane.engine.state.agentMsg();
+            if (as_json) {
+                if (!first) w.writeAll(",") catch break;
+                agents.writeAgentJson(w, leaf.pane.ipc_id, tab_id, session_id, 0, status, msg) catch break;
+            } else {
+                agents.writeAgentTsv(w, leaf.pane.ipc_id, tab_id, session_id, 0, status, msg) catch break;
+            }
+            first = false;
+        }
+    }
+    if (as_json) w.writeAll("]") catch {};
+
     sendOk(cmd, stream.getWritten());
 }
 

--- a/src/ipc/protocol.zig
+++ b/src/ipc/protocol.zig
@@ -54,6 +54,9 @@ pub const MessageType = enum(u8) {
     list = 0x3A,
     list_tabs = 0x40,
     list_splits = 0x41,
+    list_agents = 0x4E,
+    // Long-lived: response fd is parked and streamed NDJSON frames over time.
+    watch_agents = 0x4F,
 
     // ── Popup ──
     popup = 0x42,

--- a/src/ipc/server.zig
+++ b/src/ipc/server.zig
@@ -186,6 +186,7 @@ fn handleClient(fd: posix.fd_t) void {
 /// Shutdown: signal the listener thread, close fd, unlink socket.
 pub fn shutdown() void {
     @atomicStore(i32, &g_ipc_shutdown, 1, .seq_cst);
+    @import("watch.zig").closeAll();
     if (listener_fd != -1) {
         posix.close(listener_fd);
         listener_fd = -1;

--- a/src/ipc/watch.zig
+++ b/src/ipc/watch.zig
@@ -1,0 +1,192 @@
+// Attyx — agent status watch subscriptions
+//
+// Streaming counterpart to the one-shot `list agents` query. A `watch agents`
+// IPC request is NOT answered-and-closed like every other command; instead its
+// response fd is parked in a small registry and fed one framed JSON line on
+// every agent status transition (NDJSON over the control socket).
+//
+// Threading: both register() (from the IPC handler) and broadcast() (from the
+// event-loop tick) run on the PTY thread — the handler is drained inside the
+// same tick that detects status changes. So the registry needs no locking; the
+// IPC listener thread never touches it (it only hands fds over via the queue).
+//
+// Backpressure: watcher fds are non-blocking and each frame is written in a
+// single shot. If a write can't complete (slow/dead client, full socket
+// buffer) the watcher is dropped rather than risk stalling the PTY thread or
+// corrupting the frame stream. Status changes are low-frequency, so a healthy
+// client never hits this.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+const is_windows = builtin.os.tag == .windows;
+const platform = @import("../platform/platform.zig");
+const protocol = @import("protocol.zig");
+const queue = @import("queue.zig");
+const agents = @import("agents.zig");
+const terminal = @import("../app/terminal.zig");
+const PtyThreadCtx = terminal.PtyThreadCtx;
+const Pane = @import("../app/pane.zig").Pane;
+const split_layout_mod = @import("../app/split_layout.zig");
+
+const max_watchers = 16;
+/// Worst-case framed JSON line: header + a generous JSON object cap.
+const frame_cap = protocol.header_size + 1024;
+
+const Watcher = struct {
+    fd: posix.fd_t,
+    session_id: u32,
+    /// Only stream this pane's agent; 0 = all agents.
+    pane_filter: u32,
+};
+
+var watchers: [max_watchers]Watcher = undefined;
+var watcher_count: usize = 0;
+
+/// Handle a `watch_agents` IPC request. On success the fd is retained (not
+/// closed) and parked in the registry after an initial snapshot. On failure
+/// the fd is closed here.
+pub fn handleWatchAgents(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
+    const fd = cmd.response_fd;
+    if (fd == queue.invalid_fd) return;
+
+    if (is_windows) {
+        sendErrAndClose(fd, "watch is not supported on this platform");
+        return;
+    }
+    if (watcher_count >= max_watchers) {
+        sendErrAndClose(fd, "too many watchers");
+        return;
+    }
+
+    setNonBlocking(fd);
+
+    // Optional pane filter: payload is [pane_filter:u32 LE] (0 = all agents).
+    const pane_filter: u32 = if (cmd.payload_len >= 4)
+        std.mem.readInt(u32, cmd.payload[0..4], .little)
+    else
+        0;
+
+    // Send the current set of active agents up front so a freshly-attached
+    // watcher has full state without waiting for the next transition. If the
+    // client is already unwritable, drop it before parking.
+    if (!writeSnapshot(ctx, fd, pane_filter)) {
+        protocol.closeFd(fd);
+        return;
+    }
+
+    watchers[watcher_count] = .{ .fd = fd, .session_id = cmd.session_id, .pane_filter = pane_filter };
+    watcher_count += 1;
+}
+
+/// Broadcast a single agent's current status to all watchers. Called from the
+/// event loop when a pane's agent_status_changed flag fires (includes the
+/// transition to `.none` when a session ends, so watchers see agents leave).
+/// `tab_id` is the agent's tab's stable handle (its focused pane's IPC id).
+pub fn broadcastAgent(ctx: *PtyThreadCtx, pane: *Pane, tab_id: u32) void {
+    if (watcher_count == 0) return;
+
+    var frame_buf: [frame_cap]u8 = undefined;
+    const frame = buildFrame(&frame_buf, sessionId(ctx), pane, tab_id) orelse return;
+
+    var i: usize = 0;
+    while (i < watcher_count) {
+        const wt = watchers[i];
+        // Skip watchers filtered to a different pane.
+        if (wt.pane_filter != 0 and wt.pane_filter != pane.ipc_id) {
+            i += 1;
+            continue;
+        }
+        if (tryWriteFrame(wt.fd, frame)) {
+            i += 1;
+        } else {
+            dropWatcher(i);
+        }
+    }
+}
+
+/// Close every parked watcher fd. Called on instance shutdown.
+pub fn closeAll() void {
+    for (watchers[0..watcher_count]) |wt| protocol.closeFd(wt.fd);
+    watcher_count = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+fn sessionId(ctx: *PtyThreadCtx) u32 {
+    if (ctx.session_client) |sc| return sc.attached_session_id orelse 0;
+    return 0;
+}
+
+/// Build a framed (.success) NDJSON line for one agent. Returns null if the
+/// JSON object overflowed the buffer (never expected for our field set).
+fn buildFrame(buf: []u8, session: u32, pane: *Pane, tab_id: u32) ?[]const u8 {
+    var json_buf: [frame_cap - protocol.header_size]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&json_buf);
+    agents.writeAgentJson(
+        stream.writer(),
+        pane.ipc_id,
+        tab_id,
+        session,
+        agents.panePid(pane.pty.master),
+        pane.engine.state.agent_status,
+        pane.engine.state.agentMsg(),
+    ) catch return null;
+    return protocol.encodeMessage(buf, .success, stream.getWritten()) catch null;
+}
+
+/// Write the current active agents (status != none) to a single fd as one
+/// frame each. With pane_filter != 0, only that pane is included. Returns false
+/// if any write fails (caller drops the watcher).
+fn writeSnapshot(ctx: *PtyThreadCtx, fd: posix.fd_t, pane_filter: u32) bool {
+    const session = sessionId(ctx);
+    const mgr = ctx.tab_mgr;
+    var frame_buf: [frame_cap]u8 = undefined;
+    for (0..mgr.count) |i| {
+        const layout = &(mgr.tabs[i] orelse continue);
+        const tab_id = layout.focusedPane().ipc_id;
+        var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
+        const lc = layout.collectLeaves(&leaves);
+        for (leaves[0..lc]) |leaf| {
+            if (leaf.pane.engine.state.agent_status == .none) continue;
+            if (pane_filter != 0 and pane_filter != leaf.pane.ipc_id) continue;
+            const frame = buildFrame(&frame_buf, session, leaf.pane, tab_id) orelse continue;
+            if (!tryWriteFrame(fd, frame)) return false;
+        }
+    }
+    return true;
+}
+
+/// Single-shot, non-blocking write. Returns true only when the entire frame
+/// was written. WouldBlock, partial writes, and broken pipes all fail (and the
+/// caller drops the watcher) — never blocks the PTY thread.
+fn tryWriteFrame(fd: posix.fd_t, frame: []const u8) bool {
+    if (is_windows) return false;
+    const n = posix.write(fd, frame) catch return false;
+    return n == frame.len;
+}
+
+fn dropWatcher(idx: usize) void {
+    protocol.closeFd(watchers[idx].fd);
+    watcher_count -= 1;
+    if (idx != watcher_count) watchers[idx] = watchers[watcher_count];
+}
+
+fn sendErrAndClose(fd: posix.fd_t, msg: []const u8) void {
+    var buf: [128]u8 = undefined;
+    if (protocol.encodeMessage(&buf, .err, msg)) |m| {
+        protocol.writeAll(fd, m) catch {};
+    } else |_| {}
+    protocol.closeFd(fd);
+}
+
+fn setNonBlocking(fd: posix.fd_t) void {
+    if (is_windows) return;
+    if (fd < 0) return;
+    const F_GETFL: i32 = 3;
+    const F_SETFL: i32 = 4;
+    const flags = posix.fcntl(fd, F_GETFL, 0) catch return;
+    _ = posix.fcntl(fd, F_SETFL, flags | platform.O_NONBLOCK) catch {};
+}

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -90,6 +90,15 @@ pub fn getForegroundProcessName(master_fd: std.posix.fd_t, buf: *[256]u8) ?[]con
     return impl.getProcessName(fg_pid, buf);
 }
 
+/// Return the foreground process PID on the given PTY (the actual program
+/// running in the pane, e.g. an agent process). POSIX-only — returns null on
+/// Windows or for an inactive PTY (master_fd < 0, e.g. daemon-backed panes).
+pub fn getForegroundProcessId(master_fd: std.posix.fd_t) ?std.posix.pid_t {
+    if (!is_posix) return null;
+    if (master_fd < 0) return null;
+    return impl.getPtyForegroundPid(master_fd);
+}
+
 /// Query the foreground process's CWD. First checks if a tmux client is
 /// running inside our PTY session and resolves the active pane's CWD.
 /// Falls back to a direct pid-to-cwd lookup for plain shells.

--- a/src/term/key_encode.zig
+++ b/src/term/key_encode.zig
@@ -114,6 +114,15 @@ pub fn encodeKey(event: KeyEvent, enc_state: EncoderState, out: *[128]u8) []cons
     return encodeXterm(event, enc_state, out);
 }
 
+/// True when `bytes` is a user interrupt — a lone ESC (the agent interrupt key)
+/// or Ctrl-C (ETX). No agent harness emits a hook on interrupt, so callers use
+/// this to reset a working agent's status back to idle when the user aborts.
+/// Matches a single byte only, so multi-byte escape sequences (arrow keys etc.,
+/// which also start with ESC) are not mistaken for an interrupt.
+pub fn isInterruptSequence(bytes: []const u8) bool {
+    return bytes.len == 1 and (bytes[0] == 0x1b or bytes[0] == 0x03);
+}
+
 // ---------------------------------------------------------------------------
 // xterm encoding (kitty_flags == 0)
 // ---------------------------------------------------------------------------

--- a/src/term/key_encode_test.zig
+++ b/src/term/key_encode_test.zig
@@ -595,3 +595,12 @@ test "kitty all_keys: numpad uses CSI u" {
     );
     try testing.expectEqualStrings("\x1b[57404u", r);
 }
+
+test "isInterruptSequence matches lone ESC and Ctrl-C only" {
+    try testing.expect(ke.isInterruptSequence("\x1b")); // Esc
+    try testing.expect(ke.isInterruptSequence("\x03")); // Ctrl-C
+    try testing.expect(!ke.isInterruptSequence("\x1b[A")); // arrow up (ESC-prefixed)
+    try testing.expect(!ke.isInterruptSequence("\x1b[Z")); // shift-tab
+    try testing.expect(!ke.isInterruptSequence("a")); // ordinary key
+    try testing.expect(!ke.isInterruptSequence("")); // empty
+}

--- a/src/term/state.zig
+++ b/src/term/state.zig
@@ -610,6 +610,7 @@ pub const TerminalState = struct {
     const handleXyronEvent = @import("state_osc.zig").handleXyronEvent;
     pub const setAgentStatus = @import("state_osc.zig").setAgentStatus;
     pub const agentMsg = @import("state_osc.zig").agentMsg;
+    pub const applyAgentInputTransition = @import("state_osc.zig").applyAgentInputTransition;
 
     // -- Kitty keyboard protocol ---------------------------------------------
 

--- a/src/term/state_osc.zig
+++ b/src/term/state_osc.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const TerminalState = @import("state.zig").TerminalState;
 const AgentStatus = @import("actions.zig").AgentStatus;
+const key_encode = @import("key_encode.zig");
 
 pub fn startHyperlink(self: *TerminalState, uri: []const u8) void {
     if (uri.len == 0) {
@@ -76,6 +77,33 @@ pub fn agentMsg(self: *const TerminalState) []const u8 {
     return self.agent_msg_buf[0..self.agent_msg_len];
 }
 
+/// Infer an agent status transition from user input. Agent harnesses emit no
+/// hook on interrupt or when an input prompt is answered, so we derive these
+/// from the bytes the user sends to the pane:
+///   - interrupt (lone ESC / Ctrl-C) while working or waiting → idle (aborted)
+///   - any real answer while blocked on input → working (the agent resumes)
+/// Navigation keys (ESC-prefixed sequences) and input in idle/none states are
+/// left alone — the agent's own hooks drive those. Called on the pane's
+/// authoritative engine: the keyboard path (local) and the daemon's pane_input
+/// handler (grid-sync, which then broadcasts the change to clients).
+pub fn applyAgentInputTransition(self: *TerminalState, bytes: []const u8) void {
+    if (bytes.len == 0) return;
+    const interrupt = key_encode.isInterruptSequence(bytes);
+    switch (self.agent_status) {
+        .working => if (interrupt) self.setAgentStatus(.idle, ""),
+        .input => {
+            if (interrupt) {
+                self.setAgentStatus(.idle, ""); // Ctrl-C/Esc cancels the prompt
+            } else if (bytes[0] != 0x1b) {
+                // A real answer (digit, Enter, text) — not a navigation key —
+                // unblocks the agent, which is now working again.
+                self.setAgentStatus(.working, "");
+            }
+        },
+        else => {},
+    }
+}
+
 /// Handle OSC 7339;xyron:{json} event.
 /// Dispatches by event type: ipc_ready, cwd_changed, etc.
 pub fn handleXyronEvent(self: *TerminalState, json: []const u8) void {
@@ -112,4 +140,38 @@ fn extractJsonStr(json: []const u8, key: []const u8) ?[]const u8 {
     const val = json[start..][0..end];
     if (val.len == 0) return null;
     return val;
+}
+
+test "applyAgentInputTransition infers interrupt and prompt-answer transitions" {
+    const testing = std.testing;
+    var st = try TerminalState.init(testing.allocator, 24, 80, 100);
+    defer st.deinit();
+
+    // working + ordinary input (Enter) → still working
+    st.setAgentStatus(.working, "");
+    st.applyAgentInputTransition("\r");
+    try testing.expectEqual(AgentStatus.working, st.agent_status);
+
+    // working + Ctrl-C → idle (interrupt)
+    st.applyAgentInputTransition("\x03");
+    try testing.expectEqual(AgentStatus.idle, st.agent_status);
+
+    // input + a real answer (digit) → working (the reported fix)
+    st.setAgentStatus(.input, "");
+    st.applyAgentInputTransition("2");
+    try testing.expectEqual(AgentStatus.working, st.agent_status);
+
+    // input + a navigation key (arrow) → still input, not a premature flip
+    st.setAgentStatus(.input, "");
+    st.applyAgentInputTransition("\x1b[B");
+    try testing.expectEqual(AgentStatus.input, st.agent_status);
+
+    // input + Esc → idle (cancel the prompt)
+    st.applyAgentInputTransition("\x1b");
+    try testing.expectEqual(AgentStatus.idle, st.agent_status);
+
+    // idle + input → unchanged; the agent's UserPromptSubmit hook drives idle→working
+    st.setAgentStatus(.idle, "");
+    st.applyAgentInputTransition("hello");
+    try testing.expectEqual(AgentStatus.idle, st.agent_status);
 }


### PR DESCRIPTION
Agents running in panes (Claude Code, Codex, opencode) already reported their run state via injected hooks, but it was only visible as a tab dot. This makes that state queryable and streamable from the `attyx` CLI, and fixes three cases where the dot got stuck on the wrong color.

## New CLI / IPC surface

Per-pane agent status, scoped to the instance's panes (use `list sessions` for cross-session tallies):

- **`attyx list agents [--json] [-p <id>]`** — one-shot listing of panes running an agent. Fields: `pane_id`, `tab_id`, `session`, `pid`, `state`, `message`.
- **`attyx watch agents [-p <id>]`** — long-lived NDJSON stream: a snapshot on connect, then one line per status change (including the transition to `none` when an agent ends). Pushed from the existing status-change point, so it never misses fast transitions.

```
$ attyx list agents
pane_id  tab_id  session  pid    state    message
3        3       1        48213  working  Editing parser.zig

$ attyx watch agents -p 3
{"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"working","message":"..."}
{"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"idle","message":""}
```

- `pid` is the agent's foreground process (`0` when unknown, e.g. daemon-backed panes where the PID lives daemon-side).
- `tab_id` reuses the tab's focused-pane id — the `pane:N` handle `attyx list` already prints — so no new tab-identity scheme is introduced. For a single-pane tab it equals `pane_id`.
- Both default to all agents; `-p` filters to one pane and applies to the snapshot and the live stream.

The streaming watcher registry is PTY-thread-local (the handler and change-detection both run there, so no locking) and writes are non-blocking: a slow client is dropped rather than stalling the terminal.

## Detection fixes

Each is a status transition that no agent hook reports:

- **Launch** — inject a `SessionStart` hook so an agent registers as idle the moment it starts, instead of staying invisible until the first prompt.
- **Upgrade gap** — the hook-injection fast-path was fooled by `SessionStart` and `Stop` sharing the `idle` command: it concluded everything was injected and skipped re-injection, so `SessionStart` never landed. It now verifies each event's command per-event instead of a global substring scan, so existing configs pick up newly added hooks on the next launch.
- **Interrupt / prompt-answer** — no hook fires on Esc/Ctrl-C, or when an input prompt is answered, so the dot stuck on `working`/`input`. attyx now infers these from the keystroke via `TerminalState.applyAgentInputTransition`: interrupt while busy → `idle`; a real answer while blocked on input → `working`; navigation keys (ESC-prefixed sequences) and other states are left to the agent's own hooks. Applied at both input choke points — the local PTY write and the daemon's `pane_input` handler (which broadcasts to all grid-sync clients).

## Notes

- The `SessionStart` fix requires restarting attyx once (re-injection runs at startup) and launching a fresh agent.
- Tests added: agent record serialization, CLI parsing + request encoding for both commands, the interrupt predicate, the input-transition state logic, and a regression test for the per-event injection check.
- The shipped `attyx` skill (`skills/claude/attyx/SKILL.md`) documents the new commands.