### PR TITLE
Drive the agent-status dot from the shell (launch + exit)

### DIFF
--- a/src/app/shell_integration.zig
+++ b/src/app/shell_integration.zig
@@ -97,6 +97,7 @@ pub fn setup() ArgvOverride {
 // ---------------------------------------------------------------------------
 
 const win_scripts = @import("shell_scripts_windows.zig");
+const posix_scripts = @import("shell_scripts_posix.zig");
 
 pub const powershell_script = win_scripts.powershell_script;
 pub const cmd_prompt_string = win_scripts.cmd_prompt_string;
@@ -294,176 +295,13 @@ fn setupXyron(exe_dir: []const u8) ArgvOverride {
 // Shell scripts
 // ---------------------------------------------------------------------------
 
-pub const zsh_script =
-    \\#!/bin/zsh
-    \\# Attyx shell integration (zsh .zshenv)
-    \\# ZDOTDIR stays pointed at our integration dir so zsh also picks up
-    \\# our .zshrc wrapper (which re-installs hooks after user's .zshrc).
-    \\# Resolve user's original ZDOTDIR for sourcing their config files.
-    \\__ATTYX_ZDOTDIR="${__ATTYX_ORIGINAL_ZDOTDIR:-$HOME}"
-    \\if [[ -n "$__ATTYX_BIN_DIR" ]] && [[ ":$PATH:" != *":$__ATTYX_BIN_DIR:"* ]]; then
-    \\  export PATH="$__ATTYX_BIN_DIR:$PATH"
-    \\fi
-    \\unset __ATTYX_BIN_DIR
-    \\# OSC 7: report cwd on directory changes and on every prompt
-    \\# Write to stderr so OSC sequences reach the terminal even when stdout
-    \\# is redirected (e.g. --wait capture pipe).
-    \\__attyx_chpwd() { printf '\e]7;file://%s%s\a' "${HOST}" "${PWD}" >&2 }
-    \\# OSC 7337: report PATH for popup commands
-    \\__attyx_report_path() { printf '\e]7337;set-path;%s\a' "$PATH" >&2 }
-    \\# Execute startup command after full shell init, then remove the hook
-    \\__attyx_startup() {
-    \\  __attyx_chpwd; __attyx_report_path
-    \\  if [[ -n "$__ATTYX_STARTUP_CMD" ]]; then
-    \\    local cmd="$__ATTYX_STARTUP_CMD"
-    \\    unset __ATTYX_STARTUP_CMD
-    \\    eval "$cmd"
-    \\  fi
-    \\}
-    \\__attyx_precmd() { __attyx_chpwd; __attyx_report_path }
-    \\# Run startup hook once on first prompt, then switch to normal precmd
-    \\__attyx_first_precmd() {
-    \\  __attyx_startup
-    \\  precmd_functions=(${precmd_functions:#__attyx_first_precmd} __attyx_precmd)
-    \\}
-    \\# Source user's .zshenv
-    \\[[ -f "$__ATTYX_ZDOTDIR/.zshenv" ]] && source "$__ATTYX_ZDOTDIR/.zshenv"
-    \\# Sensible history defaults — only set if user hasn't configured them.
-    \\# Without these, zsh defaults to SAVEHIST=0 (no history saved to disk).
-    \\[[ -z "$HISTFILE" ]] && export HISTFILE="$HOME/.zsh_history"
-    \\(( HISTSIZE <= 100 )) && HISTSIZE=10000
-    \\(( SAVEHIST <= 0 )) && SAVEHIST=10000
-    \\setopt APPEND_HISTORY SHARE_HISTORY HIST_IGNORE_DUPS 2>/dev/null
-    \\# Emit initial CWD report
-    \\__attyx_chpwd
-    \\
-;
-
-/// .zshrc wrapper — sources user's .zshrc, then re-installs hooks.
-/// This runs AFTER user's .zshrc, so hooks survive frameworks that
-/// reset precmd_functions / chpwd_functions (oh-my-zsh, etc.).
-pub const zsh_rc_script =
-    \\#!/bin/zsh
-    \\# Attyx shell integration (zsh .zshrc)
-    \\# Restore ZDOTDIR so subsequent zsh invocations use user's config
-    \\if [[ -n "$__ATTYX_ORIGINAL_ZDOTDIR" ]]; then
-    \\  ZDOTDIR="$__ATTYX_ORIGINAL_ZDOTDIR"
-    \\elif [[ -z "$__ATTYX_ORIGINAL_ZDOTDIR" ]]; then
-    \\  ZDOTDIR="$HOME"
-    \\fi
-    \\unset __ATTYX_ORIGINAL_ZDOTDIR
-    \\# Source user's .zshrc
-    \\[[ -f "$ZDOTDIR/.zshrc" ]] && source "$ZDOTDIR/.zshrc"
-    \\# Re-install hooks — user's .zshrc may have reset the arrays
-    \\[[ -z "${chpwd_functions[(r)__attyx_chpwd]}" ]] && chpwd_functions+=(__attyx_chpwd)
-    \\if [[ -z "${precmd_functions[(r)__attyx_precmd]}" ]] && [[ -z "${precmd_functions[(r)__attyx_first_precmd]}" ]]; then
-    \\  precmd_functions+=(__attyx_first_precmd)
-    \\fi
-    \\
-;
-
-/// .zprofile wrapper — sources user's .zprofile.
-pub const zsh_profile_script =
-    \\#!/bin/zsh
-    \\# Attyx shell integration (zsh .zprofile)
-    \\__ATTYX_ZDOTDIR="${__ATTYX_ORIGINAL_ZDOTDIR:-$HOME}"
-    \\[[ -f "$__ATTYX_ZDOTDIR/.zprofile" ]] && source "$__ATTYX_ZDOTDIR/.zprofile"
-    \\
-;
-
-/// .zlogin wrapper — sources user's .zlogin.
-pub const zsh_login_script =
-    \\#!/bin/zsh
-    \\# Attyx shell integration (zsh .zlogin)
-    \\[[ -f "$ZDOTDIR/.zlogin" ]] && source "$ZDOTDIR/.zlogin"
-    \\
-;
-
-pub const bash_script =
-    \\# Attyx shell integration (bash)
-    \\# Source the real rc files first
-    \\if [ -f /etc/profile ]; then . /etc/profile; fi
-    \\if [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc"; fi
-    \\# Append attyx bin dir to PATH
-    \\if [ -n "$__ATTYX_BIN_DIR" ] && [ "${PATH#*"$__ATTYX_BIN_DIR"}" = "$PATH" ]; then
-    \\  export PATH="$__ATTYX_BIN_DIR:$PATH"
-    \\fi
-    \\unset __ATTYX_BIN_DIR
-    \\# OSC 7: report cwd (stderr so --wait capture pipe doesn't eat it)
-    \\__attyx_chpwd() { printf '\e]7;file://%s%s\a' "$(hostname)" "$PWD" >&2; }
-    \\# OSC 7337: report PATH for popup commands
-    \\__attyx_report_path() { printf '\e]7337;set-path;%s\a' "$PATH" >&2; }
-    \\# Execute startup command on first prompt, then remove the hook
-    \\__attyx_first_prompt() {
-    \\  __attyx_chpwd; __attyx_report_path
-    \\  if [ -n "$__ATTYX_STARTUP_CMD" ]; then
-    \\    local cmd="$__ATTYX_STARTUP_CMD"
-    \\    unset __ATTYX_STARTUP_CMD
-    \\    eval "$cmd"
-    \\  fi
-    \\  PROMPT_COMMAND="__attyx_chpwd;__attyx_report_path${__ATTYX_ORIG_PC:+;$__ATTYX_ORIG_PC}"
-    \\  unset __ATTYX_ORIG_PC
-    \\}
-    \\__ATTYX_ORIG_PC="$PROMPT_COMMAND"
-    \\PROMPT_COMMAND="__attyx_first_prompt"
-    \\
-;
-
-pub const fish_script =
-    \\# Attyx shell integration (fish)
-    \\if set -q __ATTYX_BIN_DIR; and not contains $__ATTYX_BIN_DIR $PATH
-    \\  set -gx PATH $__ATTYX_BIN_DIR $PATH
-    \\end
-    \\set -e __ATTYX_BIN_DIR
-    \\# OSC 7: report cwd on directory changes and on every prompt
-    \\function __attyx_chpwd --on-variable PWD
-    \\  printf '\e]7;file://%s%s\a' (hostname) "$PWD" >&2
-    \\end
-    \\# Execute startup command on first prompt, then switch to normal hook
-    \\function __attyx_first_prompt --on-event fish_prompt
-    \\  __attyx_chpwd
-    \\  printf '\e]7337;set-path;%s\a' "$PATH" >&2
-    \\  if set -q __ATTYX_STARTUP_CMD
-    \\    set -l cmd $__ATTYX_STARTUP_CMD
-    \\    set -e __ATTYX_STARTUP_CMD
-    \\    eval $cmd
-    \\  end
-    \\  functions -e __attyx_first_prompt
-    \\end
-    \\# OSC 7337: report PATH for popup commands; also report CWD on prompt
-    \\function __attyx_report_path --on-event fish_prompt
-    \\  __attyx_chpwd
-    \\  printf '\e]7337;set-path;%s\a' "$PATH" >&2
-    \\end
-    \\__attyx_chpwd
-    \\
-;
-
-const nushell_script =
-    \\# Attyx shell integration (nushell)
-    \\$env.config = ($env.config? | default {} | merge {
-    \\  hooks: {
-    \\    pre_prompt: [{ ||
-    \\      # OSC 7: report cwd (stderr so --wait capture pipe doesn't eat it)
-    \\      print -ne $"\e]7;file://(sys host | get hostname)(pwd)\a"
-    \\      # OSC 7337: report PATH for popup commands
-    \\      print -ne $"\e]7337;set-path;($env.PATH | str join ':')\a"
-    \\      # Execute startup command on first prompt
-    \\      if ($env.__ATTYX_STARTUP_CMD? | is-not-empty) {
-    \\        let cmd = $env.__ATTYX_STARTUP_CMD
-    \\        hide-env __ATTYX_STARTUP_CMD
-    \\        nu -c $cmd
-    \\      }
-    \\    }]
-    \\  }
-    \\})
-    \\# Append attyx bin dir to PATH
-    \\if ($env.__ATTYX_BIN_DIR? | is-not-empty) {
-    \\  $env.PATH = ($env.PATH | prepend $env.__ATTYX_BIN_DIR)
-    \\  hide-env __ATTYX_BIN_DIR
-    \\}
-    \\
-;
+pub const zsh_script = posix_scripts.zsh_script;
+pub const zsh_rc_script = posix_scripts.zsh_rc_script;
+pub const zsh_profile_script = posix_scripts.zsh_profile_script;
+pub const zsh_login_script = posix_scripts.zsh_login_script;
+pub const bash_script = posix_scripts.bash_script;
+pub const fish_script = posix_scripts.fish_script;
+const nushell_script = posix_scripts.nushell_script;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/app/shell_scripts_posix.zig
+++ b/src/app/shell_scripts_posix.zig
@@ -1,0 +1,289 @@
+//! POSIX shell integration scripts (zsh/bash/fish/nushell), split out of
+//! shell_integration.zig to keep that module under the file-size limit. Mirrors
+//! the existing shell_scripts_windows.zig split. These are referenced (and some
+//! re-exported) from shell_integration.zig.
+
+pub const zsh_script =
+    \\#!/bin/zsh
+    \\# Attyx shell integration (zsh .zshenv)
+    \\# ZDOTDIR stays pointed at our integration dir so zsh also picks up
+    \\# our .zshrc wrapper (which re-installs hooks after user's .zshrc).
+    \\# Resolve user's original ZDOTDIR for sourcing their config files.
+    \\__ATTYX_ZDOTDIR="${__ATTYX_ORIGINAL_ZDOTDIR:-$HOME}"
+    \\if [[ -n "$__ATTYX_BIN_DIR" ]] && [[ ":$PATH:" != *":$__ATTYX_BIN_DIR:"* ]]; then
+    \\  export PATH="$__ATTYX_BIN_DIR:$PATH"
+    \\fi
+    \\unset __ATTYX_BIN_DIR
+    \\# OSC 7: report cwd on directory changes and on every prompt
+    \\# Write to stderr so OSC sequences reach the terminal even when stdout
+    \\# is redirected (e.g. --wait capture pipe).
+    \\__attyx_chpwd() { printf '\e]7;file://%s%s\a' "${HOST}" "${PWD}" >&2 }
+    \\# OSC 7337: report PATH for popup commands
+    \\__attyx_report_path() { printf '\e]7337;set-path;%s\a' "$PATH" >&2 }
+    \\# Agent status dot: Codex defers its launch hook to the first turn and has no
+    \\# exit hook, and an agent that's killed or Ctrl-C'd fires no stop/end hook. So
+    \\# drive the per-tab dot from the shell — idle when a known agent launches,
+    \\# cleared when it exits — as a backstop independent of each agent's own hooks.
+    \\__attyx_agent_name() {
+    \\  local -a words=(${(z)1}); local w base=""
+    \\  for w in $words; do
+    \\    case $w in (*=*) ;; (sudo|env|command|exec|nohup|nice|time|builtin) ;; (*) base=${w:t}; break ;; esac
+    \\  done
+    \\  case $base in (codex|claude|opencode) print -r -- $base ;; esac
+    \\}
+    \\__attyx_preexec() {
+    \\  __ATTYX_AGENT=$(__attyx_agent_name "$1")
+    \\  [[ -n $__ATTYX_AGENT ]] && printf '\e]7337;agent-status;agent;idle\a' >&2
+    \\}
+    \\__attyx_agent_clear() {
+    \\  [[ -n $__ATTYX_AGENT ]] || return
+    \\  printf '\e]7337;agent-status;agent;none\a' >&2; __ATTYX_AGENT=""
+    \\}
+    \\# Execute startup command after full shell init, then remove the hook
+    \\__attyx_startup() {
+    \\  __attyx_chpwd; __attyx_report_path
+    \\  if [[ -n "$__ATTYX_STARTUP_CMD" ]]; then
+    \\    local cmd="$__ATTYX_STARTUP_CMD"
+    \\    unset __ATTYX_STARTUP_CMD
+    \\    eval "$cmd"
+    \\  fi
+    \\}
+    \\__attyx_precmd() { __attyx_agent_clear; __attyx_chpwd; __attyx_report_path }
+    \\# Run startup hook once on first prompt, then switch to normal precmd
+    \\__attyx_first_precmd() {
+    \\  __attyx_startup
+    \\  precmd_functions=(${precmd_functions:#__attyx_first_precmd} __attyx_precmd)
+    \\}
+    \\# Source user's .zshenv
+    \\[[ -f "$__ATTYX_ZDOTDIR/.zshenv" ]] && source "$__ATTYX_ZDOTDIR/.zshenv"
+    \\# Sensible history defaults — only set if user hasn't configured them.
+    \\# Without these, zsh defaults to SAVEHIST=0 (no history saved to disk).
+    \\[[ -z "$HISTFILE" ]] && export HISTFILE="$HOME/.zsh_history"
+    \\(( HISTSIZE <= 100 )) && HISTSIZE=10000
+    \\(( SAVEHIST <= 0 )) && SAVEHIST=10000
+    \\setopt APPEND_HISTORY SHARE_HISTORY HIST_IGNORE_DUPS 2>/dev/null
+    \\# Emit initial CWD report
+    \\__attyx_chpwd
+    \\
+;
+
+/// .zshrc wrapper — sources user's .zshrc, then re-installs hooks.
+/// This runs AFTER user's .zshrc, so hooks survive frameworks that
+/// reset precmd_functions / chpwd_functions (oh-my-zsh, etc.).
+pub const zsh_rc_script =
+    \\#!/bin/zsh
+    \\# Attyx shell integration (zsh .zshrc)
+    \\# Restore ZDOTDIR so subsequent zsh invocations use user's config
+    \\if [[ -n "$__ATTYX_ORIGINAL_ZDOTDIR" ]]; then
+    \\  ZDOTDIR="$__ATTYX_ORIGINAL_ZDOTDIR"
+    \\elif [[ -z "$__ATTYX_ORIGINAL_ZDOTDIR" ]]; then
+    \\  ZDOTDIR="$HOME"
+    \\fi
+    \\unset __ATTYX_ORIGINAL_ZDOTDIR
+    \\# Source user's .zshrc
+    \\[[ -f "$ZDOTDIR/.zshrc" ]] && source "$ZDOTDIR/.zshrc"
+    \\# Re-install hooks — user's .zshrc may have reset the arrays
+    \\[[ -z "${chpwd_functions[(r)__attyx_chpwd]}" ]] && chpwd_functions+=(__attyx_chpwd)
+    \\if [[ -z "${precmd_functions[(r)__attyx_precmd]}" ]] && [[ -z "${precmd_functions[(r)__attyx_first_precmd]}" ]]; then
+    \\  precmd_functions+=(__attyx_first_precmd)
+    \\fi
+    \\[[ -z "${preexec_functions[(r)__attyx_preexec]}" ]] && preexec_functions+=(__attyx_preexec)
+    \\
+;
+
+/// .zprofile wrapper — sources user's .zprofile.
+pub const zsh_profile_script =
+    \\#!/bin/zsh
+    \\# Attyx shell integration (zsh .zprofile)
+    \\__ATTYX_ZDOTDIR="${__ATTYX_ORIGINAL_ZDOTDIR:-$HOME}"
+    \\[[ -f "$__ATTYX_ZDOTDIR/.zprofile" ]] && source "$__ATTYX_ZDOTDIR/.zprofile"
+    \\
+;
+
+/// .zlogin wrapper — sources user's .zlogin.
+pub const zsh_login_script =
+    \\#!/bin/zsh
+    \\# Attyx shell integration (zsh .zlogin)
+    \\[[ -f "$ZDOTDIR/.zlogin" ]] && source "$ZDOTDIR/.zlogin"
+    \\
+;
+
+pub const bash_script =
+    \\# Attyx shell integration (bash)
+    \\# Source the real rc files first
+    \\if [ -f /etc/profile ]; then . /etc/profile; fi
+    \\if [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc"; fi
+    \\# Append attyx bin dir to PATH
+    \\if [ -n "$__ATTYX_BIN_DIR" ] && [ "${PATH#*"$__ATTYX_BIN_DIR"}" = "$PATH" ]; then
+    \\  export PATH="$__ATTYX_BIN_DIR:$PATH"
+    \\fi
+    \\unset __ATTYX_BIN_DIR
+    \\# OSC 7: report cwd (stderr so --wait capture pipe doesn't eat it)
+    \\__attyx_chpwd() { printf '\e]7;file://%s%s\a' "$(hostname)" "$PWD" >&2; }
+    \\# OSC 7337: report PATH for popup commands
+    \\__attyx_report_path() { printf '\e]7337;set-path;%s\a' "$PATH" >&2; }
+    \\# Agent status dot: Codex defers its launch hook to the first turn and has no
+    \\# exit hook, and an agent that's killed or Ctrl-C'd fires no stop/end hook. So
+    \\# drive the per-tab dot from the shell — idle when a known agent launches (a
+    \\# DEBUG trap, the bash preexec), cleared on the next prompt — as a backstop
+    \\# independent of each agent's own hooks.
+    \\__attyx_agent_name() {
+    \\  local -a arr; local tok first="" base; read -ra arr <<< "$1"
+    \\  for tok in "${arr[@]}"; do
+    \\    case $tok in *=*) ;; sudo|env|command|exec|nohup|nice|time|builtin) ;; *) first=$tok; break ;; esac
+    \\  done
+    \\  base=${first##*/}
+    \\  case $base in codex|claude|opencode) printf '%s' "$base" ;; esac
+    \\}
+    \\__attyx_preexec() {
+    \\  [ -n "$COMP_LINE" ] && return
+    \\  # The DEBUG trap fires for every command; skip our own hooks and bail before
+    \\  # the agent_name subshell unless an agent name actually appears.
+    \\  case "$BASH_COMMAND" in __attyx_*) return ;; *codex*|*claude*|*opencode*) ;; *) return ;; esac
+    \\  local a; a=$(__attyx_agent_name "$BASH_COMMAND")
+    \\  [ -n "$a" ] && { __ATTYX_AGENT=$a; printf '\e]7337;agent-status;agent;idle\a' >&2; }
+    \\}
+    \\__attyx_agent_clear() {
+    \\  [ -n "$__ATTYX_AGENT" ] || return
+    \\  printf '\e]7337;agent-status;agent;none\a' >&2; __ATTYX_AGENT=
+    \\}
+    \\# Execute startup command on first prompt, then remove the hook
+    \\__attyx_first_prompt() {
+    \\  __attyx_agent_clear; __attyx_chpwd; __attyx_report_path
+    \\  if [ -n "$__ATTYX_STARTUP_CMD" ]; then
+    \\    local cmd="$__ATTYX_STARTUP_CMD"
+    \\    unset __ATTYX_STARTUP_CMD
+    \\    eval "$cmd"
+    \\  fi
+    \\  PROMPT_COMMAND="__attyx_agent_clear;__attyx_chpwd;__attyx_report_path${__ATTYX_ORIG_PC:+;$__ATTYX_ORIG_PC}"
+    \\  unset __ATTYX_ORIG_PC
+    \\}
+    \\__ATTYX_ORIG_PC="$PROMPT_COMMAND"
+    \\PROMPT_COMMAND="__attyx_first_prompt"
+    \\# Install the preexec DEBUG trap only if the user hasn't set one (bash allows
+    \\# a single DEBUG trap; clobbering theirs could break their setup).
+    \\[ -z "$(trap -p DEBUG)" ] && trap '__attyx_preexec' DEBUG
+    \\
+;
+
+pub const fish_script =
+    \\# Attyx shell integration (fish)
+    \\if set -q __ATTYX_BIN_DIR; and not contains $__ATTYX_BIN_DIR $PATH
+    \\  set -gx PATH $__ATTYX_BIN_DIR $PATH
+    \\end
+    \\set -e __ATTYX_BIN_DIR
+    \\# OSC 7: report cwd on directory changes and on every prompt
+    \\function __attyx_chpwd --on-variable PWD
+    \\  printf '\e]7;file://%s%s\a' (hostname) "$PWD" >&2
+    \\end
+    \\# Execute startup command on first prompt, then switch to normal hook
+    \\function __attyx_first_prompt --on-event fish_prompt
+    \\  __attyx_chpwd
+    \\  printf '\e]7337;set-path;%s\a' "$PATH" >&2
+    \\  if set -q __ATTYX_STARTUP_CMD
+    \\    set -l cmd $__ATTYX_STARTUP_CMD
+    \\    set -e __ATTYX_STARTUP_CMD
+    \\    eval $cmd
+    \\  end
+    \\  functions -e __attyx_first_prompt
+    \\end
+    \\# OSC 7337: report PATH for popup commands; also report CWD on prompt
+    \\function __attyx_report_path --on-event fish_prompt
+    \\  __attyx_chpwd
+    \\  printf '\e]7337;set-path;%s\a' "$PATH" >&2
+    \\end
+    \\# Agent status dot: Codex defers its launch hook to the first turn and has no
+    \\# exit hook, and an agent that's killed or Ctrl-C'd fires no stop/end hook. So
+    \\# drive the per-tab dot from the shell — idle when a known agent launches,
+    \\# cleared when it exits — as a backstop independent of each agent's own hooks.
+    \\function __attyx_agent_name --argument-names cmd
+    \\  set -l first ""
+    \\  for w in (string split -n -- ' ' $cmd)
+    \\    string match -q '*=*' -- $w; and continue
+    \\    contains -- $w sudo env command exec nohup nice time builtin; and continue
+    \\    set first $w; break
+    \\  end
+    \\  test -n "$first"; or return
+    \\  set -l base (string split -- / $first)[-1]
+    \\  contains -- $base codex claude opencode; and echo $base
+    \\end
+    \\function __attyx_preexec --on-event fish_preexec
+    \\  set -g __ATTYX_AGENT (__attyx_agent_name $argv[1])
+    \\  test -n "$__ATTYX_AGENT"; and printf '\e]7337;agent-status;agent;idle\a' >&2
+    \\end
+    \\function __attyx_postexec --on-event fish_postexec
+    \\  test -n "$__ATTYX_AGENT"; or return
+    \\  printf '\e]7337;agent-status;agent;none\a' >&2
+    \\  set -e __ATTYX_AGENT
+    \\end
+    \\__attyx_chpwd
+    \\
+;
+
+pub const nushell_script =
+    \\# Attyx shell integration (nushell)
+    \\$env.config = ($env.config? | default {} | merge {
+    \\  hooks: {
+    \\    pre_prompt: [{ ||
+    \\      # Agent status dot: clear it when a known agent that we flagged on launch
+    \\      # has exited (Codex/an interrupted agent fires no exit hook of its own).
+    \\      if ($env.__ATTYX_AGENT? | is-not-empty) {
+    \\        print -ne $"\e]7337;agent-status;agent;none\a"
+    \\        hide-env __ATTYX_AGENT
+    \\      }
+    \\      # OSC 7: report cwd (stderr so --wait capture pipe doesn't eat it)
+    \\      print -ne $"\e]7;file://(sys host | get hostname)(pwd)\a"
+    \\      # OSC 7337: report PATH for popup commands
+    \\      print -ne $"\e]7337;set-path;($env.PATH | str join ':')\a"
+    \\      # Execute startup command on first prompt
+    \\      if ($env.__ATTYX_STARTUP_CMD? | is-not-empty) {
+    \\        let cmd = $env.__ATTYX_STARTUP_CMD
+    \\        hide-env __ATTYX_STARTUP_CMD
+    \\        nu -c $cmd
+    \\      }
+    \\    }]
+    \\    # Show the dot as idle the moment a known agent launches (Codex defers its
+    \\    # own launch hook to the first turn, so the dot would otherwise be blank).
+    \\    pre_execution: [{ ||
+    \\      let words = ((commandline) | split row ' '
+    \\        | where {|w| $w !~ '=' }
+    \\        | where {|w| $w not-in ['sudo' 'env' 'command' 'exec' 'nohup' 'nice' 'time' 'builtin'] })
+    \\      let agent = (if ($words | is-empty) { '' } else {
+    \\        let base = ($words | first | path basename)
+    \\        if $base in ['codex' 'claude' 'opencode'] { $base } else { '' }
+    \\      })
+    \\      if ($agent | is-not-empty) {
+    \\        $env.__ATTYX_AGENT = $agent
+    \\        print -ne $"\e]7337;agent-status;agent;idle\a"
+    \\      }
+    \\    }]
+    \\  }
+    \\})
+    \\# Append attyx bin dir to PATH
+    \\if ($env.__ATTYX_BIN_DIR? | is-not-empty) {
+    \\  $env.PATH = ($env.PATH | prepend $env.__ATTYX_BIN_DIR)
+    \\  hide-env __ATTYX_BIN_DIR
+    \\}
+    \\
+;
+
+const std = @import("std");
+const testing = std.testing;
+
+// Every standalone-launching POSIX script must emit the agent-status dot OSC on
+// launch (idle) and clear it (none), and detect the three agents. Guards against
+// a future edit silently dropping the lifecycle hooks from one shell.
+test "each posix script drives the agent-status dot for all agents" {
+    const launchers = [_][]const u8{ zsh_script, bash_script, fish_script, nushell_script };
+    for (launchers) |s| {
+        try testing.expect(std.mem.indexOf(u8, s, "agent-status;agent;idle") != null);
+        try testing.expect(std.mem.indexOf(u8, s, "agent-status;agent;none") != null);
+        for ([_][]const u8{ "codex", "claude", "opencode" }) |agent|
+            try testing.expect(std.mem.indexOf(u8, s, agent) != null);
+    }
+}
+
+test "zsh registers the preexec hook and bash installs a DEBUG trap" {
+    try testing.expect(std.mem.indexOf(u8, zsh_rc_script, "preexec_functions+=(__attyx_preexec)") != null);
+    try testing.expect(std.mem.indexOf(u8, bash_script, "trap '__attyx_preexec' DEBUG") != null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -351,6 +351,7 @@ test {
         _ = @import("app/agent_integration.zig");
         _ = @import("app/agent_integration_codex.zig");
         _ = @import("app/agent_integration_opencode.zig");
+        _ = @import("app/shell_scripts_posix.zig");
     }
 }
 


### PR DESCRIPTION
## Problem

Two gaps in the per-tab agent-status dot, both because it relied solely on each agent's own lifecycle hooks:

1. **No dot on launch for Codex.** Codex enqueues its `SessionStart` hook as *pending* and only runs it on the first turn, so a freshly-launched Codex shows no dot until you send a prompt.
2. **The dot never clears on exit.** Codex has no `SessionEnd` hook at all, and any agent (Claude/Codex/opencode) that's killed or `Ctrl-C`'d fires no stop/end hook — so the dot gets stuck.

## Fix

Drive the dot from the **shell integration** as a backstop independent of the agents' own hooks (the same OSC `7337;agent-status` flow):

- **Launch** → emit `idle` when a known agent (`codex`/`claude`/`opencode`) is the command being run.
- **Exit** → emit `none` when it finishes and the prompt returns.

Implemented for all four shells using each one's native lifecycle hook:

| Shell | launch | clear |
|-------|--------|-------|
| zsh | `preexec_functions` | `precmd_functions` |
| bash | `DEBUG` trap | `PROMPT_COMMAND` |
| fish | `fish_preexec` | `fish_postexec` |
| nushell | `pre_execution` | `pre_prompt` |

Detection matches the **first real command word's basename**, skipping env assignments (`FOO=bar`) and wrappers (`sudo`/`env`/`command`/…), so `echo codex` or `git commit -m codex` don't trigger it, and `claude-extra` is rejected. The agents' own hooks still drive `working`/`input` during a session — this only backstops the launch and exit edges.

Safety:
- The bash `DEBUG` trap is installed only if the user has none (bash allows a single DEBUG trap), and short-circuits before the detection subshell unless an agent name is actually present, to stay cheap on the per-command hot path.
- All config writes preserve the user's existing hooks/PROMPT_COMMAND.

## Refactor

The POSIX shell-script constants move into a new `shell_scripts_posix.zig` (mirroring the existing `shell_scripts_windows.zig` split) so `shell_integration.zig` stays under the file-size limit; the constants are re-exported, so external references are unchanged.

## Testing

Validated each shell's real embedded script by running it with a fake agent and capturing the OSC:
- zsh, bash, fish: correct `idle` on launch + `none` on exit; non-agent commands and `claude-extra` correctly ignored.
- nushell: detection logic + config-load verified; `commandline` API per the docs.
- All five embedded scripts pass their shell's syntax check (`zsh -n`, `bash -n`, `fish --no-execute`, `nu` source).
- New Zig regression tests assert every script carries the idle/none OSC, detects all three agents, and that zsh registers `preexec` / bash installs the DEBUG trap.
- `zig build test`: 1155/1156; the one failure is a pre-existing flaky daemon timeout (fails on `main` too, unrelated).