### PR TITLE
Add MCP server exposing IPC over stdio and in-app HTTP

### DIFF
--- a/src/app/terminal.zig
+++ b/src/app/terminal.zig
@@ -870,6 +870,13 @@ pub fn run(
         if (ipc_thread) |t| t.join();
     }
 
+    // Start the embedded MCP HTTP server (loopback) for the UI's lifetime.
+    const mcp_http = @import("../ipc/mcp_http.zig");
+    if (config.mcp_enabled and config.mcp_port != 0) {
+        mcp_http.start(config.mcp_host, config.mcp_port);
+    }
+    defer mcp_http.shutdown();
+
     const thread = try std.Thread.spawn(.{}, event_loop.ptyReaderThread, .{&ctx});
     defer thread.join();
 

--- a/src/config/cli.zig
+++ b/src/config/cli.zig
@@ -26,6 +26,7 @@ pub const Action = enum {
     kill_daemon,
     ipc_command,
     host,
+    mcp,
 };
 
 fn fatal(msg: []const u8) noreturn {
@@ -75,6 +76,9 @@ pub fn parse(args: []const [:0]const u8) CliResult {
             return result;
         } else if (std.mem.eql(u8, first, "kill-daemon")) {
             result.action = .kill_daemon;
+            return result;
+        } else if (std.mem.eql(u8, first, "mcp")) {
+            result.action = .mcp;
             return result;
         } else if (isIpcSubcommand(first)) {
             result.action = .ipc_command;

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -174,6 +174,16 @@ pub const AppConfig = struct {
     // agents' configs untouched.
     agent_status: bool = true,
 
+    // [mcp]
+    // Embedded MCP (Model Context Protocol) server. When enabled, Attyx runs a
+    // loopback HTTP MCP endpoint at http://<host>:<port>/mcp for as long as the
+    // UI is open, exposing terminal control to MCP clients (e.g. Claude). The
+    // `attyx mcp` stdio bridge is always available regardless of this setting.
+    mcp_enabled: bool = true,
+    mcp_host: []const u8 = "127.0.0.1",
+    _owned_mcp_host: ?[]const u8 = null,
+    mcp_port: u16 = 7333,
+
     // [cursor]
     cursor_shape: CursorShapeConfig = .block,
     cursor_blink: bool = true,
@@ -277,6 +287,7 @@ pub const AppConfig = struct {
         const alloc = self._allocator orelse return;
         if (self._owned_font_family) |s| alloc.free(s);
         if (self._owned_theme_name) |s| alloc.free(s);
+        if (self._owned_mcp_host) |s| alloc.free(s);
         if (self._owned_fallback_items) |items| {
             for (items) |item| alloc.free(item);
             alloc.free(items);

--- a/src/config/config_parse.zig
+++ b/src/config/config_parse.zig
@@ -189,6 +189,35 @@ pub fn applyToml(allocator: std.mem.Allocator, content: []const u8, path: []cons
         }
     }
 
+    // [mcp]
+    if (Lookup.get(root, "mcp", "enabled")) |v| {
+        if (v == .bool) {
+            config.mcp_enabled = v.bool;
+        } else {
+            std.debug.print("error: {s}: mcp.enabled must be a boolean\n", .{path});
+            return error.ConfigValidationError;
+        }
+    }
+    if (Lookup.get(root, "mcp", "host")) |v| {
+        if (v == .string) {
+            const dupe = try allocator.dupe(u8, v.string);
+            if (config._owned_mcp_host) |old| allocator.free(old);
+            config.mcp_host = dupe;
+            config._owned_mcp_host = dupe;
+        } else {
+            std.debug.print("error: {s}: mcp.host must be a string\n", .{path});
+            return error.ConfigValidationError;
+        }
+    }
+    if (Lookup.get(root, "mcp", "port")) |v| {
+        if (v == .int and v.int >= 0 and v.int <= 65535) {
+            config.mcp_port = @intCast(v.int);
+        } else {
+            std.debug.print("error: {s}: mcp.port must be an integer 0-65535\n", .{path});
+            return error.ConfigValidationError;
+        }
+    }
+
     // [cursor]
     if (Lookup.get(root, "cursor", "shape")) |v| {
         if (v == .string) {

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -97,6 +97,27 @@
 # status = true
 
 
+# ── MCP server ───────────────────────────────────────────────────────
+
+[mcp]
+
+# Embedded MCP (Model Context Protocol) server. While the UI is open, Attyx
+# serves an HTTP MCP endpoint that lets MCP clients (e.g. Claude) drive the
+# terminal: list/create panes and tabs, send keys, read pane output, manage
+# sessions, and check agent status. Connect a client to:
+#   http://127.0.0.1:7333/mcp
+# The `attyx mcp` stdio bridge works regardless of this setting.
+# enabled = true
+
+# Host to bind. Keep this on loopback (127.0.0.1) — the tools run arbitrary
+# commands in your terminal, so never expose them to the network.
+# host = "127.0.0.1"
+
+# Port to listen on. Set to 0 to disable the HTTP listener while keeping the
+# stdio bridge available.
+# port = 7333
+
+
 # ── Background ───────────────────────────────────────────────────────
 
 [background]

--- a/src/ipc/client.zig
+++ b/src/ipc/client.zig
@@ -344,7 +344,7 @@ fn buildSendKeysRequest(buf: []u8, payload: []const u8, pane_id: u32, target_ses
     return buf[0..inner.len];
 }
 
-fn buildRequest(buf: []u8, parsed: @import("../config/cli_ipc.zig").IpcRequest) ![]u8 {
+pub fn buildRequest(buf: []u8, parsed: @import("../config/cli_ipc.zig").IpcRequest) ![]u8 {
     return switch (parsed.command) {
         .tab_create => protocol.encodeMessage(buf, if (parsed.wait) .tab_create_wait else .tab_create, parsed.text_arg),
         .tab_close => blk: {
@@ -500,7 +500,7 @@ fn buildRequest(buf: []u8, parsed: @import("../config/cli_ipc.zig").IpcRequest) 
 /// Wrap an already-encoded IPC message in a session_envelope.
 /// Extracts inner msg_type + payload and re-encodes as:
 ///   session_envelope([session_id:u32 LE][inner_msg_type:u8][inner_payload...])
-fn wrapSessionEnvelope(buf: []u8, inner_msg: []const u8, session_id: u32) ![]u8 {
+pub fn wrapSessionEnvelope(buf: []u8, inner_msg: []const u8, session_id: u32) ![]u8 {
     if (inner_msg.len < protocol.header_size) return error.BufferTooSmall;
     const inner_type = inner_msg[4];
     const inner_payload = inner_msg[protocol.header_size..];

--- a/src/ipc/mcp.zig
+++ b/src/ipc/mcp.zig
@@ -1,0 +1,190 @@
+// Attyx — MCP server (stdio transport)
+//
+// Speaks the Model Context Protocol over stdin/stdout (newline-delimited
+// JSON-RPC 2.0) and bridges every tools/call into an IPC request against the
+// running Attyx instance. Configure an MCP client (e.g. Claude Desktop) with:
+//   { "command": "attyx", "args": ["mcp"] }
+//
+// Only the methods that matter are implemented: initialize, tools/list,
+// tools/call. Notifications get no response. No auth — stdio is owned by the
+// trusted parent process.
+
+const std = @import("std");
+const protocol = @import("protocol.zig");
+const client = @import("client.zig");
+const mcp_tools = @import("mcp_tools.zig");
+const version = @import("attyx").version;
+
+const protocol_version = "2024-11-05";
+const max_response = 65536;
+
+const init_result = "{\"protocolVersion\":\"" ++ protocol_version ++
+    "\",\"capabilities\":{\"tools\":{}},\"serverInfo\":{\"name\":\"attyx\",\"version\":\"" ++
+    version ++ "\"}}";
+
+pub fn run(gpa: std.mem.Allocator) void {
+    const stdin = std.fs.File.stdin();
+    var buf: std.ArrayList(u8) = .{};
+    defer buf.deinit(gpa);
+
+    var chunk: [4096]u8 = undefined;
+    while (true) {
+        const n = stdin.read(&chunk) catch break;
+        if (n == 0) break; // EOF — client closed stdin
+        buf.appendSlice(gpa, chunk[0..n]) catch break;
+
+        // Process every complete (newline-terminated) message in the buffer.
+        while (std.mem.indexOfScalar(u8, buf.items, '\n')) |nl| {
+            const line = std.mem.trim(u8, buf.items[0..nl], " \t\r");
+            if (line.len > 0) handleLineStdio(gpa, line);
+            const remaining = buf.items.len - (nl + 1);
+            std.mem.copyForwards(u8, buf.items[0..remaining], buf.items[nl + 1 ..]);
+            buf.shrinkRetainingCapacity(remaining);
+        }
+    }
+}
+
+fn handleLineStdio(gpa: std.mem.Allocator, line: []const u8) void {
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    if (handleMessage(arena_state.allocator(), line)) |resp| {
+        writeRaw(resp);
+        writeRaw("\n");
+    }
+}
+
+/// Process one JSON-RPC message and return the response (without a trailing
+/// newline) allocated in `a`, or null when no reply is warranted (a
+/// notification, or non-object input). Shared by the stdio server and the
+/// in-app HTTP server.
+pub fn handleMessage(a: std.mem.Allocator, line: []const u8) ?[]const u8 {
+    const parsed = std.json.parseFromSlice(std.json.Value, a, line, .{}) catch
+        return respondError(a, null, -32700, "parse error");
+    if (parsed.value != .object) return null;
+    const root = parsed.value.object;
+
+    const method_v = root.get("method") orelse return null;
+    if (method_v != .string) return null;
+    const method = method_v.string;
+    const id = root.get("id"); // absent → notification, no response
+
+    if (std.mem.eql(u8, method, "initialize")) {
+        return respond(a, id, init_result);
+    } else if (std.mem.eql(u8, method, "tools/list")) {
+        return respond(a, id, "{\"tools\":" ++ mcp_tools.TOOLS_JSON ++ "}");
+    } else if (std.mem.eql(u8, method, "tools/call")) {
+        return handleToolCall(a, root.get("params"), id);
+    } else if (std.mem.startsWith(u8, method, "notifications/")) {
+        return null; // notifications expect no reply
+    } else if (id != null) {
+        return respondError(a, id, -32601, "method not found");
+    }
+    return null;
+}
+
+fn handleToolCall(a: std.mem.Allocator, params_opt: ?std.json.Value, id: ?std.json.Value) []const u8 {
+    const params = params_opt orelse return respondError(a, id, -32602, "missing params");
+    if (params != .object) return respondError(a, id, -32602, "invalid params");
+
+    const name_v = params.object.get("name") orelse return respondError(a, id, -32602, "missing tool name");
+    if (name_v != .string) return respondError(a, id, -32602, "invalid tool name");
+
+    const args: ?std.json.ObjectMap = if (params.object.get("arguments")) |v|
+        (if (v == .object) v.object else null)
+    else
+        null;
+
+    const req = mcp_tools.fill(name_v.string, args) orelse
+        return respondError(a, id, -32602, "unknown tool or missing required argument");
+
+    const out = callIpc(a, req);
+    const text_json = std.json.Stringify.valueAlloc(a, std.json.Value{ .string = out.text }, .{}) catch "\"\"";
+    const result = std.fmt.allocPrint(
+        a,
+        "{{\"content\":[{{\"type\":\"text\",\"text\":{s}}}],\"isError\":{s}}}",
+        .{ text_json, if (out.is_error) "true" else "false" },
+    ) catch return respondError(a, id, -32603, "internal error");
+    return respond(a, id, result);
+}
+
+const CallOut = struct { is_error: bool, text: []const u8 };
+
+/// Send one IPC request to the running instance and interpret the response.
+/// Mirrors the relevant parts of client.run (minus stdout/exit semantics).
+fn callIpc(a: std.mem.Allocator, req: @import("../config/cli_ipc.zig").IpcRequest) CallOut {
+    var sock_buf: [256]u8 = undefined;
+    const socket_path = client.discoverSocket(&sock_buf, req.target_pid) orelse
+        return .{ .is_error = true, .text = "no running Attyx instance found" };
+
+    var req_buf: [protocol.header_size + 4096]u8 = undefined;
+    var request = client.buildRequest(&req_buf, req) catch
+        return .{ .is_error = true, .text = "failed to build request" };
+
+    var env_buf: [protocol.header_size + 5 + 4096]u8 = undefined;
+    if (req.target_session != 0) {
+        request = client.wrapSessionEnvelope(&env_buf, request, req.target_session) catch
+            return .{ .is_error = true, .text = "failed to build session envelope" };
+    }
+
+    // get-text --lines can return far more than max_response; heap-allocate.
+    var stack_buf: [max_response]u8 = undefined;
+    var heap_buf: ?[]u8 = null;
+    defer if (heap_buf) |b| std.heap.page_allocator.free(b);
+    const resp_buf: []u8 = if (req.command == .get_text and req.lines > 0) blk: {
+        const b = std.heap.page_allocator.alloc(u8, 8 * 1024 * 1024) catch
+            return .{ .is_error = true, .text = "out of memory for response buffer" };
+        heap_buf = b;
+        break :blk b;
+    } else stack_buf[0..];
+
+    const resp = client.sendCommand(socket_path, request, resp_buf) catch
+        return .{ .is_error = true, .text = "failed to communicate with Attyx instance" };
+
+    return switch (resp.msg_type) {
+        .success => .{ .is_error = false, .text = a.dupe(u8, resp.payload) catch "" },
+        .err => .{ .is_error = true, .text = a.dupe(u8, resp.payload) catch "error" },
+        .exit_code => blk: {
+            const code: u8 = if (resp.payload.len > 0) resp.payload[0] else 1;
+            const body = if (resp.payload.len > 1) resp.payload[1..] else "";
+            break :blk .{
+                .is_error = code != 0,
+                .text = std.fmt.allocPrint(a, "exit_code={d}\n{s}", .{ code, body }) catch "",
+            };
+        },
+        else => .{ .is_error = true, .text = "unexpected response type" },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC envelope writers
+// ---------------------------------------------------------------------------
+
+fn respond(a: std.mem.Allocator, id: ?std.json.Value, result_json: []const u8) []const u8 {
+    return std.fmt.allocPrint(
+        a,
+        "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"result\":{s}}}",
+        .{ idStr(a, id), result_json },
+    ) catch "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32603,\"message\":\"oom\"}}";
+}
+
+fn respondError(a: std.mem.Allocator, id: ?std.json.Value, code: i32, msg: []const u8) []const u8 {
+    const msg_json = std.json.Stringify.valueAlloc(a, std.json.Value{ .string = msg }, .{}) catch "\"error\"";
+    return std.fmt.allocPrint(
+        a,
+        "{{\"jsonrpc\":\"2.0\",\"id\":{s},\"error\":{{\"code\":{d},\"message\":{s}}}}}",
+        .{ idStr(a, id), code, msg_json },
+    ) catch "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32603,\"message\":\"oom\"}}";
+}
+
+fn idStr(a: std.mem.Allocator, id: ?std.json.Value) []const u8 {
+    const v = id orelse return "null";
+    return std.json.Stringify.valueAlloc(a, v, .{}) catch "null";
+}
+
+fn writeRaw(s: []const u8) void {
+    std.fs.File.stdout().writeAll(s) catch {};
+}
+
+test {
+    _ = mcp_tools;
+}

--- a/src/ipc/mcp_http.zig
+++ b/src/ipc/mcp_http.zig
@@ -1,0 +1,184 @@
+// Attyx — in-app MCP server (Streamable HTTP transport)
+//
+// Listens on a TCP port (loopback by default) for as long as the UI runs and
+// answers MCP JSON-RPC over HTTP. Clients connect with a URL, e.g.
+//   http://127.0.0.1:7333/mcp
+// matching how local desktop apps (Figma Dev Mode, JetBrains) expose MCP.
+//
+// Only the request/response subset of Streamable HTTP is implemented: POST a
+// JSON-RPC message, get the JSON-RPC response back as application/json. No SSE
+// / GET stream and no session ids — our tools are all request/response.
+// ponytail: POST-only; add SSE/GET + Mcp-Session-Id if we ever push notifications.
+//
+// The JSON-RPC handling itself is shared with the stdio server (mcp.handleMessage).
+// callIpc inside it connects to this same process's control socket, so the
+// listener just needs the UI's IPC server thread to be up.
+
+const std = @import("std");
+const posix = std.posix;
+const mcp = @import("mcp.zig");
+const logging = @import("../logging/log.zig");
+
+var g_shutdown: i32 = 0;
+var listener_fd: posix.fd_t = -1;
+var g_thread: ?std.Thread = null;
+
+const max_request = 1024 * 1024; // 1 MiB request cap
+
+/// Start the MCP HTTP listener on host:port and spawn its accept thread.
+/// No-op (logs a warning) on bind failure — the UI keeps running regardless.
+pub fn start(host: []const u8, port: u16) void {
+    const addr = std.net.Address.parseIp(host, port) catch {
+        logging.warn("mcp", "invalid mcp host '{s}', not starting", .{host});
+        return;
+    };
+
+    const fd = posix.socket(posix.AF.INET, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, 0) catch |err| {
+        logging.warn("mcp", "failed to create socket: {}", .{err});
+        return;
+    };
+    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1))) catch {};
+    posix.bind(fd, &addr.any, addr.getOsSockLen()) catch |err| {
+        logging.warn("mcp", "failed to bind {s}:{d}: {} (port in use?)", .{ host, port, err });
+        posix.close(fd);
+        return;
+    };
+    posix.listen(fd, 8) catch |err| {
+        logging.warn("mcp", "failed to listen: {}", .{err});
+        posix.close(fd);
+        return;
+    };
+
+    listener_fd = fd;
+    g_thread = std.Thread.spawn(.{}, run, .{}) catch |err| {
+        logging.warn("mcp", "failed to spawn thread: {}", .{err});
+        posix.close(fd);
+        listener_fd = -1;
+        return;
+    };
+    logging.info("mcp", "MCP HTTP server on http://{s}:{d}/mcp", .{ host, port });
+}
+
+pub fn shutdown() void {
+    @atomicStore(i32, &g_shutdown, 1, .seq_cst);
+    if (listener_fd != -1) {
+        posix.close(listener_fd);
+        listener_fd = -1;
+    }
+    if (g_thread) |t| {
+        t.join();
+        g_thread = null;
+    }
+}
+
+fn run() void {
+    const fd = listener_fd;
+    if (fd == -1) return;
+    while (@atomicLoad(i32, &g_shutdown, .seq_cst) == 0) {
+        var pfd = [1]posix.pollfd{.{ .fd = fd, .events = 0x0001, .revents = 0 }}; // POLLIN
+        const ready = posix.poll(&pfd, 200) catch continue;
+        if (ready == 0) continue;
+        if (pfd[0].revents & 0x0001 == 0) continue;
+        const client_fd = posix.accept(fd, null, null, posix.SOCK.CLOEXEC) catch continue;
+        handleConn(client_fd);
+    }
+}
+
+fn handleConn(fd: posix.fd_t) void {
+    defer posix.close(fd);
+
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    const req = readRequest(a, fd) catch {
+        writeStatus(fd, "400 Bad Request");
+        return;
+    };
+
+    // Only POST <path> carries a JSON-RPC message. GET (SSE) is unsupported.
+    if (!std.mem.eql(u8, req.method, "POST")) {
+        writeStatus(fd, "405 Method Not Allowed");
+        return;
+    }
+
+    if (mcp.handleMessage(a, req.body)) |resp| {
+        writeJson(fd, resp);
+    } else {
+        // Notification / no reply — 202 Accepted with empty body, per spec.
+        writeStatus(fd, "202 Accepted");
+    }
+}
+
+const Request = struct { method: []const u8, body: []const u8 };
+
+/// Read an HTTP/1.1 request: status line, headers, then Content-Length bytes.
+/// Minimal by design — enough for an MCP client POSTing a JSON body.
+fn readRequest(a: std.mem.Allocator, fd: posix.fd_t) !Request {
+    var buf: std.ArrayList(u8) = .{};
+    var chunk: [4096]u8 = undefined;
+    var header_end: ?usize = null;
+
+    // Read until we have the full header block (\r\n\r\n).
+    while (header_end == null) {
+        const n = try posix.read(fd, &chunk);
+        if (n == 0) return error.Closed;
+        try buf.appendSlice(a, chunk[0..n]);
+        if (buf.items.len > max_request) return error.TooLarge;
+        header_end = std.mem.indexOf(u8, buf.items, "\r\n\r\n");
+    }
+    const head = buf.items[0..header_end.?];
+
+    // Method is the first token of the request line.
+    const sp = std.mem.indexOfScalar(u8, head, ' ') orelse return error.BadRequest;
+    const method = head[0..sp];
+
+    const content_length = parseContentLength(head) orelse 0;
+    const body_start = header_end.? + 4;
+
+    // Read any remaining body bytes until we have Content-Length of them.
+    while (buf.items.len - body_start < content_length) {
+        const n = try posix.read(fd, &chunk);
+        if (n == 0) break;
+        try buf.appendSlice(a, chunk[0..n]);
+        if (buf.items.len > max_request) return error.TooLarge;
+    }
+
+    const body_len = @min(content_length, buf.items.len - body_start);
+    return .{ .method = method, .body = buf.items[body_start .. body_start + body_len] };
+}
+
+fn parseContentLength(head: []const u8) ?usize {
+    var it = std.mem.tokenizeSequence(u8, head, "\r\n");
+    while (it.next()) |line| {
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const name = std.mem.trim(u8, line[0..colon], " ");
+        if (std.ascii.eqlIgnoreCase(name, "content-length")) {
+            const val = std.mem.trim(u8, line[colon + 1 ..], " ");
+            return std.fmt.parseInt(usize, val, 10) catch null;
+        }
+    }
+    return null;
+}
+
+fn writeJson(fd: posix.fd_t, body: []const u8) void {
+    var hdr_buf: [128]u8 = undefined;
+    const hdr = std.fmt.bufPrint(&hdr_buf, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n", .{body.len}) catch return;
+    writeAll(fd, hdr);
+    writeAll(fd, body);
+}
+
+fn writeStatus(fd: posix.fd_t, status: []const u8) void {
+    var buf: [128]u8 = undefined;
+    const resp = std.fmt.bufPrint(&buf, "HTTP/1.1 {s}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", .{status}) catch return;
+    writeAll(fd, resp);
+}
+
+fn writeAll(fd: posix.fd_t, bytes: []const u8) void {
+    var off: usize = 0;
+    while (off < bytes.len) {
+        const n = posix.write(fd, bytes[off..]) catch return;
+        if (n == 0) return;
+        off += n;
+    }
+}

--- a/src/ipc/mcp_tools.zig
+++ b/src/ipc/mcp_tools.zig
@@ -1,0 +1,243 @@
+// Attyx — MCP tool table
+//
+// One MCP tool per IPC command. `TOOLS_JSON` is the static `tools/list`
+// payload (hand-written JSON schemas); `fill()` maps a tool name + its
+// JSON arguments into an `IpcRequest` that client.buildRequest already knows
+// how to encode. This is the single place that knows the tool surface.
+//
+// watch_agents is intentionally omitted: MCP tool calls are request/response,
+// so streaming doesn't fit. Clients poll list_agents instead.
+// ponytail: poll list_agents; add MCP notifications if push latency matters.
+
+const std = @import("std");
+const cli_ipc = @import("../config/cli_ipc.zig");
+const IpcRequest = cli_ipc.IpcRequest;
+
+/// The complete `tools/list` result array. Static — the surface never changes
+/// at runtime, so there's no reason to build it dynamically. Written one tool
+/// per source line for readability, then flattened to a single line at comptime
+/// (the MCP stdio transport is newline-delimited, so the payload must not
+/// contain raw newlines — none of the schemas embed any).
+const TOOLS_RAW =
+    \\[
+    \\{"name":"list","description":"List the full session/tab/pane tree of the running Attyx instance.","inputSchema":{"type":"object","properties":{"session":{"type":"integer","description":"Target session id (omit for current)."}}}},
+    \\{"name":"list_tabs","description":"List tabs in the current (or targeted) session.","inputSchema":{"type":"object","properties":{"session":{"type":"integer"}}}},
+    \\{"name":"list_panes","description":"List panes (splits) with their stable IPC ids.","inputSchema":{"type":"object","properties":{"session":{"type":"integer"}}}},
+    \\{"name":"list_agents","description":"List AI agents running in panes and their status (working, input_requested, idle...). Returns JSON.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Restrict to one pane id."},"session":{"type":"integer"}}}},
+    \\{"name":"get_text","description":"Capture visible screen text of a pane. With 'lines', captures that many trailing rows from scrollback.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"lines":{"type":"integer","description":"Trailing rows to capture (omit for visible screen)."},"session":{"type":"integer"}}}},
+    \\{"name":"send_keys","description":"Send keystrokes/text to a pane. Supports C-style escapes (\\n, \\t, \\x03) and named keys like {Enter} {Down}.","inputSchema":{"type":"object","properties":{"text":{"type":"string"},"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"session":{"type":"integer"}},"required":["text"]}},
+    \\{"name":"focus","description":"Move keyboard focus between panes.","inputSchema":{"type":"object","properties":{"direction":{"type":"string","enum":["up","down","left","right"]},"session":{"type":"integer"}},"required":["direction"]}},
+    \\{"name":"scroll","description":"Scroll the focused pane.","inputSchema":{"type":"object","properties":{"to":{"type":"string","enum":["top","bottom","page_up","page_down"]},"session":{"type":"integer"}},"required":["to"]}},
+    \\{"name":"tab_create","description":"Open a new tab, optionally running a command. With wait=true, blocks until the command exits and returns its exit code + output.","inputSchema":{"type":"object","properties":{"command":{"type":"string"},"wait":{"type":"boolean"},"session":{"type":"integer"}}}},
+    \\{"name":"tab_close","description":"Close a tab (1-based number) or the active tab if omitted.","inputSchema":{"type":"object","properties":{"tab":{"type":"integer","description":"1-based tab number."},"session":{"type":"integer"}}}},
+    \\{"name":"tab_select","description":"Switch to a tab by 1-based index (1-9).","inputSchema":{"type":"object","properties":{"index":{"type":"integer","minimum":1,"maximum":9},"session":{"type":"integer"}},"required":["index"]}},
+    \\{"name":"tab_switch","description":"Switch to the next or previous tab.","inputSchema":{"type":"object","properties":{"direction":{"type":"string","enum":["next","prev"]},"session":{"type":"integer"}},"required":["direction"]}},
+    \\{"name":"tab_move","description":"Move the active tab left or right in the tab bar.","inputSchema":{"type":"object","properties":{"direction":{"type":"string","enum":["left","right"]},"session":{"type":"integer"}},"required":["direction"]}},
+    \\{"name":"tab_rename","description":"Rename a tab (1-based number) or the active tab if omitted.","inputSchema":{"type":"object","properties":{"name":{"type":"string"},"tab":{"type":"integer"},"session":{"type":"integer"}},"required":["name"]}},
+    \\{"name":"split","description":"Split the focused pane, optionally running a command. With wait=true, blocks until the command exits.","inputSchema":{"type":"object","properties":{"direction":{"type":"string","enum":["vertical","horizontal"]},"command":{"type":"string"},"wait":{"type":"boolean"},"session":{"type":"integer"}},"required":["direction"]}},
+    \\{"name":"split_close","description":"Close a pane by id, or the focused pane if omitted.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer"},"session":{"type":"integer"}}}},
+    \\{"name":"split_rotate","description":"Rotate pane layout.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer"},"session":{"type":"integer"}}}},
+    \\{"name":"split_zoom","description":"Toggle zoom (maximize) for a pane.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer"},"session":{"type":"integer"}}}},
+    \\{"name":"theme_set","description":"Switch the active color theme by name.","inputSchema":{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}},
+    \\{"name":"config_reload","description":"Reload the Attyx config from disk.","inputSchema":{"type":"object","properties":{}}},
+    \\{"name":"popup","description":"Open a floating popup pane running a command.","inputSchema":{"type":"object","properties":{"command":{"type":"string"},"width":{"type":"integer","description":"Width percent 1-100."},"height":{"type":"integer","description":"Height percent 1-100."},"border":{"type":"string","enum":["single","double","rounded","heavy","none"]},"session":{"type":"integer"}},"required":["command"]}},
+    \\{"name":"session_list","description":"List all sessions.","inputSchema":{"type":"object","properties":{}}},
+    \\{"name":"session_create","description":"Create a session. With background=true it is created without switching to it.","inputSchema":{"type":"object","properties":{"name":{"type":"string"},"cwd":{"type":"string","description":"Working directory."},"background":{"type":"boolean"}}}},
+    \\{"name":"session_kill","description":"Kill a session by id.","inputSchema":{"type":"object","properties":{"session_id":{"type":"integer"}},"required":["session_id"]}},
+    \\{"name":"session_switch","description":"Switch the active window to a session by id.","inputSchema":{"type":"object","properties":{"session_id":{"type":"integer"}},"required":["session_id"]}},
+    \\{"name":"session_rename","description":"Rename a session (id), or the current session if id omitted.","inputSchema":{"type":"object","properties":{"session_id":{"type":"integer"},"name":{"type":"string"}},"required":["name"]}}
+    \\]
+;
+
+/// TOOLS_RAW with newlines stripped, so it's a single transport line.
+pub const TOOLS_JSON = blk: {
+    @setEvalBranchQuota(50000);
+    var arr: [TOOLS_RAW.len]u8 = undefined;
+    var n: usize = 0;
+    for (TOOLS_RAW) |c| if (c != '\n') {
+        arr[n] = c;
+        n += 1;
+    };
+    const flat = arr[0..n].*;
+    break :blk flat;
+};
+
+fn getStr(args: ?std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const a = args orelse return null;
+    const v = a.get(key) orelse return null;
+    return if (v == .string) v.string else null;
+}
+
+fn getInt(args: ?std.json.ObjectMap, key: []const u8) ?i64 {
+    const a = args orelse return null;
+    const v = a.get(key) orelse return null;
+    return if (v == .integer) v.integer else null;
+}
+
+fn getBool(args: ?std.json.ObjectMap, key: []const u8) bool {
+    const a = args orelse return false;
+    const v = a.get(key) orelse return false;
+    return v == .bool and v.bool;
+}
+
+fn u32Of(args: ?std.json.ObjectMap, key: []const u8) u32 {
+    const n = getInt(args, key) orelse return 0;
+    return if (n < 0) 0 else @intCast(n);
+}
+
+/// Map a tool name + its JSON arguments object to an IpcRequest.
+/// Returns null for an unknown tool or a missing required argument.
+pub fn fill(name: []const u8, args: ?std.json.ObjectMap) ?IpcRequest {
+    const eql = std.mem.eql;
+    var r = IpcRequest{
+        .command = undefined,
+        .target_session = u32Of(args, "session"),
+        .pane_id = u32Of(args, "pane"),
+    };
+
+    if (eql(u8, name, "list")) {
+        r.command = .list;
+    } else if (eql(u8, name, "list_tabs")) {
+        r.command = .list_tabs;
+    } else if (eql(u8, name, "list_panes")) {
+        r.command = .list_splits;
+    } else if (eql(u8, name, "list_agents")) {
+        r.command = .list_agents;
+        r.json_output = true;
+    } else if (eql(u8, name, "get_text")) {
+        r.command = .get_text;
+        r.lines = u32Of(args, "lines");
+    } else if (eql(u8, name, "send_keys")) {
+        r.command = .send_keys;
+        r.text_arg = getStr(args, "text") orelse return null;
+    } else if (eql(u8, name, "focus")) {
+        const d = getStr(args, "direction") orelse return null;
+        r.command = if (eql(u8, d, "up")) .focus_up else if (eql(u8, d, "down")) .focus_down else if (eql(u8, d, "left")) .focus_left else if (eql(u8, d, "right")) .focus_right else return null;
+    } else if (eql(u8, name, "scroll")) {
+        const t = getStr(args, "to") orelse return null;
+        r.command = if (eql(u8, t, "top")) .scroll_to_top else if (eql(u8, t, "bottom")) .scroll_to_bottom else if (eql(u8, t, "page_up")) .scroll_page_up else if (eql(u8, t, "page_down")) .scroll_page_down else return null;
+    } else if (eql(u8, name, "tab_create")) {
+        r.command = .tab_create;
+        r.text_arg = getStr(args, "command") orelse "";
+        r.wait = getBool(args, "wait");
+    } else if (eql(u8, name, "tab_close")) {
+        r.command = .tab_close;
+        if (getInt(args, "tab")) |t| {
+            if (t < 1) return null;
+            r.tab_idx = @intCast(t - 1);
+        }
+    } else if (eql(u8, name, "tab_select")) {
+        const idx = getInt(args, "index") orelse return null;
+        if (idx < 1 or idx > 9) return null;
+        r.command = .tab_select;
+        r.index_arg = @intCast(idx);
+    } else if (eql(u8, name, "tab_switch")) {
+        const d = getStr(args, "direction") orelse return null;
+        r.command = if (eql(u8, d, "next")) .tab_next else if (eql(u8, d, "prev")) .tab_prev else return null;
+    } else if (eql(u8, name, "tab_move")) {
+        const d = getStr(args, "direction") orelse return null;
+        r.command = if (eql(u8, d, "left")) .tab_move_left else if (eql(u8, d, "right")) .tab_move_right else return null;
+    } else if (eql(u8, name, "tab_rename")) {
+        r.command = .tab_rename;
+        r.text_arg = getStr(args, "name") orelse return null;
+        if (getInt(args, "tab")) |t| {
+            if (t < 1) return null;
+            r.tab_idx = @intCast(t - 1);
+        }
+    } else if (eql(u8, name, "split")) {
+        const d = getStr(args, "direction") orelse return null;
+        r.command = if (eql(u8, d, "vertical")) .split_vertical else if (eql(u8, d, "horizontal")) .split_horizontal else return null;
+        r.text_arg = getStr(args, "command") orelse "";
+        r.wait = getBool(args, "wait");
+    } else if (eql(u8, name, "split_close")) {
+        r.command = .split_close;
+    } else if (eql(u8, name, "split_rotate")) {
+        r.command = .split_rotate;
+    } else if (eql(u8, name, "split_zoom")) {
+        r.command = .split_zoom;
+    } else if (eql(u8, name, "theme_set")) {
+        r.command = .theme_set;
+        r.text_arg = getStr(args, "name") orelse return null;
+    } else if (eql(u8, name, "config_reload")) {
+        r.command = .config_reload;
+    } else if (eql(u8, name, "popup")) {
+        r.command = .popup;
+        r.text_arg = getStr(args, "command") orelse return null;
+        if (getInt(args, "width")) |w| if (w >= 1 and w <= 100) {
+            r.width_pct = @intCast(w);
+        };
+        if (getInt(args, "height")) |h| if (h >= 1 and h <= 100) {
+            r.height_pct = @intCast(h);
+        };
+        if (getStr(args, "border")) |b| {
+            r.border_style = if (eql(u8, b, "single")) 0 else if (eql(u8, b, "double")) 1 else if (eql(u8, b, "rounded")) 2 else if (eql(u8, b, "heavy")) 3 else if (eql(u8, b, "none")) 4 else 2;
+        }
+    } else if (eql(u8, name, "session_list")) {
+        r.command = .session_list;
+    } else if (eql(u8, name, "session_create")) {
+        r.command = .session_create;
+        r.text_arg = getStr(args, "name") orelse "";
+        r.cwd_arg = getStr(args, "cwd") orelse "";
+        r.background = getBool(args, "background");
+    } else if (eql(u8, name, "session_kill")) {
+        r.command = .session_kill;
+        r.session_id_arg = u32Of(args, "session_id");
+    } else if (eql(u8, name, "session_switch")) {
+        r.command = .session_switch;
+        r.session_id_arg = u32Of(args, "session_id");
+    } else if (eql(u8, name, "session_rename")) {
+        r.command = .session_rename;
+        r.session_id_arg = u32Of(args, "session_id");
+        r.text_arg = getStr(args, "name") orelse return null;
+    } else {
+        return null;
+    }
+
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+fn argsFrom(a: std.mem.Allocator, json: []const u8) std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, a, json, .{}) catch unreachable;
+}
+
+test "fill maps send_keys with text and pane" {
+    var p = argsFrom(std.testing.allocator, "{\"text\":\"hi\",\"pane\":3}");
+    defer p.deinit();
+    const r = fill("send_keys", p.value.object).?;
+    try std.testing.expectEqual(cli_ipc.IpcCommand.send_keys, r.command);
+    try std.testing.expectEqualStrings("hi", r.text_arg);
+    try std.testing.expectEqual(@as(u32, 3), r.pane_id);
+}
+
+test "fill maps focus direction" {
+    var p = argsFrom(std.testing.allocator, "{\"direction\":\"left\"}");
+    defer p.deinit();
+    const r = fill("focus", p.value.object).?;
+    try std.testing.expectEqual(cli_ipc.IpcCommand.focus_left, r.command);
+}
+
+test "fill rejects send_keys without text" {
+    var p = argsFrom(std.testing.allocator, "{}");
+    defer p.deinit();
+    try std.testing.expect(fill("send_keys", p.value.object) == null);
+}
+
+test "fill rejects unknown tool" {
+    try std.testing.expect(fill("nope", null) == null);
+}
+
+test "fill tab_close converts 1-based to 0-based index" {
+    var p = argsFrom(std.testing.allocator, "{\"tab\":3}");
+    defer p.deinit();
+    const r = fill("tab_close", p.value.object).?;
+    try std.testing.expectEqual(@as(u8, 2), r.tab_idx);
+}
+
+test "fill tab_close without tab keeps active sentinel" {
+    const r = fill("tab_close", null).?;
+    try std.testing.expectEqual(@as(u8, 0xFF), r.tab_idx);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -244,6 +244,10 @@ pub fn main() !void {
             ipc_client.run(args);
             return;
         },
+        .mcp => {
+            @import("ipc/mcp.zig").run(allocator);
+            return;
+        },
         .print_config => {
             var merged = try loadMergedConfig(allocator, result.no_config, result.config_path, args);
             defer merged.deinit();
@@ -337,6 +341,8 @@ test {
     _ = @import("config/config.zig");
     _ = @import("config/cli_ipc.zig");
     _ = @import("ipc/client.zig");
+    _ = @import("ipc/mcp.zig");
+    if (!is_windows) _ = @import("ipc/mcp_http.zig");
     if (!is_windows) {
         _ = @import("app/daemon/session_test.zig");
         // resize.zig forms an import cycle with event_loop.zig, which keeps its


### PR DESCRIPTION
Exposes the full IPC command surface to MCP clients (e.g. Claude) as 26 typed tools, so external apps can drive Attyx: list/create panes and tabs, send keys, read pane output, manage sessions, check agent status.

## Transports

Both share one JSON-RPC core (`mcp.handleMessage`) and one tool table.

- **`attyx mcp`** — stdio bridge for clients that spawn a subprocess (e.g. Claude Desktop `{"command":"attyx","args":["mcp"]}`). Bridges to a running instance over the existing control socket. Cross-platform.
- **In-app HTTP server** — Streamable HTTP (POST `/mcp`), bound to `127.0.0.1:7333`, up for the UI's lifetime. Connect at `http://127.0.0.1:7333/mcp`. Mirrors how local desktop apps (Figma Dev Mode, JetBrains) expose MCP. POST-only request/response — no SSE/session ids, since every tool is request/response. posix-only for now.

## Config

New `[mcp]` section, enabled by default on loopback:

```toml
[mcp]
# enabled = true
# host = "127.0.0.1"
# port = 7333      # 0 disables the HTTP listener; stdio bridge stays available
```

Bound to `127.0.0.1` only by design: the tools run arbitrary terminal commands, so the endpoint must never reach the network. No auth, matching local-app MCP convention (loopback is the trust boundary).

## Scope

- `watch_agents` (streaming) is omitted; clients poll `list_agents`.
- Windows gets the stdio bridge; the HTTP listener is posix-only for now.

## Testing

- 6 new unit tests for the tool-name → IPC request mapping.
- Verified end-to-end: a `tools/call list` over HTTP round-trips through the in-app server to its own IPC socket and returns the live pane tree; GET → 405; initialize/tools-list correct.