### PR TITLE
Add send_image: inject an image into a pane over IPC/CLI/MCP

### DIFF
--- a/src/config/cli_help.zig
+++ b/src/config/cli_help.zig
@@ -139,7 +139,7 @@ const options =
     opt("--cell-width <value>       ", "Cell width: points or percent (e.g. \"110%\")") ++
     opt("--cell-height <value>      ", "Cell height: points or percent (e.g. \"115%\")") ++
     opt("--theme <string>           ", "Theme name (default: \"default\")") ++
-    opt("--scrollback-lines <int>   ", "Scrollback buffer lines (default: 20000)") ++
+    opt("--scrollback-lines <int>   ", "Scrollback buffer lines (default: 5000)") ++
     opt("--reflow / --no-reflow     ", "Enable/disable reflow on resize") ++
     opt("--cursor-shape <shape>     ", "Cursor shape: block, beam, underline") ++
     opt("--cursor-blink             ", "Enable cursor blinking " ++ d ++ "(--no-cursor-blink to disable)" ++ r) ++

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -33,6 +33,7 @@ pub const IpcCommand = enum {
     focus_left,
     focus_right,
     send_keys,
+    send_image,
     get_text,
     config_reload,
     theme_set,

--- a/src/config/default_config.toml
+++ b/src/config/default_config.toml
@@ -197,7 +197,7 @@
 
 [splits]
 
-# Pixels per step when resizing panes. Range: 1-50.  [live]
+# Cells per step when resizing panes. Range: 1-50.  [live]
 # resize_step = 4
 
 
@@ -404,7 +404,7 @@
 # [[popup]]
 # hotkey = "ctrl+shift+g"      # Key combo to toggle this popup
 # command = "lazygit"           # Command to run inside the popup
-# width = "80%"                 # Popup width (percentage or pixels)
+# width = "80%"                 # Popup width (percentage of terminal)
 # height = "80%"               # Popup height
 # border = "single"            # Border style: "single", "double", "rounded", "heavy", "none"
 # border_color = "#78829a"     # Border color, hex "#RRGGBB"

--- a/src/ipc/client.zig
+++ b/src/ipc/client.zig
@@ -414,6 +414,16 @@ pub fn buildRequest(buf: []u8, parsed: @import("../config/cli_ipc.zig").IpcReque
 
             break :blk protocol.encodeMessage(buf, .send_keys, processed);
         },
+        // payload: [pane_id:u32 LE (0=active)][utf8 file path]. The path is
+        // sent verbatim — quoting + bracketed-paste wrapping happen in the
+        // instance handler, which knows the target pane's paste mode.
+        .send_image => blk: {
+            var payload_buf: [4 + 4080]u8 = undefined;
+            std.mem.writeInt(u32, payload_buf[0..4], parsed.pane_id, .little);
+            const plen = @min(parsed.text_arg.len, payload_buf.len - 4);
+            @memcpy(payload_buf[4 .. 4 + plen], parsed.text_arg[0..plen]);
+            break :blk protocol.encodeMessage(buf, .send_image, payload_buf[0 .. 4 + plen]);
+        },
         .get_text => blk: {
             if (parsed.pane_id != 0) {
                 var payload: [8]u8 = undefined;

--- a/src/ipc/handler.zig
+++ b/src/ipc/handler.zig
@@ -211,6 +211,7 @@ pub fn handle(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
             sendInputToPane(pane, text, ctx);
             sendOk(cmd, "");
         },
+        .send_image => handleSendImage(cmd, ctx),
         .get_text => handler_query.buildGetText(cmd, ctx),
         .get_text_pane => handler_query.buildGetTextPane(cmd, ctx),
 
@@ -299,6 +300,47 @@ fn sendInputToPane(pane: *Pane, text: []const u8, ctx: *PtyThreadCtx) void {
         };
         offset += n;
     }
+}
+
+// ---------------------------------------------------------------------------
+// Image attach — inject a quoted file path as a (bracketed) paste, exactly as
+// a native file drag-and-drop does, so TUIs like Claude Code attach the image.
+// ---------------------------------------------------------------------------
+
+const image_paste = @import("image_paste.zig");
+
+fn handleSendImage(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
+    if (cmd.payload_len < 4) {
+        sendError(cmd, "missing pane ID");
+        return;
+    }
+    const pane_id = std.mem.readInt(u32, cmd.payload[0..4], .little);
+    const path = cmd.payload[4..cmd.payload_len];
+    if (path.len == 0) {
+        sendError(cmd, "missing image path");
+        return;
+    }
+
+    var out: [2 * std.fs.max_path_bytes + 16]u8 = undefined;
+    if (pane_id == 0) {
+        const pane = ctx.tab_mgr.activePane();
+        const bytes = image_paste.buildPaste(pane.engine.state.bracketed_paste, path, &out) catch {
+            sendError(cmd, "image path too long");
+            return;
+        };
+        sendInputToActivePty(bytes);
+    } else {
+        const pane = ctx.tab_mgr.findPaneById(pane_id) orelse {
+            sendError(cmd, "pane not found");
+            return;
+        };
+        const bytes = image_paste.buildPaste(pane.engine.state.bracketed_paste, path, &out) catch {
+            sendError(cmd, "image path too long");
+            return;
+        };
+        sendInputToPane(pane, bytes, ctx);
+    }
+    sendOk(cmd, "");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ipc/handler_windows.zig
+++ b/src/ipc/handler_windows.zig
@@ -15,6 +15,7 @@ const WinCtx = event_loop.WinCtx;
 const Pane = @import("../app/pane.zig").Pane;
 const session_win = @import("../app/session_windows.zig");
 const tab_rename = @import("tab_rename.zig");
+const image_paste = @import("image_paste.zig");
 
 extern fn attyx_dispatch_action(action_raw: u8) u8;
 extern fn attyx_send_input(bytes: [*]const u8, len: c_int) void;
@@ -147,6 +148,38 @@ pub fn handle(cmd: *queue.IpcCommand, ctx: *WinCtx) void {
                 return;
             };
             _ = pane.pty.writeToPty(text) catch {};
+            sendOk(cmd, "");
+        },
+        .send_image => {
+            if (cmd.payload_len < 4) {
+                sendError(cmd, "missing pane ID");
+                return;
+            }
+            const pane_id = std.mem.readInt(u32, cmd.payload[0..4], .little);
+            const path = cmd.payload[4..cmd.payload_len];
+            if (path.len == 0) {
+                sendError(cmd, "missing image path");
+                return;
+            }
+            var out: [2 * std.fs.max_path_bytes + 16]u8 = undefined;
+            if (pane_id == 0) {
+                const pane = ctx.tab_mgr.activePane();
+                const bytes = image_paste.buildPaste(pane.engine.state.bracketed_paste, path, &out) catch {
+                    sendError(cmd, "image path too long");
+                    return;
+                };
+                attyx_send_input(bytes.ptr, @intCast(bytes.len));
+            } else {
+                const pane = ctx.tab_mgr.findPaneById(pane_id) orelse {
+                    sendError(cmd, "pane not found");
+                    return;
+                };
+                const bytes = image_paste.buildPaste(pane.engine.state.bracketed_paste, path, &out) catch {
+                    sendError(cmd, "image path too long");
+                    return;
+                };
+                _ = pane.pty.writeToPty(bytes) catch {};
+            }
             sendOk(cmd, "");
         },
         .get_text => {

--- a/src/ipc/image_paste.zig
+++ b/src/ipc/image_paste.zig
@@ -1,0 +1,100 @@
+// Attyx — image drag/paste payload builder
+//
+// Builds the exact byte sequence that dropping an image file onto a pane
+// produces: the shell-quoted file path, optionally wrapped in bracketed-paste
+// markers. This mirrors the native drag-and-drop handler (macos_input_ime.m)
+// so a path injected over IPC is indistinguishable from a real drop — which is
+// how TUIs like Claude Code pick up an image attachment.
+//
+// Pure and allocation-free: takes a caller buffer, returns a slice of it.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const input = @import("attyx").input;
+
+pub const Error = error{BufferTooSmall};
+
+/// Shell-quote a file path so it survives as a single token. POSIX wraps in
+/// single quotes, escaping embedded quotes as '\''; Windows wraps in double
+/// quotes (image paths rarely contain a literal '"', so no escaping is done).
+pub fn quotePath(path: []const u8, out: []u8) Error![]const u8 {
+    const q: u8 = if (builtin.os.tag == .windows) '"' else '\'';
+    var n: usize = 0;
+    if (n >= out.len) return error.BufferTooSmall;
+    out[n] = q;
+    n += 1;
+    if (builtin.os.tag == .windows) {
+        if (n + path.len > out.len) return error.BufferTooSmall;
+        @memcpy(out[n..][0..path.len], path);
+        n += path.len;
+    } else {
+        for (path) |c| {
+            if (c == '\'') {
+                const esc = "'\\''"; // ' -> '\''
+                if (n + esc.len > out.len) return error.BufferTooSmall;
+                @memcpy(out[n..][0..esc.len], esc);
+                n += esc.len;
+            } else {
+                if (n >= out.len) return error.BufferTooSmall;
+                out[n] = c;
+                n += 1;
+            }
+        }
+    }
+    if (n >= out.len) return error.BufferTooSmall;
+    out[n] = q;
+    n += 1;
+    return out[0..n];
+}
+
+/// Build the full injection payload: the quoted path, wrapped in bracketed
+/// paste when the target pane has it enabled. Writes into `out`.
+pub fn buildPaste(bracketed: bool, path: []const u8, out: []u8) Error![]const u8 {
+    var qbuf: [2 * std.fs.max_path_bytes + 2]u8 = undefined;
+    const quoted = try quotePath(path, &qbuf);
+    return input.wrapPaste(bracketed, quoted, out);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "quotePath wraps a plain path" {
+    var buf: [256]u8 = undefined;
+    const q = try quotePath("/tmp/shot.png", &buf);
+    if (builtin.os.tag == .windows) {
+        try std.testing.expectEqualStrings("\"/tmp/shot.png\"", q);
+    } else {
+        try std.testing.expectEqualStrings("'/tmp/shot.png'", q);
+    }
+}
+
+test "quotePath escapes embedded single quote (posix)" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    var buf: [256]u8 = undefined;
+    const q = try quotePath("/tmp/it's.png", &buf);
+    try std.testing.expectEqualStrings("'/tmp/it'\\''s.png'", q);
+}
+
+test "buildPaste wraps in bracketed paste when enabled" {
+    var buf: [256]u8 = undefined;
+    const b = try buildPaste(true, "/a/b.png", &buf);
+    const q: u8 = if (builtin.os.tag == .windows) '"' else '\'';
+    var expected: [256]u8 = undefined;
+    const e = std.fmt.bufPrint(&expected, "\x1b[200~{c}/a/b.png{c}\x1b[201~", .{ q, q }) catch unreachable;
+    try std.testing.expectEqualStrings(e, b);
+}
+
+test "buildPaste omits markers when bracketed paste disabled" {
+    var buf: [256]u8 = undefined;
+    const b = try buildPaste(false, "/a/b.png", &buf);
+    const q: u8 = if (builtin.os.tag == .windows) '"' else '\'';
+    var expected: [256]u8 = undefined;
+    const e = std.fmt.bufPrint(&expected, "{c}/a/b.png{c}", .{ q, q }) catch unreachable;
+    try std.testing.expectEqualStrings(e, b);
+}
+
+test "quotePath reports BufferTooSmall" {
+    var buf: [4]u8 = undefined;
+    try std.testing.expectError(error.BufferTooSmall, quotePath("/too/long/path", &buf));
+}

--- a/src/ipc/mcp.zig
+++ b/src/ipc/mcp.zig
@@ -94,8 +94,17 @@ fn handleToolCall(a: std.mem.Allocator, params_opt: ?std.json.Value, id: ?std.js
     else
         null;
 
-    const req = mcp_tools.fill(name_v.string, args) orelse
-        return respondError(a, id, -32602, "unknown tool or missing required argument");
+    // send_image may carry inline base64 → materialize a temp file first; it
+    // needs an allocator + filesystem, so it lives outside the pure fill().
+    const req: @import("../config/cli_ipc.zig").IpcRequest = if (std.mem.eql(u8, name_v.string, "send_image"))
+        mcp_tools.fillSendImage(a, args) catch |e| return respondError(a, id, -32602, switch (e) {
+            error.MissingSource => "send_image requires 'path' or 'data'",
+            error.DecodeFailed => "send_image: invalid base64 data",
+            error.WriteFailed => "send_image: failed to write temp image file",
+        })
+    else
+        mcp_tools.fill(name_v.string, args) orelse
+            return respondError(a, id, -32602, "unknown tool or missing required argument");
 
     const out = callIpc(a, req);
     const text_json = std.json.Stringify.valueAlloc(a, std.json.Value{ .string = out.text }, .{}) catch "\"\"";

--- a/src/ipc/mcp_tools.zig
+++ b/src/ipc/mcp_tools.zig
@@ -10,6 +10,7 @@
 // ponytail: poll list_agents; add MCP notifications if push latency matters.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const cli_ipc = @import("../config/cli_ipc.zig");
 const IpcRequest = cli_ipc.IpcRequest;
 
@@ -26,6 +27,7 @@ const TOOLS_RAW =
     \\{"name":"list_agents","description":"List AI agents running in panes and their status (working, input_requested, idle...). Returns JSON.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Restrict to one pane id."},"session":{"type":"integer"}}}},
     \\{"name":"get_text","description":"Capture visible screen text of a pane. With 'lines', captures that many trailing rows from scrollback.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"lines":{"type":"integer","description":"Trailing rows to capture (omit for visible screen)."},"session":{"type":"integer"}}}},
     \\{"name":"send_keys","description":"Send keystrokes/text to a pane. Supports C-style escapes (\\n, \\t, \\x03) and named keys like {Enter} {Down}.","inputSchema":{"type":"object","properties":{"text":{"type":"string"},"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"session":{"type":"integer"}},"required":["text"]}},
+    \\{"name":"send_image","description":"Attach an image to a pane as if a file were dragged/pasted into the terminal (e.g. to give Claude Code a screenshot). Provide either 'path' (an image file already on disk) or 'data' (base64-encoded image bytes, materialized to a temp file). The image's file path is injected as a bracketed paste; Enter is NOT pressed.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute path to an image file on disk."},"data":{"type":"string","description":"Base64-encoded image bytes (used when no path is available)."},"filename":{"type":"string","description":"Optional original filename; its extension names the temp file when using 'data'."},"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"session":{"type":"integer"}}}},
     \\{"name":"focus","description":"Move keyboard focus between panes.","inputSchema":{"type":"object","properties":{"direction":{"type":"string","enum":["up","down","left","right"]},"session":{"type":"integer"}},"required":["direction"]}},
     \\{"name":"scroll","description":"Scroll the focused pane.","inputSchema":{"type":"object","properties":{"to":{"type":"string","enum":["top","bottom","page_up","page_down"]},"session":{"type":"integer"}},"required":["to"]}},
     \\{"name":"tab_create","description":"Open a new tab, optionally running a command. With wait=true, blocks until the command exits and returns its exit code + output.","inputSchema":{"type":"object","properties":{"command":{"type":"string"},"wait":{"type":"boolean"},"session":{"type":"integer"}}}},
@@ -197,6 +199,83 @@ pub fn fill(name: []const u8, args: ?std.json.ObjectMap) ?IpcRequest {
 }
 
 // ---------------------------------------------------------------------------
+// send_image: resolve a `path` or materialize base64 `data` to a temp file.
+// Kept separate from fill() because it needs an allocator + filesystem access,
+// which fill() (a pure name→request mapper) deliberately avoids.
+// ---------------------------------------------------------------------------
+
+pub const ImageError = error{ MissingSource, DecodeFailed, WriteFailed };
+
+/// Build a send_image request. With `path`, the existing file is used as-is.
+/// With base64 `data`, the bytes are decoded and written to a temp file whose
+/// path is returned. The request's text_arg (the path) is allocated in `a`.
+pub fn fillSendImage(a: std.mem.Allocator, args: ?std.json.ObjectMap) ImageError!IpcRequest {
+    var r = IpcRequest{
+        .command = .send_image,
+        .target_session = u32Of(args, "session"),
+        .pane_id = u32Of(args, "pane"),
+    };
+
+    if (getStr(args, "path")) |p| {
+        if (p.len == 0) return error.MissingSource;
+        r.text_arg = a.dupe(u8, p) catch return error.WriteFailed;
+        return r;
+    }
+
+    const data = getStr(args, "data") orelse return error.MissingSource;
+    r.text_arg = try materializeBase64(a, data, getStr(args, "filename"));
+    return r;
+}
+
+/// Decode base64 image bytes (tolerating embedded whitespace) and write them to
+/// a uniquely-named temp file, returning its absolute path (allocated in `a`).
+fn materializeBase64(a: std.mem.Allocator, data: []const u8, filename: ?[]const u8) ImageError![]const u8 {
+    // Strip whitespace some encoders insert (line-wrapped base64) before decode.
+    const clean = a.alloc(u8, data.len) catch return error.WriteFailed;
+    var cn: usize = 0;
+    for (data) |c| {
+        if (c == '\n' or c == '\r' or c == ' ' or c == '\t') continue;
+        clean[cn] = c;
+        cn += 1;
+    }
+    const src = clean[0..cn];
+
+    const decoder = std.base64.standard.Decoder;
+    const n = decoder.calcSizeForSlice(src) catch return error.DecodeFailed;
+    const bytes = a.alloc(u8, n) catch return error.WriteFailed;
+    decoder.decode(bytes, src) catch return error.DecodeFailed;
+
+    const ext = extOf(filename);
+    var rnd: [8]u8 = undefined;
+    std.crypto.random.bytes(&rnd);
+    const hex = std.fmt.bytesToHex(rnd, .lower);
+    const sep: []const u8 = if (builtin.os.tag == .windows) "\\" else "/";
+    const path = std.fmt.allocPrint(a, "{s}{s}attyx-img-{s}{s}", .{
+        tmpDir(), sep, &hex, ext,
+    }) catch return error.WriteFailed;
+
+    const file = std.fs.createFileAbsolute(path, .{}) catch return error.WriteFailed;
+    defer file.close();
+    file.writeAll(bytes) catch return error.WriteFailed;
+    return path;
+}
+
+fn tmpDir() []const u8 {
+    if (builtin.os.tag == .windows) return std.posix.getenv("TEMP") orelse "C:\\Windows\\Temp";
+    return std.posix.getenv("TMPDIR") orelse "/tmp";
+}
+
+/// Pick a file extension (including the dot) from the original filename, or
+/// default to .png. Claude Code keys image detection off the path's extension.
+fn extOf(filename: ?[]const u8) []const u8 {
+    const f = filename orelse return ".png";
+    const dot = std.mem.lastIndexOfScalar(u8, f, '.') orelse return ".png";
+    const ext = f[dot..];
+    if (ext.len < 2 or ext.len > 6) return ".png";
+    return ext;
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -228,6 +307,46 @@ test "fill rejects send_keys without text" {
 
 test "fill rejects unknown tool" {
     try std.testing.expect(fill("nope", null) == null);
+}
+
+test "fillSendImage with path passes it through" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var p = argsFrom(arena.allocator(), "{\"path\":\"/tmp/shot.png\",\"pane\":4}");
+    defer p.deinit();
+    const r = try fillSendImage(arena.allocator(), p.value.object);
+    try std.testing.expectEqual(cli_ipc.IpcCommand.send_image, r.command);
+    try std.testing.expectEqualStrings("/tmp/shot.png", r.text_arg);
+    try std.testing.expectEqual(@as(u32, 4), r.pane_id);
+}
+
+test "fillSendImage decodes base64 data to a temp file" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    // "hi" base64-encoded is "aGk=".
+    var p = argsFrom(arena.allocator(), "{\"data\":\"aGk=\",\"filename\":\"a.jpg\"}");
+    defer p.deinit();
+    const r = try fillSendImage(arena.allocator(), p.value.object);
+    try std.testing.expectEqual(cli_ipc.IpcCommand.send_image, r.command);
+    try std.testing.expect(std.mem.endsWith(u8, r.text_arg, ".jpg"));
+    defer std.fs.deleteFileAbsolute(r.text_arg) catch {};
+    const contents = try std.fs.cwd().readFileAlloc(arena.allocator(), r.text_arg, 64);
+    try std.testing.expectEqualStrings("hi", contents);
+}
+
+test "fillSendImage without path or data errors" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var p = argsFrom(arena.allocator(), "{}");
+    defer p.deinit();
+    try std.testing.expectError(error.MissingSource, fillSendImage(arena.allocator(), p.value.object));
+}
+
+test "extOf falls back to png" {
+    try std.testing.expectEqualStrings(".png", extOf(null));
+    try std.testing.expectEqualStrings(".png", extOf("noext"));
+    try std.testing.expectEqualStrings(".jpeg", extOf("shot.jpeg"));
 }
 
 test "fill tab_close converts 1-based to 0-based index" {

--- a/src/ipc/mcp_tools.zig
+++ b/src/ipc/mcp_tools.zig
@@ -251,7 +251,7 @@ fn materializeBase64(a: std.mem.Allocator, data: []const u8, filename: ?[]const 
     const hex = std.fmt.bytesToHex(rnd, .lower);
     const sep: []const u8 = if (builtin.os.tag == .windows) "\\" else "/";
     const path = std.fmt.allocPrint(a, "{s}{s}attyx-img-{s}{s}", .{
-        tmpDir(), sep, &hex, ext,
+        tmpDir(a), sep, &hex, ext,
     }) catch return error.WriteFailed;
 
     const file = std.fs.createFileAbsolute(path, .{}) catch return error.WriteFailed;
@@ -260,9 +260,13 @@ fn materializeBase64(a: std.mem.Allocator, data: []const u8, filename: ?[]const 
     return path;
 }
 
-fn tmpDir() []const u8 {
-    if (builtin.os.tag == .windows) return std.posix.getenv("TEMP") orelse "C:\\Windows\\Temp";
-    return std.posix.getenv("TMPDIR") orelse "/tmp";
+/// Temp dir for materialized images. Uses getEnvVarOwned (not posix.getenv,
+/// which is a compile error on Windows) — the returned slice is request-scoped,
+/// like the path it's spliced into. Falls back to the platform default.
+fn tmpDir(a: std.mem.Allocator) []const u8 {
+    if (builtin.os.tag == .windows)
+        return std.process.getEnvVarOwned(a, "TEMP") catch "C:\\Windows\\Temp";
+    return std.process.getEnvVarOwned(a, "TMPDIR") catch "/tmp";
 }
 
 /// Pick a file extension (including the dot) from the original filename, or

--- a/src/ipc/protocol.zig
+++ b/src/ipc/protocol.zig
@@ -90,6 +90,9 @@ pub const MessageType = enum(u8) {
     // ── Session-targeted envelope ──
     session_envelope = 0x50, // payload: [session_id:u32 LE][inner_msg_type:u8][inner_payload...]
 
+    // ── Image attach (drag/paste a file path into a pane) ──
+    send_image = 0x51, // payload: [pane_id:u32 LE (0=active)][utf8 file path]
+
     // ── Responses ──
     success = 0xA0,
     err = 0xA1,
@@ -303,6 +306,20 @@ test "tab_select encode" {
     const h = try decodeHeader(msg[0..header_size]);
     try std.testing.expectEqual(MessageType.tab_select, h.msg_type);
     try std.testing.expectEqual(@as(u8, 3), msg[header_size]);
+}
+
+test "send_image message round-trip carries pane id and path" {
+    var buf: [256]u8 = undefined;
+    var payload: [64]u8 = undefined;
+    std.mem.writeInt(u32, payload[0..4], 7, .little);
+    const path = "/tmp/shot.png";
+    @memcpy(payload[4 .. 4 + path.len], path);
+    const msg = try encodeMessage(&buf, .send_image, payload[0 .. 4 + path.len]);
+    const h = try decodeHeader(msg[0..header_size]);
+    try std.testing.expectEqual(MessageType.send_image, h.msg_type);
+    const body = msg[header_size..];
+    try std.testing.expectEqual(@as(u32, 7), std.mem.readInt(u32, body[0..4], .little));
+    try std.testing.expectEqualStrings(path, body[4..]);
 }
 
 test "session_id encode" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -342,6 +342,7 @@ test {
     _ = @import("config/cli_ipc.zig");
     _ = @import("ipc/client.zig");
     _ = @import("ipc/mcp.zig");
+    _ = @import("ipc/image_paste.zig");
     if (!is_windows) _ = @import("ipc/mcp_http.zig");
     if (!is_windows) {
         _ = @import("app/daemon/session_test.zig");


### PR DESCRIPTION
## What

Adds a `send_image` path that drops an image file into a pane exactly as a native drag-and-drop would — the shell-quoted file path, wrapped in bracketed-paste markers when the pane has them enabled — so TUIs like Claude Code pick it up as an image attachment.

Exposed three ways:
- **IPC**: new `send_image` message (`0x51`), payload `[pane_id:u32 LE (0=active)][utf8 path]`.
- **CLI**: `send_image` command.
- **MCP**: a `send_image` tool accepting either a file `path` or inline base64 `data` (materialized to a temp file before dispatch, with clear errors for missing source / bad base64 / write failure).

## How

The payload builder lives in a new, pure, allocation-free `image_paste.zig` (caller buffer in, slice out) that mirrors the native drag-and-drop handler. It shell-quotes the path (POSIX single-quote with `'\''` escaping; Windows double-quote) and wraps in bracketed paste when enabled. Handlers for both POSIX and Windows resolve the target pane and inject the bytes.

## Tests

- `image_paste.zig` unit tests: POSIX/Windows quoting, embedded single-quote escaping, bracketed-paste wrapping on/off, and buffer-too-small — now wired into the test runner.
- `protocol.zig`: `send_image` round-trip (pane id + path).
- `mcp_tools.zig`: `send_image` arg filling.
- `zig build test`: 1165/1166; the one failure is a pre-existing flaky daemon timeout (fails on `main` too, unrelated).

## Also

Fixes a few stale doc strings: the `--scrollback-lines` help default (now 5000, matching `config.zig`), and the `resize_step` / popup-width comments in the sample config.