### PR TITLE
Fix Codex agent-status detection by pre-trusting injected hooks

### DIFF
--- a/src/app/agent_integration.zig
+++ b/src/app/agent_integration.zig
@@ -22,14 +22,15 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const opencode = @import("agent_integration_opencode.zig");
+const codex = @import("agent_integration_codex.zig");
 
 const is_windows = builtin.os.tag == .windows;
 
 /// The emitter's filename, also used as the marker for identifying our hook
 /// entries when de-duplicating on re-injection.
-const emitter_name = "attyx-agent-status";
+pub const emitter_name = "attyx-agent-status";
 
-const EventSpec = struct { name: []const u8, matcher: ?[]const u8, state: []const u8 };
+pub const EventSpec = struct { name: []const u8, matcher: ?[]const u8, state: []const u8 };
 
 /// Claude Code hooks (settings.json). PermissionRequest is status-only — the
 /// emitter writes nothing to stdout, so it makes no allow/deny decision and the
@@ -46,18 +47,6 @@ const claude_events = [_]EventSpec{
     .{ .name = "Notification", .matcher = null, .state = "notify" },
     .{ .name = "Stop", .matcher = null, .state = "idle" },
     .{ .name = "SessionEnd", .matcher = null, .state = "none" },
-};
-
-/// Codex hooks (~/.codex/hooks.json) — same JSON shape and event names as
-/// Claude (SessionStart fires on launch/resume/clear/compact). Codex has no
-/// Notification or SessionEnd events, so there's no idle-prompt or clear-on-exit
-/// signal; the dot registers idle on launch and rests at idle after a turn.
-const codex_events = [_]EventSpec{
-    .{ .name = "SessionStart", .matcher = null, .state = "idle" },
-    .{ .name = "UserPromptSubmit", .matcher = null, .state = "working" },
-    .{ .name = "PreToolUse", .matcher = null, .state = "working" },
-    .{ .name = "PermissionRequest", .matcher = null, .state = "input" },
-    .{ .name = "Stop", .matcher = null, .state = "idle" },
 };
 
 /// Install the emitter and inject hooks into every discovered Claude config
@@ -85,38 +74,13 @@ pub fn install(gpa: std.mem.Allocator, home: []const u8) void {
         ensureHooksFile(a, settings, emitter_path, &claude_events);
     }
 
-    // 3. Codex — same JSON hook shape, at ~/.codex/hooks.json.
-    installCodex(a, home, emitter_path);
+    // 3. Codex — same JSON hook shape (at ~/.codex/hooks.json), but Codex gates
+    //    command hooks behind a trust check, so the module also pre-trusts them.
+    codex.install(a, home, emitter_path);
 
     // 4. opencode — a JS plugin that shells out to the emitter, loaded via the
     //    plugins dir and registered in opencode.json(c). See its own module.
     opencode.install(a, home, emitter_path);
-}
-
-/// Codex: merge hooks into ~/.codex/hooks.json and enable the hooks feature.
-fn installCodex(a: std.mem.Allocator, home: []const u8, emitter_path: []const u8) void {
-    const dir = std.fmt.allocPrint(a, "{s}/.codex", .{home}) catch return;
-    // Only act if Codex is actually set up (don't create ~/.codex speculatively).
-    var d = std.fs.cwd().openDir(dir, .{}) catch return;
-    d.close();
-    const hooks_path = std.fmt.allocPrint(a, "{s}/hooks.json", .{dir}) catch return;
-    ensureHooksFile(a, hooks_path, emitter_path, &codex_events);
-    ensureCodexFeatureFlag(a, dir);
-}
-
-/// Ensure `[features] hooks = true` in ~/.codex/config.toml. Conservative: only
-/// appends the table when the file has no `[features]` section, to avoid
-/// creating a duplicate TOML table. (Hooks are on by default in current Codex,
-/// so this is belt-and-suspenders.)
-fn ensureCodexFeatureFlag(a: std.mem.Allocator, codex_dir: []const u8) void {
-    const path = std.fmt.allocPrint(a, "{s}/config.toml", .{codex_dir}) catch return;
-    const existing = readFile(a, path) orelse "";
-    if (std.mem.indexOf(u8, existing, "[features]") != null) return; // user manages it
-    const appended = std.fmt.allocPrint(a, "{s}{s}[features]\nhooks = true\n", .{
-        existing,
-        if (existing.len > 0 and existing[existing.len - 1] != '\n') "\n" else "",
-    }) catch return;
-    writeAtomic(a, path, appended, 0o644);
 }
 
 /// Collect Claude config dirs to inject into: ~/.claude (the default) plus any
@@ -138,7 +102,7 @@ fn discoverClaudeConfigDirs(a: std.mem.Allocator, home: []const u8, out: *std.Ar
 
 /// Merge `events` hooks into a JSON hooks file (Claude settings.json or Codex
 /// hooks.json — same `{ "hooks": { ... } }` shape). No-op if already present.
-fn ensureHooksFile(a: std.mem.Allocator, path: []const u8, emitter_path: []const u8, events: []const EventSpec) void {
+pub fn ensureHooksFile(a: std.mem.Allocator, path: []const u8, emitter_path: []const u8, events: []const EventSpec) void {
     const content = readFile(a, path) orelse "{}";
 
     // Fast path: every command already present → leave the file untouched
@@ -356,6 +320,13 @@ const emitter_script =
 
 const testing = std.testing;
 
+fn countOccurrences(haystack: []const u8, needle: []const u8) usize {
+    var count: usize = 0;
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, haystack, i, needle)) |pos| : (count += 1) i = pos + needle.len;
+    return count;
+}
+
 fn mergeToString(a: std.mem.Allocator, input: []const u8, emitter: []const u8) ![]u8 {
     var parsed = try std.json.parseFromSlice(std.json.Value, a, input, .{});
     const root = &parsed.value;
@@ -395,15 +366,9 @@ test "re-merge is idempotent (no duplicate attyx groups)" {
     const a = arena.allocator();
     const once = try mergeToString(a, "{}", "/E/attyx-agent-status");
     const twice = try mergeToString(a, once, "/E/attyx-agent-status");
-    // Count occurrences of the Stop command in the twice-merged output: exactly 1.
-    var count: usize = 0;
-    var i: usize = 0;
-    const needle = "/E/attyx-agent-status idle";
-    while (std.mem.indexOfPos(u8, twice, i, needle)) |pos| {
-        count += 1;
-        i = pos + needle.len;
-    }
-    try testing.expectEqual(@as(usize, 1), count);
+    // Idempotency: re-merging adds no new groups, so the idle command (emitted by
+    // both SessionStart and Stop) occurs the same number of times either way.
+    try testing.expectEqual(countOccurrences(once, "/E/attyx-agent-status idle"), countOccurrences(twice, "/E/attyx-agent-status idle"));
 }
 
 test "re-merge with a changed emitter path drops the stale group" {
@@ -447,20 +412,6 @@ test "hasAllCommands requires the SessionStart event, not just the shared idle c
 test "emitter script self-gates on ATTYX_PID and emits the OSC" {
     try testing.expect(std.mem.indexOf(u8, emitter_script, "[ -n \"$ATTYX_PID\" ] || exit 0") != null);
     try testing.expect(std.mem.indexOf(u8, emitter_script, "]7337;agent-status;agent;%s") != null);
-}
-
-test "codex events cover working, input, and idle" {
-    var arena = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-    var parsed = try std.json.parseFromSlice(std.json.Value, a, "{}", .{});
-    try mergeHooks(a, &parsed.value.object, "/E/attyx-agent-status", &codex_events);
-    const out = try std.json.Stringify.valueAlloc(a, parsed.value, .{ .whitespace = .indent_2 });
-    for ([_][]const u8{ "SessionStart", "UserPromptSubmit", "PreToolUse", "PermissionRequest", "Stop" }) |ev|
-        try testing.expect(std.mem.indexOf(u8, out, ev) != null);
-    try testing.expect(std.mem.indexOf(u8, out, "Notification") == null); // codex has none
-    try testing.expect(std.mem.indexOf(u8, out, "/E/attyx-agent-status input") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "/E/attyx-agent-status idle") != null); // SessionStart/Stop
 }
 
 test "install generates the emitter and injects hooks into ~/.claude" {

--- a/src/app/agent_integration_codex.zig
+++ b/src/app/agent_integration_codex.zig
@@ -1,0 +1,349 @@
+//! Codex agent-status integration.
+//!
+//! Codex loads lifecycle hooks from `~/.codex/hooks.json` using the same JSON
+//! shape and event names as Claude (SessionStart fires on launch/resume/clear/
+//! compact). Codex has no Notification or SessionEnd events, so there's no
+//! idle-prompt or clear-on-exit signal; the dot registers idle on launch and
+//! rests at idle after a turn.
+//!
+//! The catch that makes Codex different from Claude: Codex **gates command hooks
+//! behind a trust check**. It records a `trusted_hash` per hook in
+//! `~/.codex/config.toml` `[hooks.state]` and silently skips any hook whose
+//! current hash isn't trusted. So writing hooks.json alone produces no status —
+//! the hooks never run. We therefore also pre-trust our own hooks by writing the
+//! matching `trusted_hash`, computed with Codex's exact algorithm, so they fire
+//! immediately (matching the zero-touch Claude experience).
+//!
+//! All file writes are non-destructive and idempotent: config.toml is patched at
+//! the text level (no parse + re-stringify) so the user's other settings and
+//! formatting survive, and we never duplicate a TOML table header.
+const std = @import("std");
+const ai = @import("agent_integration.zig");
+
+/// Codex lifecycle hooks. Matchers are null (match-all); the trust-hash and
+/// matcher-resolution logic below mirrors Codex so a future non-null matcher
+/// would still produce a correct hash.
+const codex_events = [_]ai.EventSpec{
+    .{ .name = "SessionStart", .matcher = null, .state = "idle" },
+    .{ .name = "UserPromptSubmit", .matcher = null, .state = "working" },
+    .{ .name = "PreToolUse", .matcher = null, .state = "working" },
+    .{ .name = "PermissionRequest", .matcher = null, .state = "input" },
+    .{ .name = "Stop", .matcher = null, .state = "idle" },
+};
+
+/// Merge hooks into ~/.codex/hooks.json, enable the hooks feature, and pre-trust
+/// our hooks. Best-effort; a no-op if Codex isn't set up.
+pub fn install(a: std.mem.Allocator, home: []const u8, emitter_path: []const u8) void {
+    const dir = std.fmt.allocPrint(a, "{s}/.codex", .{home}) catch return;
+    // Only act if Codex is actually set up (don't create ~/.codex speculatively).
+    var d = std.fs.cwd().openDir(dir, .{}) catch return;
+    d.close();
+
+    const hooks_path = std.fmt.allocPrint(a, "{s}/hooks.json", .{dir}) catch return;
+    ai.ensureHooksFile(a, hooks_path, emitter_path, &codex_events);
+
+    const config_path = std.fmt.allocPrint(a, "{s}/config.toml", .{dir}) catch return;
+    ensureFeatureFlag(a, config_path);
+    ensureTrust(a, config_path, hooks_path, emitter_path);
+}
+
+/// Ensure `[features] hooks = true` in config.toml. Conservative: only appends
+/// the table when the file has no `[features]` section, to avoid creating a
+/// duplicate TOML table. (Hooks are on by default in current Codex, so this is
+/// belt-and-suspenders.)
+fn ensureFeatureFlag(a: std.mem.Allocator, config_path: []const u8) void {
+    const existing = ai.readFile(a, config_path) orelse "";
+    if (std.mem.indexOf(u8, existing, "[features]") != null) return; // user manages it
+    const appended = std.fmt.allocPrint(a, "{s}{s}[features]\nhooks = true\n", .{
+        existing,
+        if (existing.len > 0 and existing[existing.len - 1] != '\n') "\n" else "",
+    }) catch return;
+    ai.writeAtomic(a, config_path, appended, 0o644);
+}
+
+// ---------------------------------------------------------------------------
+// Trust seeding
+// ---------------------------------------------------------------------------
+
+/// Write a `trusted_hash` into config.toml `[hooks.state]` for each injected
+/// hook so Codex runs them without an interactive trust prompt. Recomputed every
+/// startup against the current emitter path, so it self-heals if that changes.
+fn ensureTrust(a: std.mem.Allocator, config_path: []const u8, hooks_path: []const u8, emitter_path: []const u8) void {
+    var content = ai.readFile(a, config_path) orelse "";
+    var changed = false;
+
+    // Codex keys trust by the symlink-resolved path of the hooks file, so we
+    // canonicalize too (a no-op on the usual symlink-free home, but correct when
+    // HOME contains a symlink component). The file exists — ensureHooksFile just
+    // wrote it — so realpath should succeed; fall back to the raw path if not.
+    const key_path = std.fs.realpathAlloc(a, hooks_path) catch hooks_path;
+
+    for (codex_events) |ev| {
+        const label = eventLabel(ev.name) orelse continue;
+        const command = std.fmt.allocPrint(a, "{s} {s}", .{ emitter_path, ev.state }) catch return;
+        // State key mirrors Codex: `<hooks.json path>:<event label>:<group>:<handler>`.
+        // Each event has exactly one group and one handler, so both indices are 0.
+        const key = std.fmt.allocPrint(a, "{s}:{s}:0:0", .{ key_path, label }) catch return;
+        const hash = trustedHash(a, label, resolveMatcher(ev.name, ev.matcher), command) catch return;
+
+        if (upsertTrust(a, content, key, hash) catch return) |next| {
+            content = next;
+            changed = true;
+        }
+    }
+
+    if (changed) ai.writeAtomic(a, config_path, content, 0o644);
+}
+
+/// Codex's snake_case label for a Claude-style event name, used in both the
+/// trust-state key and the hashed identity. Null for events Codex lacks.
+fn eventLabel(name: []const u8) ?[]const u8 {
+    const map = .{
+        .{ "SessionStart", "session_start" },
+        .{ "UserPromptSubmit", "user_prompt_submit" },
+        .{ "PreToolUse", "pre_tool_use" },
+        .{ "PermissionRequest", "permission_request" },
+        .{ "Stop", "stop" },
+    };
+    inline for (map) |pair| {
+        if (std.mem.eql(u8, name, pair[0])) return pair[1];
+    }
+    return null;
+}
+
+/// Mirror Codex's `matcher_pattern_for_event`: UserPromptSubmit and Stop ignore
+/// any configured matcher (always null); other events pass it through. The
+/// resolved matcher is what Codex folds into the trust hash.
+fn resolveMatcher(name: []const u8, matcher: ?[]const u8) ?[]const u8 {
+    if (std.mem.eql(u8, name, "UserPromptSubmit") or std.mem.eql(u8, name, "Stop")) return null;
+    return matcher;
+}
+
+/// Reproduce Codex's command-hook trust hash: `sha256:` + hex of SHA-256 over the
+/// compact, key-sorted JSON of the normalized hook identity. The normalized
+/// handler always carries `async=false`, `timeout=600` (Codex's default), and no
+/// command_windows/statusMessage, so we can emit the canonical bytes directly.
+/// Keys are sorted: top-level `event_name` < `hooks` < `matcher`; handler keys
+/// `async` < `command` < `timeout` < `type`.
+fn trustedHash(a: std.mem.Allocator, label: []const u8, matcher: ?[]const u8, command: []const u8) ![]u8 {
+    var json = std.ArrayList(u8){};
+    defer json.deinit(a);
+    const w = json.writer(a);
+
+    try w.writeAll("{\"event_name\":");
+    try writeJsonString(w, label);
+    try w.writeAll(",\"hooks\":[{\"async\":false,\"command\":");
+    try writeJsonString(w, command);
+    try w.writeAll(",\"timeout\":600,\"type\":\"command\"}]");
+    if (matcher) |m| {
+        try w.writeAll(",\"matcher\":");
+        try writeJsonString(w, m);
+    }
+    try w.writeAll("}");
+
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(json.items, &digest, .{});
+    const hex = std.fmt.bytesToHex(&digest, .lower);
+    return std.fmt.allocPrint(a, "sha256:{s}", .{hex});
+}
+
+/// Append a JSON-escaped string literal (with surrounding quotes). Matches
+/// serde_json: escapes `"` and `\` and control chars; leaves `/` unescaped.
+fn writeJsonString(w: anytype, s: []const u8) !void {
+    try w.writeByte('"');
+    for (s) |c| switch (c) {
+        '"' => try w.writeAll("\\\""),
+        '\\' => try w.writeAll("\\\\"),
+        0x08 => try w.writeAll("\\b"),
+        0x0c => try w.writeAll("\\f"),
+        '\n' => try w.writeAll("\\n"),
+        '\r' => try w.writeAll("\\r"),
+        '\t' => try w.writeAll("\\t"),
+        else => if (c < 0x20) {
+            try w.print("\\u{x:0>4}", .{c});
+        } else {
+            try w.writeByte(c);
+        },
+    };
+    try w.writeByte('"');
+}
+
+/// Ensure config.toml records `trusted_hash = "<hash>"` under the table
+/// `[hooks.state."<key>"]`. Returns the updated content, or null if it already
+/// holds the exact hash. Never duplicates the table header (which TOML rejects).
+fn upsertTrust(a: std.mem.Allocator, content: []const u8, key: []const u8, hash: []const u8) !?[]u8 {
+    const header = try std.fmt.allocPrint(a, "[hooks.state.\"{s}\"]", .{key});
+    const hash_line = try std.fmt.allocPrint(a, "trusted_hash = \"{s}\"", .{hash});
+
+    const hpos = std.mem.indexOf(u8, content, header) orelse {
+        // Header absent — append a fresh table block.
+        const sep: []const u8 = if (content.len == 0 or content[content.len - 1] == '\n') "" else "\n";
+        return try std.fmt.allocPrint(a, "{s}{s}{s}\n{s}\n", .{ content, sep, header, hash_line });
+    };
+
+    // Header present. Scope to its table block: from the header to the next
+    // table header (`\n[`) or EOF.
+    const body_start = hpos + header.len;
+    const block_end = if (std.mem.indexOf(u8, content[body_start..], "\n[")) |rel|
+        body_start + rel
+    else
+        content.len;
+    const block = content[body_start..block_end];
+
+    if (std.mem.indexOf(u8, block, hash_line) != null) return null; // already correct
+
+    if (std.mem.indexOf(u8, block, "trusted_hash")) |rel| {
+        // Replace the existing (stale) trusted_hash line in place.
+        const line_start = body_start + rel;
+        const line_end = if (std.mem.indexOfScalar(u8, content[line_start..], '\n')) |nl|
+            line_start + nl
+        else
+            content.len;
+        return try std.fmt.allocPrint(a, "{s}{s}{s}", .{ content[0..line_start], hash_line, content[line_end..] });
+    }
+
+    // Header exists but carries no trusted_hash yet — insert one after the
+    // header line.
+    const after_header = if (std.mem.indexOfScalar(u8, content[hpos..], '\n')) |nl|
+        hpos + nl + 1
+    else
+        content.len;
+    const sep: []const u8 = if (after_header == content.len and (content.len == 0 or content[content.len - 1] != '\n')) "\n" else "";
+    return try std.fmt.allocPrint(a, "{s}{s}{s}\n{s}", .{ content[0..after_header], sep, hash_line, content[after_header..] });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "trustedHash reproduces Codex's hashes for our events (no matcher)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const emit = "/E/attyx-agent-status";
+    // Vectors verified byte-for-byte against codex 0.142.2's stored trusted_hash.
+    const cases = .{
+        .{ "session_start", emit ++ " idle", "sha256:beef52cd722f43ea007b06b96ecd4051526adfb9c5af530c61663ab3c8f7329f" },
+        .{ "stop", emit ++ " idle", "sha256:441a072a32c82a71f6c4723988c97c76b2b64be543199d316fdc014c4a3bb081" },
+        .{ "user_prompt_submit", emit ++ " working", "sha256:0572432629b482efb5ec70e58168e00ca488c25ec6410f6273efc077a42970df" },
+        .{ "pre_tool_use", emit ++ " working", "sha256:ab05750ea20cf56e3f00057a995c0de1cf67c1e4f73a3e74ff8039f7196a3b1b" },
+        .{ "permission_request", emit ++ " input", "sha256:b10b226c92d04785a4f9ddf22a5477901954b696f532c8bcd6a8aec60321907f" },
+    };
+    inline for (cases) |c| {
+        const got = try trustedHash(a, c[0], null, c[1]);
+        try testing.expectEqualStrings(c[2], got);
+    }
+}
+
+test "trustedHash folds in a non-null matcher" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const got = try trustedHash(a, "pre_tool_use", "*", "/E/attyx-agent-status working");
+    try testing.expectEqualStrings("sha256:3a576e6da0c48b6901314a9288a9b7ad2c68b3ff4578bc2513e09994086ad25c", got);
+}
+
+test "resolveMatcher drops matcher for UserPromptSubmit and Stop" {
+    try testing.expect(resolveMatcher("Stop", "*") == null);
+    try testing.expect(resolveMatcher("UserPromptSubmit", "*") == null);
+    try testing.expectEqualStrings("*", resolveMatcher("PreToolUse", "*").?);
+    try testing.expect(resolveMatcher("PreToolUse", null) == null);
+}
+
+test "upsertTrust appends a fresh block then is idempotent" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const key = "/H/hooks.json:session_start:0:0";
+    const hash = "sha256:abc";
+
+    const once = (try upsertTrust(a, "", key, hash)).?;
+    try testing.expectEqualStrings("[hooks.state.\"/H/hooks.json:session_start:0:0\"]\ntrusted_hash = \"sha256:abc\"\n", once);
+
+    // Second pass with the same hash: no change.
+    try testing.expect((try upsertTrust(a, once, key, hash)) == null);
+}
+
+test "upsertTrust preserves existing config and appends with a separator" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const existing = "[features]\nhooks = true"; // no trailing newline
+    const out = (try upsertTrust(a, existing, "/H/hooks.json:stop:0:0", "sha256:xyz")).?;
+    try testing.expect(std.mem.indexOf(u8, out, "[features]") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "hooks = true\n[hooks.state.") != null); // separated onto its own line
+    try testing.expect(std.mem.indexOf(u8, out, "trusted_hash = \"sha256:xyz\"") != null);
+}
+
+test "upsertTrust replaces a stale hash in place without duplicating the header" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const key = "/H/hooks.json:stop:0:0";
+    const stale =
+        "[hooks.state.\"/H/hooks.json:stop:0:0\"]\ntrusted_hash = \"sha256:OLD\"\n";
+    const out = (try upsertTrust(a, stale, key, "sha256:NEW")).?;
+    try testing.expect(std.mem.indexOf(u8, out, "sha256:OLD") == null); // stale gone
+    try testing.expect(std.mem.indexOf(u8, out, "trusted_hash = \"sha256:NEW\"") != null);
+    // Header appears exactly once.
+    const header = "[hooks.state.\"/H/hooks.json:stop:0:0\"]";
+    var count: usize = 0;
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, out, i, header)) |p| : (count += 1) i = p + header.len;
+    try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "upsertTrust leaves a following table intact when replacing a hash" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const input =
+        "[hooks.state.\"/H/hooks.json:stop:0:0\"]\ntrusted_hash = \"sha256:OLD\"\n\n[other]\nkeep = 1\n";
+    const out = (try upsertTrust(a, input, "/H/hooks.json:stop:0:0", "sha256:NEW")).?;
+    try testing.expect(std.mem.indexOf(u8, out, "trusted_hash = \"sha256:NEW\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "[other]\nkeep = 1\n") != null); // neighbour untouched
+}
+
+test "writeJsonString escapes quotes and backslashes but not slashes" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(a);
+    try writeJsonString(buf.writer(a), "/a/\"b\"\\c");
+    try testing.expectEqualStrings("\"/a/\\\"b\\\"\\\\c\"", buf.items);
+}
+
+test "install writes hooks, enables the feature, and pre-trusts every event" {
+    const home = "/tmp/attyx_codex_install_test";
+    std.fs.cwd().deleteTree("/tmp/attyx_codex_install_test") catch {};
+    try std.fs.cwd().makePath(home ++ "/.codex"); // install only acts if ~/.codex exists
+    defer std.fs.cwd().deleteTree("/tmp/attyx_codex_install_test") catch {};
+
+    // install() owns no allocations — like production (agent_integration.install),
+    // it relies on the caller passing a short-lived arena.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    install(a, home, "/E/attyx-agent-status");
+
+    const hooks = ai.readFile(a, home ++ "/.codex/hooks.json") orelse return error.NoHooks;
+    try testing.expect(std.mem.indexOf(u8, hooks, "SessionStart") != null);
+
+    const config = ai.readFile(a, home ++ "/.codex/config.toml") orelse return error.NoConfig;
+    try testing.expect(std.mem.indexOf(u8, config, "[features]") != null);
+    // A trust entry per event, each carrying a sha256 hash.
+    for ([_][]const u8{ "session_start", "user_prompt_submit", "pre_tool_use", "permission_request", "stop" }) |label| {
+        const needle = std.fmt.allocPrint(a, ":{s}:0:0\"]", .{label}) catch return error.Oom;
+        try testing.expect(std.mem.indexOf(u8, config, needle) != null);
+    }
+    try testing.expect(std.mem.indexOf(u8, config, "trusted_hash = \"sha256:") != null);
+
+    // Idempotent: a second install makes no further changes to config.toml.
+    install(a, home, "/E/attyx-agent-status");
+    const config2 = ai.readFile(a, home ++ "/.codex/config.toml") orelse return error.NoConfig;
+    try testing.expectEqualStrings(config, config2);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -348,6 +348,9 @@ test {
         // resize.zig forms an import cycle with event_loop.zig, which keeps its
         // in-file `test {}` from being collected; aggregate it here instead.
         _ = @import("app/ui/resize_test.zig");
+        _ = @import("app/agent_integration.zig");
+        _ = @import("app/agent_integration_codex.zig");
+        _ = @import("app/agent_integration_opencode.zig");
     }
 }
 


### PR DESCRIPTION
## Problem

Launching **codex** in a pane shows no status updates and no green dot, even though Attyx writes the codex hooks. **claude** works fine.

## Root cause

Codex gates command hooks behind a **trust check**: it records a `trusted_hash` per hook in `~/.codex/config.toml` `[hooks.state]` and **silently skips** any hook whose current hash isn't trusted. Attyx writes `~/.codex/hooks.json` but never trusts it, so on a fresh setup the hooks never run — no `OSC 7337;agent-status` is emitted, so the per-tab dot never appears.

Claude Code has **no trust gate**, so its injected hooks fire zero-touch. That's the asymmetry.

Verified empirically against codex `0.142.2`: a trusted hook fires and emits the OSC; an untrusted one produces zero bytes. (`requirements.toml` managed hooks would bypass trust but live at the root-only system path `/etc/codex/requirements.toml`, so that's not viable for a user-space app.)

## Fix

When injecting the codex hooks, also write the matching `trusted_hash` into `~/.codex/config.toml` so they're trusted immediately. The hash reproduces Codex's algorithm exactly:

> `sha256:` + sha256 of the compact, key-sorted JSON of the normalized hook identity — `{event_name, hooks:[{async:false, command, timeout:600, type:"command"}]}`, with `matcher` folded in only when non-null (and forced null for UserPromptSubmit/Stop, as Codex does).

The reproduced hashes match real codex-written hashes **byte-for-byte** (pinned as test vectors). The trust-state key uses the **symlink-resolved** hooks.json path, matching how Codex keys it. It's recomputed on every startup, so it self-heals if the emitter path changes, and **degrades gracefully** to the prior no-dot state (never a crash or a security hole) if Codex ever changes the algorithm.

Pre-trusting Attyx's *own* known hook is consistent with what Attyx already does for Claude/opencode (which have no gate at all) — the user installs Attyx and Attyx vouches for its benign status emitter.

## Notes

- Codex logic moves into a focused `agent_integration_codex.zig` module (mirroring the existing opencode split) to stay under the file-size limit.
- The `agent_integration` tests were never collected by the test runner — aggregated them in. This surfaced a stale idempotency assertion (broke when the `SessionStart` hook was added); fixed to test actual idempotency.
- Config writes are non-destructive, idempotent, and never duplicate a TOML table header.

## Testing

- New module unit tests: hash reproduction (verified vs codex 0.142.2), matcher folding, TOML upsert (append / idempotent / stale-hash replace / neighbour-preserving), JSON escaping, and a full `install` integration test.
- End-to-end: seeded trust + real `codex exec` with **no** bypass flag → hooks fire and the emitter writes `OSC 7337;agent-status;agent;idle`.
- `zig build test`: 1153/1154 pass; the one failure is a pre-existing flaky daemon timeout (fails on `main` too, unrelated).