### PR TITLE
ci: pin macOS runners to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       matrix:
         include:
           - target: darwin-arm64
-            runner: macos-latest
+            runner: macos-15
             artifact: attyx-darwin-arm64.zip
             dmg: attyx-darwin-arm64.dmg
           - target: darwin-x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

Pin the arm64 release runner (`release.yml`) and the test matrix (`test.yml`) to `macos-15`, mirroring the already-pinned `macos-15-intel` runner.

## Why

The release build started failing with the build runner unable to link against libSystem — every libSystem symbol came up undefined (`__availability_version_check`, `realpath$DARWIN_EXTSN`, `clock_gettime`, `malloc`, …). The error was in `build_zcu.o`, i.e. compiling `build.zig` itself, which is independent of any app code change.

Root cause: GitHub migrated the `macos-latest` image to a newer macOS/Xcode whose SDK Zig 0.15.2 cannot link. The failing job was the only one still floating on `macos-latest`; the intel job was already pinned. `macos-15` (Apple Silicon, Xcode 16) is the known-good environment that built every prior release.

CI-only change; the build itself is untouched.