### PR TITLE
Support -s/--session for list agents and watch agents

### DIFF
--- a/skills/claude/attyx/SKILL.md
+++ b/skills/claude/attyx/SKILL.md
@@ -294,7 +294,14 @@ attyx list agents --json
 #  {"pane_id":8,"tab_id":7,"session":1,"pid":48455,"state":"input","message":"Approve running tests?"}]
 ```
 
-Fields: `pane_id` (stable ID of the agent's pane — use for targeting), `tab_id` (stable ID of the agent's tab; in attyx a tab is identified by its focused pane's id — the same `pane:N` shown by `attyx list` — so for a single-pane tab `tab_id == pane_id`), `session`, `pid` (the agent's foreground process id; `0` when unknown, e.g. daemon-backed panes), `state`, and `message` (the agent's latest status preview, may be empty). Scope is the current instance's panes. For per-session counts across **all** daemon sessions, use `attyx list sessions`.
+Fields: `pane_id` (stable ID of the agent's pane — use for targeting), `tab_id` (stable ID of the agent's tab; in attyx a tab is identified by its focused pane's id — the same `pane:N` shown by `attyx list` — so for a single-pane tab `tab_id == pane_id`), `session`, `pid` (the agent's foreground process id; `0` when unknown, e.g. daemon-backed panes), `state`, and `message` (the agent's latest status preview, may be empty). Default scope is the attached/local session. Add `-s <id>` to list any session's agents directly from the daemon — it works even when no window is attached to that session:
+
+```bash
+attyx -s 2 list agents             # agents in session 2
+attyx -s 2 list agents --json
+```
+
+For per-session counts across **all** daemon sessions, use `attyx list sessions`.
 
 ### Watching for changes — `watch agents`
 `attyx watch agents` opens a long-lived stream and prints one JSON object per line (NDJSON) every time an agent's status changes. On connect it first emits a snapshot of the current active agents, then live changes. It blocks until interrupted — pipe it or run it in the background:
@@ -312,6 +319,12 @@ done
 ```
 
 Unlike `list agents`, the watch stream **includes** transitions to `state:"none"` so you can tell when an agent's session ends. Use `watch agents` instead of polling `list agents` in a loop — it's push-based and won't miss fast transitions.
+
+Like `list agents`, the stream defaults to the attached/local session. Add `-s <id>` to watch a specific session straight from the daemon, regardless of which session a window is showing (or whether any window is attached):
+
+```bash
+attyx -s 2 watch agents            # stream session 2's agents
+```
 
 ### Watching a single agent — `--pane` / `-p`
 To follow just one agent instead of all of them, pass its stable pane ID with `-p`. The snapshot and the live stream are both filtered to that pane:

--- a/src/app/daemon/agent_headless_test.zig
+++ b/src/app/daemon/agent_headless_test.zig
@@ -1,0 +1,100 @@
+//! Tests for the headless agent surfaces: `list agents -s N` (list_agents ctl
+//! op) and `watch agents -s N` (watch_agents message). Both serve a target
+//! session directly from the daemon's own engines, with no window attached —
+//! the cross-session path that the window-side handler can't provide.
+const std = @import("std");
+const posix = std.posix;
+const testing = std.testing;
+const protocol = @import("protocol.zig");
+const harness = @import("test_harness.zig");
+const setup = harness.setup;
+const teardown = harness.teardown;
+const TestClient = harness.TestClient;
+
+/// printf an OSC 7337 agent-status (working) out of the pane's shell.
+const agent_osc_cmd = "printf '\\033]7337;agent-status;claude;working\\007'\n";
+
+/// One `list_agents` ctl round-trip. Returns the response body (JSON when
+/// `as_json`) copied into `out`. Caller-supplied buffer keeps the slice valid
+/// past the client's rolling read buffer.
+fn listAgents(client: *TestClient, sid: u32, as_json: bool, out: []u8) ![]const u8 {
+    var op_body: [5]u8 = undefined;
+    op_body[0] = if (as_json) 1 else 0;
+    std.mem.writeInt(u32, op_body[1..5], 0, .little); // pane_filter 0 = all
+    var req_buf: [64]u8 = undefined;
+    const req = try protocol.encodeCtlRequest(&req_buf, sid, @intFromEnum(protocol.CtlOp.list_agents), &op_body);
+    try client.send(.ctl_request, req);
+    const resp = try client.expect(.ctl_response, 4000);
+    try testing.expect(resp.len >= 1);
+    try testing.expectEqual(@as(u8, 0), resp[0]); // status ok
+    const body = resp[1..];
+    @memcpy(out[0..body.len], body);
+    return out[0..body.len];
+}
+
+test "list_agents ctl: empty for a session with no agent" {
+    var env = try setup();
+    defer teardown(&env);
+
+    var client = try TestClient.connect(env.path());
+    defer client.deinit();
+
+    var buf: [4200]u8 = undefined;
+    const cp = try protocol.encodeCreate(&buf, "headless-empty", 24, 80, "/tmp", "");
+    try client.send(.create, cp);
+    const sid = try protocol.decodeCreated(try client.expect(.created, 5000));
+
+    var out: [256]u8 = undefined;
+    const body = try listAgents(&client, sid, true, &out);
+    try testing.expectEqualStrings("[]", body);
+}
+
+test "list_agents and watch_agents stream an active agent" {
+    var env = try setup();
+    defer teardown(&env);
+
+    var client = try TestClient.connect(env.path());
+    defer client.deinit();
+
+    var buf: [4200]u8 = undefined;
+    const cp = try protocol.encodeCreate(&buf, "headless-agent", 24, 80, "/tmp", "");
+    try client.send(.create, cp);
+    const sid = try protocol.decodeCreated(try client.expect(.created, 5000));
+
+    // Drive the agent OSC over the headless write_input path — this also
+    // activates the deferred pane (spawns its PTY + engine), so no attach is
+    // needed. op_body: [pane_id:u32 (0 = first)][bytes].
+    var in_buf: [128]u8 = undefined;
+    std.mem.writeInt(u32, in_buf[0..4], 0, .little);
+    @memcpy(in_buf[4..][0..agent_osc_cmd.len], agent_osc_cmd);
+    const wreq_body = in_buf[0 .. 4 + agent_osc_cmd.len];
+    var wreq_buf: [192]u8 = undefined;
+    const wreq = try protocol.encodeCtlRequest(&wreq_buf, sid, @intFromEnum(protocol.CtlOp.write_input), wreq_body);
+    try client.send(.ctl_request, wreq);
+    _ = try client.expect(.ctl_response, 4000); // write ack
+
+    // Poll list_agents until the daemon's engine has processed the OSC.
+    var out: [512]u8 = undefined;
+    var found = false;
+    var tries: u32 = 0;
+    while (tries < 40) : (tries += 1) {
+        const body = try listAgents(&client, sid, true, &out);
+        if (std.mem.indexOf(u8, body, "\"state\":\"working\"") != null) {
+            found = true;
+            break;
+        }
+        posix.nanosleep(0, 100_000_000);
+    }
+    try testing.expect(found);
+
+    // A fresh watcher must receive the already-active agent as a snapshot
+    // agent_event right after parking.
+    var watcher = try TestClient.connect(env.path());
+    defer watcher.deinit();
+    var wbuf: [8]u8 = undefined;
+    std.mem.writeInt(u32, wbuf[0..4], sid, .little);
+    std.mem.writeInt(u32, wbuf[4..8], 0, .little); // pane_filter 0 = all
+    try watcher.send(.watch_agents, &wbuf);
+    const event = try watcher.expect(.agent_event, 4000);
+    try testing.expect(std.mem.indexOf(u8, event, "\"state\":\"working\"") != null);
+}

--- a/src/app/daemon/agent_watch.zig
+++ b/src/app/daemon/agent_watch.zig
@@ -11,6 +11,7 @@
 // with a watch_session, so no separate parking structure is needed.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const session_mod = @import("session.zig");
 const DaemonSession = session_mod.DaemonSession;
 const DaemonClient = @import("client.zig").DaemonClient;
@@ -56,12 +57,14 @@ fn sendOne(cl: *DaemonClient, session: *DaemonSession, pane: anytype, pane_id: u
     const eng = pane.engine orelse return;
     var json_buf: [1024]u8 = undefined;
     var stream = std.io.fixedBufferStream(&json_buf);
+    // No POSIX pty master fd on Windows → PID is unavailable (0 = unknown).
+    const pid: u32 = if (comptime builtin.os.tag == .windows) 0 else agents.panePid(pane.pty.master);
     agents.writeAgentJson(
         stream.writer(),
         pane_id,
         tabIdForPane(session, pane_id),
         session.id,
-        agents.panePid(pane.pty.master),
+        pid,
         eng.state.agent_status,
         eng.state.agentMsg(),
     ) catch return;

--- a/src/app/daemon/agent_watch.zig
+++ b/src/app/daemon/agent_watch.zig
@@ -1,0 +1,93 @@
+// Attyx — daemon-side agent status watch
+//
+// Streaming counterpart to the `list_agents` ctl op. A `watch_agents` message
+// parks the client connection (see DaemonClient.watch_session) and is fed one
+// `agent_event` frame per status transition. This is the cross-session path:
+// the daemon holds every session's live engine, so `attyx watch agents -s N`
+// works no matter which session a window is attached to (or whether any is).
+//
+// Mirrors the window-side src/ipc/watch.zig, but the registry is just the
+// daemon's existing client array — watchers are ordinary DaemonClients flagged
+// with a watch_session, so no separate parking structure is needed.
+
+const std = @import("std");
+const session_mod = @import("session.zig");
+const DaemonSession = session_mod.DaemonSession;
+const DaemonClient = @import("client.zig").DaemonClient;
+const layout_codec = @import("../layout_codec.zig");
+const agents = @import("../../ipc/agents.zig");
+
+const max_clients: usize = 16;
+
+/// Send the current set of active agents (status != none) in `session` to a
+/// freshly-parked watcher, so it has full state without waiting for the next
+/// transition. Honors the watcher's pane filter.
+pub fn sendSnapshot(cl: *DaemonClient, session: *DaemonSession) void {
+    var ids: [session_mod.max_panes_per_session]u32 = undefined;
+    const n = session.collectPaneIds(&ids);
+    for (ids[0..n]) |pid| {
+        if (cl.watch_pane_filter != 0 and cl.watch_pane_filter != pid) continue;
+        const pane = session.findPane(pid) orelse continue;
+        const eng = pane.engine orelse continue;
+        if (eng.state.agent_status == .none) continue;
+        sendOne(cl, session, pane, pid);
+    }
+}
+
+/// Broadcast one pane's current agent status to every watcher of its session
+/// (the pane filter is applied per watcher). Called from the event loop when a
+/// pane's agent_status_changed flag fires — including the transition to `.none`
+/// when an agent exits, so watchers see agents leave.
+pub fn broadcast(
+    clients: *[max_clients]?DaemonClient,
+    session: *DaemonSession,
+    pane: anytype,
+) void {
+    for (clients) |*slot| {
+        if (slot.*) |*cl| {
+            if (cl.watch_session != session.id) continue;
+            if (cl.watch_pane_filter != 0 and cl.watch_pane_filter != pane.id) continue;
+            sendOne(cl, session, pane, pane.id);
+        }
+    }
+}
+
+fn sendOne(cl: *DaemonClient, session: *DaemonSession, pane: anytype, pane_id: u32) void {
+    const eng = pane.engine orelse return;
+    var json_buf: [1024]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&json_buf);
+    agents.writeAgentJson(
+        stream.writer(),
+        pane_id,
+        tabIdForPane(session, pane_id),
+        session.id,
+        agents.panePid(pane.pty.master),
+        eng.state.agent_status,
+        eng.state.agentMsg(),
+    ) catch return;
+    cl.sendAgentEvent(stream.getWritten());
+}
+
+/// The tab handle (its focused pane's id) for the tab containing `pane_id`,
+/// matching what `list`/`list_agents` report. Falls back to the pane itself
+/// when there's no layout yet (a session created but never viewed).
+pub fn tabIdForPane(session: *DaemonSession, pane_id: u32) u32 {
+    if (session.layout_len == 0) return pane_id;
+    const info = layout_codec.deserialize(session.layout_data[0..session.layout_len]) catch return pane_id;
+    for (0..info.tab_count) |ti| {
+        const tab = &info.tabs[ti];
+        for (0..tab.node_count) |ni| {
+            const node = tab.nodes[ni];
+            if (node.tag == .leaf and node.pane_id == pane_id) {
+                return tabFocusedPane(tab);
+            }
+        }
+    }
+    return pane_id;
+}
+
+fn tabFocusedPane(tab: *const layout_codec.TabLayout) u32 {
+    if (tab.focused_idx >= tab.node_count) return 0;
+    const node = tab.nodes[tab.focused_idx];
+    return if (node.tag == .leaf) node.pane_id else 0;
+}

--- a/src/app/daemon/client.zig
+++ b/src/app/daemon/client.zig
@@ -46,6 +46,12 @@ pub const DaemonClient = struct {
     /// decide whether it can ship grid_snapshot/grid_delta or must fall
     /// back to the legacy byte-stream (pane_output) path.
     peer_caps: u32 = 0,
+    /// Agent-status watcher (`attyx watch agents -s N`). When set, the
+    /// connection is parked: instead of attaching, it receives an `agent_event`
+    /// frame on every status transition in `watch_session`. 0 = not a watcher.
+    watch_session: u32 = 0,
+    /// Restrict the watch stream to a single pane; 0 = all panes in the session.
+    watch_pane_filter: u32 = 0,
 
     pub fn init(fd: std.posix.fd_t) DaemonClient {
         return .{ .socket_fd = fd };
@@ -841,6 +847,14 @@ pub const DaemonClient = struct {
         const p = protocol.encodeHello(&payload, version, caps) catch return;
         var buf: [protocol.header_size + 256]u8 = undefined;
         const m = protocol.encodeMessage(&buf, .hello_ack, p) catch return;
+        self.sendRaw(m);
+    }
+
+    /// Send one agent record as an `agent_event` frame (NDJSON line, no
+    /// trailing newline — the CLI adds it). Used to stream `watch agents -s N`.
+    pub fn sendAgentEvent(self: *DaemonClient, json: []const u8) void {
+        var buf: [protocol.header_size + 1024]u8 = undefined;
+        const m = protocol.encodeMessage(&buf, .agent_event, json) catch return;
         self.sendRaw(m);
     }
 

--- a/src/app/daemon/daemon.zig
+++ b/src/app/daemon/daemon.zig
@@ -8,6 +8,7 @@ const DaemonClient = @import("client.zig").DaemonClient;
 const RingBuffer = @import("ring_buffer.zig").RingBuffer;
 const platform = @import("../../platform/platform.zig");
 const handler = @import("handler.zig");
+const agent_watch = @import("agent_watch.zig");
 const session_connect = @import("../session_connect.zig");
 const state_persist = @import("state_persist.zig");
 const upgrade = @import("upgrade.zig");
@@ -263,6 +264,9 @@ pub fn run(allocator: std.mem.Allocator, restore_path: ?[]const u8) !void {
                             const agent_dirty = if (pane.engine) |eng_ptr| eng_ptr.state.agent_status_changed else false;
                             if (agent_dirty) {
                                 if (pane.engine) |eng_ptr| eng_ptr.state.agent_status_changed = false;
+                                // Stream to headless `watch agents -s` watchers,
+                                // independent of any attached/grid-sync client.
+                                agent_watch.broadcast(&clients, s, pane);
                             }
                             for (&clients) |*cslot| {
                                 if (cslot.*) |*cl| {

--- a/src/app/daemon/handler.zig
+++ b/src/app/daemon/handler.zig
@@ -11,6 +11,7 @@ const RingBuffer = @import("ring_buffer.zig").RingBuffer;
 const layout_codec = @import("../layout_codec.zig");
 const state_persist = @import("state_persist.zig");
 const handler_ctl = @import("handler_ctl.zig");
+const agent_watch = @import("agent_watch.zig");
 
 const max_sessions: usize = 32;
 const max_clients: usize = 16;
@@ -54,9 +55,39 @@ pub fn handleMessage(
         // independent of attachment (background agents drive their own session).
         .ctl_request => handler_ctl.handle(cl, msg.payload, sessions, next_pane_id, allocator, clients),
 
+        // Park this connection as an agent-status watcher for a target session.
+        .watch_agents => handleWatchAgents(cl, msg.payload, sessions),
+
         // Ignore server→client messages
         else => {},
     }
+}
+
+/// Park a connection as an agent-status watcher. payload =
+/// [target_session:u32 LE][pane_filter:u32 LE] (filter 0 = all panes). On
+/// success the client is flagged (watch_session) and gets an initial snapshot;
+/// thereafter the event loop streams agent_event frames to it. On a missing
+/// session the connection is closed with an error.
+fn handleWatchAgents(
+    cl: *DaemonClient,
+    payload: []const u8,
+    sessions: *[max_sessions]?DaemonSession,
+) void {
+    if (payload.len < 8) {
+        cl.sendError(1, "invalid watch request");
+        cl.dead = true;
+        return;
+    }
+    const target_session = std.mem.readInt(u32, payload[0..4], .little);
+    const pane_filter = std.mem.readInt(u32, payload[4..8], .little);
+    const session = findSession(sessions, target_session) orelse {
+        cl.sendError(1, "session not found");
+        cl.dead = true;
+        return;
+    };
+    cl.watch_session = target_session;
+    cl.watch_pane_filter = pane_filter;
+    agent_watch.sendSnapshot(cl, session);
 }
 
 fn handleCreate(

--- a/src/app/daemon/handler_ctl.zig
+++ b/src/app/daemon/handler_ctl.zig
@@ -132,7 +132,8 @@ fn writeAgentRow(
     const eng = pane.engine orelse return;
     const status = eng.state.agent_status;
     if (status == .none) return;
-    const pid = agents.panePid(pane.pty.master);
+    // No POSIX pty master fd on Windows → PID is unavailable (0 = unknown).
+    const pid: u32 = if (comptime builtin.os.tag == .windows) 0 else agents.panePid(pane.pty.master);
     if (as_json) {
         if (!first.*) w.writeAll(",") catch return;
         agents.writeAgentJson(w, pane_id, tab_id, session.id, pid, status, eng.state.agentMsg()) catch return;

--- a/src/app/daemon/handler_ctl.zig
+++ b/src/app/daemon/handler_ctl.zig
@@ -16,6 +16,7 @@ const DaemonClient = @import("client.zig").DaemonClient;
 const platform = @import("../../platform/platform.zig");
 const layout_codec = @import("../layout_codec.zig");
 const handler_ctl_layout = @import("handler_ctl_layout.zig");
+const agents = @import("../../ipc/agents.zig");
 
 const max_sessions: usize = 32;
 const max_clients: usize = 16;
@@ -60,7 +61,85 @@ pub fn handle(
         .tab_move => handler_ctl_layout.tabMove(cl, session, req.body, clients),
         .tab_rename => handler_ctl_layout.tabRename(cl, session, req.body, clients),
         .scroll => handleScroll(cl, session, req.body),
+        .list_agents => handleListAgents(cl, session, req.body),
     }
+}
+
+/// List the session's panes running an agent (status != none), built from the
+/// daemon's own live engines. body = [format:u8][pane_filter:u32 LE]; format 1
+/// = JSON array, else TSV rows; pane_filter != 0 restricts output to that pane.
+/// Mirrors the window-side handler_query.buildAgentList so the two surfaces
+/// produce identical records.
+fn handleListAgents(cl: *DaemonClient, session: *DaemonSession, body: []const u8) void {
+    const as_json = body.len >= 1 and body[0] == 1;
+    const pane_filter: u32 = if (body.len >= 5)
+        std.mem.readInt(u32, body[1..5], .little)
+    else
+        0;
+
+    var buf: [8192]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    const w = stream.writer();
+
+    if (as_json) w.writeAll("[") catch {};
+    var first = true;
+
+    // Walk the stored layout so each agent's tab_id matches `list`'s tab handle
+    // (the tab's focused pane id). Fall back to a flat scan for sessions created
+    // but never viewed, where tab 1 groups every pane.
+    var used_layout = false;
+    if (session.layout_len > 0) {
+        if (layout_codec.deserialize(session.layout_data[0..session.layout_len])) |info_const| {
+            var info = info_const;
+            for (0..info.tab_count) |ti| {
+                const tab = &info.tabs[ti];
+                const tab_id = tabFocusedPane(tab);
+                var leaf_ids: [layout_codec.max_nodes_per_tab]u32 = undefined;
+                const lc = tabLeaves(tab, &leaf_ids);
+                for (leaf_ids[0..lc]) |pid| {
+                    writeAgentRow(w, session, pid, tab_id, as_json, pane_filter, &first);
+                }
+            }
+            used_layout = true;
+        } else |_| {}
+    }
+    if (!used_layout) {
+        var ids: [session_mod.max_panes_per_session]u32 = undefined;
+        const n = session.collectPaneIds(&ids);
+        const tab_id: u32 = if (n > 0) ids[0] else 0;
+        for (ids[0..n]) |pid| {
+            writeAgentRow(w, session, pid, tab_id, as_json, pane_filter, &first);
+        }
+    }
+
+    if (as_json) w.writeAll("]") catch {};
+    cl.sendCtlResponse(0, stream.getWritten());
+}
+
+/// Emit one agent record for `pane_id` if it's running an agent and passes the
+/// pane filter. `first` tracks JSON comma placement across calls.
+fn writeAgentRow(
+    w: anytype,
+    session: *DaemonSession,
+    pane_id: u32,
+    tab_id: u32,
+    as_json: bool,
+    pane_filter: u32,
+    first: *bool,
+) void {
+    if (pane_filter != 0 and pane_filter != pane_id) return;
+    const pane = session.findPane(pane_id) orelse return;
+    const eng = pane.engine orelse return;
+    const status = eng.state.agent_status;
+    if (status == .none) return;
+    const pid = agents.panePid(pane.pty.master);
+    if (as_json) {
+        if (!first.*) w.writeAll(",") catch return;
+        agents.writeAgentJson(w, pane_id, tab_id, session.id, pid, status, eng.state.agentMsg()) catch return;
+    } else {
+        agents.writeAgentTsv(w, pane_id, tab_id, session.id, pid, status, eng.state.agentMsg()) catch return;
+    }
+    first.* = false;
 }
 
 fn handleWriteInput(cl: *DaemonClient, session: *DaemonSession, body: []const u8) void {

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -44,6 +44,11 @@ pub const MessageType = enum(u8) {
     /// session. See CtlOp / encodeCtlRequest.
     ctl_request = 0x15,
 
+    /// Headless agent-status watch: park this connection as a watcher for a
+    /// session and stream `agent_event` frames on every status transition.
+    /// Payload: [target_session:u32 LE][pane_filter:u32 LE] (filter 0 = all).
+    watch_agents = 0x16,
+
     // Daemon → Client
     created = 0x81,
     session_list = 0x82,
@@ -81,6 +86,9 @@ pub const MessageType = enum(u8) {
 
     /// Reply to a ctl_request: [status:u8 (0=ok, 1=err)][body...].
     ctl_response = 0x98,
+    /// One agent status record (NDJSON line) for a parked `watch_agents`
+    /// connection. Payload is the JSON object; the CLI streams it as a line.
+    agent_event = 0x99,
 };
 
 pub const header_size: usize = 5; // 4-byte payload length + 1-byte message type
@@ -223,6 +231,11 @@ pub const CtlOp = enum(u8) {
     /// scroll cursor for that pane. See CtlScrollKind. Does not touch any
     /// window's viewport.
     scroll = 0x0E,
+    /// op_body: [format:u8][pane_filter:u32 LE] — list the session's panes that
+    /// are running an agent (status != none). format 1 = JSON array, else TSV
+    /// rows. pane_filter != 0 restricts output to that pane. Replies with the
+    /// listing built from the session's live engines.
+    list_agents = 0x0F,
 };
 
 /// `list` ctl op kinds (first byte of op_body).

--- a/src/app/daemon/session_test.zig
+++ b/src/app/daemon/session_test.zig
@@ -549,4 +549,5 @@ comptime {
     _ = @import("migration_stress_test.zig");
     _ = @import("cwd_test.zig");
     _ = @import("agent_status_test.zig");
+    _ = @import("agent_headless_test.zig");
 }

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -777,3 +777,18 @@ test "watch agents -p sets pane filter" {
     try std.testing.expectEqual(IpcCommand.watch_agents, parsed.command);
     try std.testing.expectEqual(@as(u32, 7), parsed.pane_id);
 }
+
+test "list agents -s carries target session and pane filter" {
+    const args = [_][:0]const u8{ "attyx", "-s", "3", "list", "agents", "-p", "5" };
+    const parsed = parse(&args).?;
+    try std.testing.expectEqual(IpcCommand.list_agents, parsed.command);
+    try std.testing.expectEqual(@as(u32, 3), parsed.target_session);
+    try std.testing.expectEqual(@as(u32, 5), parsed.pane_id);
+}
+
+test "watch agents -s carries target session" {
+    const args = [_][:0]const u8{ "attyx", "watch", "agents", "-s", "4" };
+    const parsed = parse(&args).?;
+    try std.testing.expectEqual(IpcCommand.watch_agents, parsed.command);
+    try std.testing.expectEqual(@as(u32, 4), parsed.target_session);
+}

--- a/src/config/cli_ipc_help.zig
+++ b/src/config/cli_ipc_help.zig
@@ -31,7 +31,8 @@ pub const top_level =
     \\
     \\Global options:
     \\  --target <pid>       Target a specific Attyx instance by PID
-    \\  -s, --session <id>   Verify command targets the given attached session
+    \\  -s, --session <id>   Target a specific session directly via the daemon
+    \\                       (works without that session being attached)
     \\  --json               Output in JSON format (for scripts and agents)
     \\  --help, -h           Show this help (works on every subcommand)
     \\
@@ -490,9 +491,10 @@ pub const list =
     \\shown by 'attyx list'); for a single-pane tab it equals pane_id. pid is the
     \\agent's foreground process id (0 = unknown, e.g. daemon-backed panes). Pass
     \\--pane/-p <id> to list just one agent's pane. With --json it returns a JSON
-    \\array; otherwise tab-separated rows. Scope is this instance's panes — use
-    \\'list sessions' for per-session counts across all daemon sessions, or
-    \\'watch agents' to stream changes.
+    \\array; otherwise tab-separated rows. Default scope is the attached/local
+    \\session; add -s/--session <id> to list any session's agents directly from
+    \\the daemon (no window needs to be attached to it). Use 'list sessions' for
+    \\per-session counts, or 'watch agents' to stream changes.
     \\
     \\Examples:
     \\  attyx list                   Full tab/pane tree
@@ -501,6 +503,7 @@ pub const list =
     \\  attyx list sessions          All daemon sessions
     \\  attyx list agents            Panes running an agent
     \\  attyx list agents -p 3       Just pane 3's agent
+    \\  attyx list agents -s 2       Agents in session 2
     \\  attyx list agents --json     Agents as a JSON array
     \\  attyx list --json            Full tree as JSON
     \\  attyx list tabs --json       Tabs as JSON
@@ -526,13 +529,18 @@ pub const watch =
     \\Options:
     \\  --pane, -p <id>   Watch only the agent in this pane (by stable pane ID
     \\                    from 'attyx list agents'). Default: all agents.
+    \\  --session, -s <id>  Stream a specific session's agents directly from the
+    \\                    daemon, regardless of which session a window is showing
+    \\                    (or whether any window is attached). Default: the
+    \\                    attached/local session.
     \\
-    \\Scope is this instance's panes (the attached or local session). Frames
-    \\for a slow/stuck reader are dropped rather than stalling the terminal.
+    \\Frames for a slow/stuck reader are dropped rather than stalling the
+    \\terminal.
     \\
     \\Examples:
     \\  attyx watch agents                 Stream changes for every agent
     \\  attyx watch agents -p 3            Stream only pane 3's agent
+    \\  attyx watch agents -s 2            Stream session 2's agents
     \\  attyx watch agents | while read l; do notify-send "$l"; done
     \\
 ;

--- a/src/ipc/client.zig
+++ b/src/ipc/client.zig
@@ -155,6 +155,12 @@ pub fn run(args: []const [:0]const u8) void {
     // which window (if any) is attached. This lets background agents drive
     // their own session without switching what any window shows.
     const client_daemon = @import("client_daemon.zig");
+    // `watch agents -s N` streams from the daemon (it holds every session's
+    // engine); without -s it still streams from the attached window below.
+    if (parsed.command == .watch_agents and parsed.target_session != 0) {
+        client_daemon.watchAgents(parsed);
+        return;
+    }
     if (parsed.target_session != 0 and client_daemon.isRoutable(parsed.command)) {
         client_daemon.run(parsed);
         return;

--- a/src/ipc/client_daemon.zig
+++ b/src/ipc/client_daemon.zig
@@ -28,7 +28,7 @@ const ctl_read_timeout_ms: i32 = 4000;
 /// focus) still need a window and land in a later phase.
 pub fn isRoutable(cmd: IpcCommand) bool {
     return switch (cmd) {
-        .send_keys, .get_text, .list, .list_tabs, .list_splits => true,
+        .send_keys, .get_text, .list, .list_tabs, .list_splits, .list_agents => true,
         .tab_create, .tab_select, .tab_next, .tab_prev => true,
         .tab_close, .tab_move_left, .tab_move_right, .tab_rename => true,
         .split_vertical, .split_horizontal, .split_close, .split_rotate => true,
@@ -51,6 +51,7 @@ pub fn run(parsed: IpcRequest) void {
         .list => list(sock, parsed, .all),
         .list_tabs => list(sock, parsed, .tabs),
         .list_splits => list(sock, parsed, .panes),
+        .list_agents => listAgents(sock, parsed),
         .tab_create => tabCreate(sock, parsed),
         .tab_select => simpleOk(sock, parsed, .tab_select, &[_]u8{parsed.index_arg}),
         .tab_next => simpleOk(sock, parsed, .tab_next, ""),
@@ -152,6 +153,80 @@ fn list(sock: []const u8, parsed: IpcRequest, kind: dproto.CtlListKind) void {
         std.process.exit(1);
     }
     printBody(reply.body);
+}
+
+/// `list agents -s N`. op_body = [format:u8][pane_filter:u32 LE]; the daemon
+/// builds the same JSON/TSV records as the window-side `list agents`.
+fn listAgents(sock: []const u8, parsed: IpcRequest) void {
+    var op_body: [5]u8 = undefined;
+    op_body[0] = if (parsed.json_output) 1 else 0;
+    std.mem.writeInt(u32, op_body[1..5], parsed.pane_id, .little);
+    var resp_buf: [16384]u8 = undefined;
+    const reply = ctlOrExit(sock, parsed.target_session, .list_agents, &op_body, &resp_buf);
+    if (reply.status != 0) {
+        reportError(reply.body);
+        std.process.exit(1);
+    }
+    printBody(reply.body);
+}
+
+/// `watch agents -s N`. Connects to the daemon, parks the connection as a
+/// watcher for the target session, then streams agent_event frames as NDJSON
+/// until the daemon closes the stream (or the user Ctrl-Cs). Mirrors the
+/// window-side client_watch.run, but speaks the daemon protocol.
+pub fn watchAgents(parsed: IpcRequest) void {
+    var sock_buf: [256]u8 = undefined;
+    const sock = session_connect.getSocketPath(&sock_buf) orelse {
+        stderr("error: cannot locate attyx daemon socket\n");
+        std.process.exit(1);
+    };
+
+    // Request payload: [target_session:u32 LE][pane_filter:u32 LE].
+    var req_payload: [8]u8 = undefined;
+    std.mem.writeInt(u32, req_payload[0..4], parsed.target_session, .little);
+    std.mem.writeInt(u32, req_payload[4..8], parsed.pane_id, .little);
+    var frame_buf: [dproto.header_size + 8]u8 = undefined;
+    const frame = dproto.encodeMessage(&frame_buf, .watch_agents, &req_payload) catch {
+        stderr("error: failed to build watch request\n");
+        std.process.exit(1);
+    };
+
+    const fd = client.connectToSocket(sock) catch {
+        stderr("error: cannot reach attyx daemon\n");
+        std.process.exit(1);
+    };
+    defer io.closeFd(fd);
+    io.writeAll(fd, frame) catch {
+        stderr("error: failed to reach attyx daemon\n");
+        std.process.exit(1);
+    };
+
+    const stdout = std.fs.File.stdout();
+    var hdr: [dproto.header_size]u8 = undefined;
+    var payload_buf: [65536]u8 = undefined;
+    while (true) {
+        io.readExact(fd, &hdr) catch return; // EOF / disconnect ends the stream
+        const h = dproto.decodeHeader(&hdr) catch return;
+        if (h.payload_len > payload_buf.len) return;
+        if (h.payload_len > 0) io.readExact(fd, payload_buf[0..h.payload_len]) catch return;
+        switch (h.msg_type) {
+            .agent_event => {
+                if (h.payload_len > 0) {
+                    stdout.writeAll(payload_buf[0..h.payload_len]) catch return;
+                    if (payload_buf[h.payload_len - 1] != '\n') stdout.writeAll("\n") catch return;
+                }
+            },
+            .err => {
+                const e = dproto.decodeError(payload_buf[0..h.payload_len]) catch {
+                    stderr("error: watch failed\n");
+                    std.process.exit(1);
+                };
+                reportError(e.msg);
+                std.process.exit(1);
+            },
+            else => {},
+        }
+    }
 }
 
 const CtlReply = struct { status: u8, body: []const u8 };


### PR DESCRIPTION
## What

`list agents` and `watch agents` were scoped to the currently attached session — passing `-s/--session <id>` either errored (`session not attached`) or silently no-op'd. This wires both commands into the daemon-routed path that `get-text`, `list`, `send-keys`, etc. already use, so they work against any session.

## Why

The window only holds the attached session's panes. The daemon holds every session's live engine (`pane.engine.state.agent_status`), so it's the right place to answer cross-session agent queries — even when no window is attached to the target session.

## How

**`list agents -s N`**
- New `list_agents` ctl op (`CtlOp 0x0F`). The daemon walks the target session's tabs/panes and emits the same JSON/TSV records as the window path, reusing the shared `src/ipc/agents.zig` writers so the two surfaces can't drift.
- Added to `isRoutable`; `client_daemon` builds the request and prints the reply.

**`watch agents -s N`**
- New `watch_agents` daemon message (`0x16`) parks the connection as an agent watcher on the target session (`DaemonClient.watch_session`), sends an initial snapshot of active agents, and stays open.
- The daemon event loop already detects per-pane `agent_status_changed`; it now also broadcasts an `agent_event` frame (`0x99`) to matching watchers on every transition (including `→ none` when an agent ends).
- The CLI streams these frames as NDJSON, mirroring the window-side `watch` client but speaking the daemon protocol.

Without `-s`, both commands behave exactly as before (served by the attached window).

## Tests

- CLI parse tests: `-s` carries the target session for both commands.
- Daemon integration tests (`agent_headless_test.zig`): `list_agents` returns `[]` for a session with no agent; driving an agent OSC headlessly then surfaces it via both `list_agents` and a `watch_agents` snapshot.

Help text (`cli_ipc_help.zig`) and the attyx skill doc updated to document the new scoping.

> Note: one pre-existing daemon test (`agent status re-shipped when a pane becomes newly active`) is flaky/failing on `main` independent of this change.