### PR TITLE
Finish the agent dashboard + send-image CLI

### DIFF
--- a/releases/v0.4.14.md
+++ b/releases/v0.4.14.md
@@ -89,3 +89,19 @@ Also fixed: `attyx watch agents` wasn't being recognized as a command at all (it
 fell through to the launch path) — it now works. And `attyx dashboard` no longer
 exits with a blank screen when talking to an older daemon: it falls back to the
 attached window's agents and stays open (so navigation and jump-to-pane work).
+
+## Dashboard, finished — `attyx dashboard`
+
+The agent dashboard gained the interactions it was missing:
+
+- **Jump to the pane** — Enter now switches to the agent's session *and* focuses its exact pane, not just the session.
+- **Session names** — the session column shows real names instead of `s<id>`.
+- **Elapsed** — an `age` column shows how long each agent has been in its current state.
+- **Sort / filter / search** — `s` cycles sort (state · cost · tokens · ctx · session), `f` cycles a state filter (all · needs-input · working · idle), `/` searches by model/message.
+- **Act on a pane** — `z` zooms the selected agent's pane, `x` closes it (with a `y/N` confirm).
+- **Detail panel** — `Tab` toggles a panel with the selected agent's full usage and latest message.
+- **Survives restarts** — if the stream drops it shows a "disconnected" banner and **auto-reconnects** with backoff (handy right after restarting the daemon).
+
+## Attach images from the CLI — `send-image`
+
+`attyx send-image <path> [-p <pane>]` drops an image into a pane as if it were dragged in — e.g. handing Claude Code a screenshot from a script. (Previously available only over MCP.)

--- a/src/config/cli.zig
+++ b/src/config/cli.zig
@@ -395,6 +395,7 @@ fn isIpcSubcommand(arg: []const u8) bool {
         "send-text", "get-text",  "reload",     "theme",
         "scroll-to", "list",      "session",    "popup",  "run",
         "watch", // stream agent status: `watch agents`
+        "send-image", // attach an image file to a pane
         "--target", // --target <pid> before subcommand
         "--json", // --json before subcommand
         "-s",      "--session", // -s/--session <id> before subcommand

--- a/src/config/cli_help.zig
+++ b/src/config/cli_help.zig
@@ -98,6 +98,7 @@ const ipc_io =
     "  " ++ d ++ "Input / Output" ++ r ++ "\n" ++
     cmd("send-keys [-p <id>] [--wait-stable] <keys>   ", "Send keystrokes to a pane") ++
     cont("                                " ++ d ++ "Named: {Enter} {Up} {Down} {Tab} {Ctrl-c} ... or \\n \\xHH" ++ r) ++
+    cmd("send-image <path> [-p <id>]   ", "Attach an image file to a pane (e.g. a screenshot)") ++
     cmd("get-text [-p <id>] [-n <N>] [--json]     ", "Read screen text (or last N rows) from a pane") ++
     "\n";
 

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -234,6 +234,27 @@ pub fn parse(args: []const [:0]const u8) ?IpcRequest {
             }
             break :blk .{ .command = .theme_set, .text_arg = fargs[start + 1], .target_pid = target_pid, .json_output = json_output };
         }
+        if (std.mem.eql(u8, sub, "send-image")) {
+            if (hasHelp(fargs, start)) showHelp(help.send_image);
+            var si = IpcRequest{ .command = .send_image, .target_pid = target_pid, .json_output = json_output };
+            var path: []const u8 = "";
+            var gi = start + 1;
+            while (gi < fargs.len) : (gi += 1) {
+                if (std.mem.eql(u8, fargs[gi], "--pane") or std.mem.eql(u8, fargs[gi], "-p")) {
+                    if (gi + 1 >= fargs.len) fatal("--pane requires a pane ID");
+                    gi += 1;
+                    parsePaneArg(fargs[gi], &si);
+                } else if (path.len == 0) {
+                    path = fargs[gi];
+                }
+            }
+            if (path.len == 0) {
+                printHelp(help.send_image);
+                break :blk null;
+            }
+            si.text_arg = path;
+            break :blk si;
+        }
         if (std.mem.eql(u8, sub, "scroll-to")) break :blk parseScrollTo(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "popup")) break :blk parsePopup(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "list")) break :blk parseList(fargs, start, target_pid, json_output);
@@ -763,6 +784,14 @@ test "watch agents maps to watch_agents" {
     const args = [_][:0]const u8{ "attyx", "watch", "agents" };
     const parsed = parse(&args).?;
     try std.testing.expectEqual(IpcCommand.watch_agents, parsed.command);
+}
+
+test "send-image maps path and pane" {
+    const args = [_][:0]const u8{ "attyx", "send-image", "/tmp/a.png", "-p", "3" };
+    const parsed = parse(&args).?;
+    try std.testing.expectEqual(IpcCommand.send_image, parsed.command);
+    try std.testing.expectEqualStrings("/tmp/a.png", parsed.text_arg);
+    try std.testing.expectEqual(@as(u32, 3), parsed.pane_id);
 }
 
 test "list agents -p sets pane filter" {

--- a/src/config/cli_ipc_help.zig
+++ b/src/config/cli_ipc_help.zig
@@ -21,6 +21,7 @@ pub const top_level =
     \\  send-keys    Send keystrokes to a pane (supports escape sequences)
     \\               Alias: send-text
     \\  get-text     Read visible text from a pane
+    \\  send-image   Attach an image file to a pane (e.g. a screenshot)
     \\  reload       Reload configuration from disk
     \\  theme        Switch to a named theme
     \\  scroll-to    Scroll the viewport (top, bottom, page-up, page-down)
@@ -421,6 +422,26 @@ pub const get_text =
     \\
     \\Tip: After running a command with send-keys, wait briefly before
     \\calling get-text to give the command time to produce output.
+    \\
+;
+
+pub const send_image =
+    \\Attach an image file to a pane — as if the file were dragged or pasted in
+    \\(e.g. to hand Claude Code a screenshot).
+    \\
+    \\Usage: attyx send-image <path> [--pane <target>]
+    \\
+    \\The image's file path is injected into the pane as a bracketed paste; Enter
+    \\is NOT pressed, so the agent receives the reference without submitting. The
+    \\path must already exist on disk.
+    \\
+    \\Options:
+    \\  --pane, -p <id>   Target a specific pane by its stable ID instead of the
+    \\                    focused one (IDs shown in 'attyx list').
+    \\
+    \\Examples:
+    \\  attyx send-image ~/shot.png            Attach to the focused pane
+    \\  attyx send-image /tmp/diagram.png -p 3 Attach to pane 3
     \\
 ;
 

--- a/src/ipc/dashboard/input.zig
+++ b/src/ipc/dashboard/input.zig
@@ -12,6 +12,12 @@ pub const Key = enum {
     quit, // q / Ctrl-C
     help, // ?
     refresh, // r
+    sort, // s — cycle sort
+    filter, // f — cycle filter
+    search, // / — enter search mode
+    zoom, // z — zoom selected pane
+    close, // x — close selected pane (confirm)
+    detail, // Tab — toggle detail panel
     none,
 };
 
@@ -27,6 +33,12 @@ pub const Decoder = struct {
             0x03, 'q' => .quit,
             '?' => .help,
             'r' => .refresh,
+            's' => .sort,
+            'f' => .filter,
+            '/' => .search,
+            'z' => .zoom,
+            'x' => .close,
+            0x09 => .detail, // Tab
             '\r', '\n' => .enter,
             'j' => .down,
             'k' => .up,
@@ -83,8 +95,8 @@ fn collect(bytes: []const u8, out: []Key) usize {
 
 test "decodes letters and control keys" {
     var out: [16]Key = undefined;
-    const n = collect("jkqG g\r\x03?r", &out);
-    const want = [_]Key{ .down, .up, .quit, .bottom, .top, .enter, .quit, .help, .refresh };
+    const n = collect("jkqG g\r\x03?rsfz x/\t", &out);
+    const want = [_]Key{ .down, .up, .quit, .bottom, .top, .enter, .quit, .help, .refresh, .sort, .filter, .zoom, .close, .search, .detail };
     try testing.expectEqual(want.len, n);
     for (want, 0..) |k, i| try testing.expectEqual(k, out[i]);
 }

--- a/src/ipc/dashboard/model.zig
+++ b/src/ipc/dashboard/model.zig
@@ -1,10 +1,10 @@
 //! Agent dashboard data model — pure, TTY-free, fully unit-testable.
 //!
 //! Holds the live agent table keyed by (session, pane). Frames arrive as NDJSON
-//! lines from a `watch_agents` stream (one record per agent transition, see
-//! `src/ipc/agents.zig writeAgentJson`); `applyLine` merges each into the table.
-//! `state == "none"` removes a row (agent ended). Sorting, totals, and selection
-//! movement live here as pure operations over the row list.
+//! lines from a `watch_agents` stream; `applyLine` merges each in. `state ==
+//! "none"` removes a row. A sort/filter/search "view" (indices into the sorted
+//! rows) drives what's shown; selection indexes into the view. Session-name
+//! resolution lives in the UI layer (the model is id-based).
 const std = @import("std");
 
 pub const max_rows = 128;
@@ -21,13 +21,63 @@ pub const State = enum {
         if (std.mem.eql(u8, s, "idle")) return .idle;
         return .none;
     }
-    /// Sort priority: needs-input first (loudest), then working, then idle.
     fn rank(self: State) u8 {
         return switch (self) {
             .input => 0,
             .working => 1,
             .idle => 2,
             .none => 3,
+        };
+    }
+};
+
+pub const SortMode = enum {
+    state,
+    cost,
+    tokens,
+    ctx,
+    session,
+
+    pub fn label(self: SortMode) []const u8 {
+        return switch (self) {
+            .state => "state",
+            .cost => "cost",
+            .tokens => "tokens",
+            .ctx => "ctx",
+            .session => "session",
+        };
+    }
+    pub fn next(self: SortMode) SortMode {
+        return switch (self) {
+            .state => .cost,
+            .cost => .tokens,
+            .tokens => .ctx,
+            .ctx => .session,
+            .session => .state,
+        };
+    }
+};
+
+pub const FilterMode = enum {
+    all,
+    input,
+    working,
+    idle,
+
+    pub fn label(self: FilterMode) []const u8 {
+        return switch (self) {
+            .all => "all",
+            .input => "needs-input",
+            .working => "working",
+            .idle => "idle",
+        };
+    }
+    pub fn next(self: FilterMode) FilterMode {
+        return switch (self) {
+            .all => .input,
+            .input => .working,
+            .working => .idle,
+            .idle => .all,
         };
     }
 };
@@ -48,6 +98,7 @@ pub const Row = struct {
     model_len: u8 = 0,
     msg_buf: [120]u8 = undefined,
     msg_len: u8 = 0,
+    state_since_ms: i64 = 0, // when the row entered its current state (for elapsed)
 
     pub fn model(self: *const Row) []const u8 {
         return self.model_buf[0..self.model_len];
@@ -55,9 +106,11 @@ pub const Row = struct {
     pub fn message(self: *const Row) []const u8 {
         return self.msg_buf[0..self.msg_len];
     }
+    fn tokensTotal(self: *const Row) u64 {
+        return (self.input_tokens orelse 0) + (self.output_tokens orelse 0);
+    }
 };
 
-// JSON shapes for std.json (defaults make every field optional; unknown keys ignored).
 const RawUsage = struct {
     input_tokens: ?u64 = null,
     output_tokens: ?u64 = null,
@@ -83,19 +136,44 @@ fn copyBuf(buf: []u8, s: []const u8) u8 {
     return @intCast(n);
 }
 
-pub const Model = struct {
-    rows: [max_rows]Row = undefined,
-    count: usize = 0,
-    selected: usize = 0,
+fn lowerEql(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (needle.len > haystack.len) return false;
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        var j: usize = 0;
+        while (j < needle.len) : (j += 1) {
+            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(needle[j])) break;
+        }
+        if (j == needle.len) return true;
+    }
+    return false;
+}
 
-    // Totals (recomputed on change).
+pub const Model = struct {
+    rows: [max_rows]Row = undefined, // canonical store, kept sorted by sort_mode
+    count: usize = 0,
+    view: [max_rows]u8 = undefined, // indices into rows passing filter+search
+    view_count: usize = 0,
+    selected: usize = 0, // index into view
+
+    sort_mode: SortMode = .state,
+    filter_mode: FilterMode = .all,
+    search_buf: [64]u8 = undefined,
+    search_len: u8 = 0,
+
+    // Totals across ALL rows (header), independent of filter/search.
     total_input: u64 = 0,
     total_output: u64 = 0,
     total_cost: f64 = 0,
     any_estimate: bool = false,
-    n_input: usize = 0, // agents needing input
+    n_input: usize = 0,
     n_working: usize = 0,
     n_idle: usize = 0,
+
+    pub fn searchQuery(self: *const Model) []const u8 {
+        return self.search_buf[0..self.search_len];
+    }
 
     fn find(self: *Model, session: u32, pane: u32) ?usize {
         for (self.rows[0..self.count], 0..) |*r, i| {
@@ -105,16 +183,14 @@ pub const Model = struct {
     }
 
     fn removeAt(self: *Model, idx: usize) void {
-        // Order-preserving remove so the table doesn't jump around.
         var i = idx;
         while (i + 1 < self.count) : (i += 1) self.rows[i] = self.rows[i + 1];
         self.count -= 1;
-        if (self.selected >= self.count and self.selected > 0) self.selected = self.count - 1;
     }
 
-    /// Apply one NDJSON record. Allocator is used only transiently for JSON
-    /// parsing (freed before return); the model itself owns no heap memory.
-    pub fn applyLine(self: *Model, gpa: std.mem.Allocator, line: []const u8) void {
+    /// Apply one NDJSON record. `now_ms` stamps the state-change time (for the
+    /// elapsed column). Allocator is used only transiently for JSON parsing.
+    pub fn applyLine(self: *Model, gpa: std.mem.Allocator, line: []const u8, now_ms: i64) void {
         const trimmed = std.mem.trim(u8, line, " \t\r\n");
         if (trimmed.len == 0 or trimmed[0] != '{') return;
         var arena = std.heap.ArenaAllocator.init(gpa);
@@ -125,26 +201,26 @@ pub const Model = struct {
         const existing = self.find(parsed.session, parsed.pane_id);
         if (st == .none) {
             if (existing) |i| self.removeAt(i);
-            self.recompute();
+            self.refresh(now_ms);
             return;
         }
         const idx = existing orelse blk: {
             if (self.count >= max_rows) {
-                self.recompute();
+                self.refresh(now_ms);
                 return;
             }
-            self.rows[self.count] = .{};
+            self.rows[self.count] = .{ .state_since_ms = now_ms };
             self.count += 1;
             break :blk self.count - 1;
         };
         var r = &self.rows[idx];
+        if (r.state != st) r.state_since_ms = now_ms;
         r.session = parsed.session;
         r.pane_id = parsed.pane_id;
         r.tab_id = parsed.tab_id;
         r.pid = parsed.pid;
         r.state = st;
         r.msg_len = copyBuf(&r.msg_buf, parsed.message);
-        // Usage merges sticky: a status-only frame must not wipe known usage.
         const u = parsed.usage;
         if (u.input_tokens) |v| r.input_tokens = v;
         if (u.output_tokens) |v| r.output_tokens = v;
@@ -155,8 +231,16 @@ pub const Model = struct {
             r.cost_is_estimate = u.cost_is_estimate;
         }
         if (u.model) |m| r.model_len = copyBuf(&r.model_buf, m);
+        self.refresh(now_ms);
+    }
+
+    /// Re-sort rows, recompute totals, and rebuild the filtered/searched view.
+    /// `now_ms` unused here but kept for symmetry/future use.
+    pub fn refresh(self: *Model, now_ms: i64) void {
+        _ = now_ms;
         self.sort();
         self.recompute();
+        self.rebuildView();
     }
 
     fn recompute(self: *Model) void {
@@ -181,49 +265,126 @@ pub const Model = struct {
                 .none => {},
             }
         }
-        if (self.selected >= self.count and self.count > 0) self.selected = self.count - 1;
-        if (self.count == 0) self.selected = 0;
     }
 
-    /// Sort by state rank (input→working→idle), then descending cost, then
-    /// session/pane for stability. Insertion sort — the table is small.
+    fn passesFilter(self: *const Model, r: *const Row) bool {
+        return switch (self.filter_mode) {
+            .all => true,
+            .input => r.state == .input,
+            .working => r.state == .working,
+            .idle => r.state == .idle,
+        };
+    }
+
+    fn matchesSearch(self: *const Model, r: *const Row) bool {
+        const q = self.searchQuery();
+        if (q.len == 0) return true;
+        if (lowerEql(r.model(), q)) return true;
+        if (lowerEql(r.message(), q)) return true;
+        var nb: [24]u8 = undefined;
+        if (std.fmt.bufPrint(&nb, "s{d} {d}", .{ r.session, r.pane_id })) |ids| {
+            if (lowerEql(ids, q)) return true;
+        } else |_| {}
+        return false;
+    }
+
+    fn rebuildView(self: *Model) void {
+        var n: usize = 0;
+        for (self.rows[0..self.count], 0..) |*r, i| {
+            if (self.passesFilter(r) and self.matchesSearch(r)) {
+                self.view[n] = @intCast(i);
+                n += 1;
+            }
+        }
+        self.view_count = n;
+        if (self.selected >= self.view_count) self.selected = if (self.view_count > 0) self.view_count - 1 else 0;
+    }
+
     fn sort(self: *Model) void {
         const rows = self.rows[0..self.count];
         var i: usize = 1;
         while (i < rows.len) : (i += 1) {
             const tmp = rows[i];
             var j: usize = i;
-            while (j > 0 and less(tmp, rows[j - 1])) : (j -= 1) rows[j] = rows[j - 1];
+            while (j > 0 and less(tmp, rows[j - 1], self.sort_mode)) : (j -= 1) rows[j] = rows[j - 1];
             rows[j] = tmp;
         }
     }
 
+    pub fn visibleCount(self: *const Model) usize {
+        return self.view_count;
+    }
+    pub fn rowAt(self: *const Model, i: usize) *const Row {
+        return &self.rows[self.view[i]];
+    }
     pub fn selectedRow(self: *const Model) ?*const Row {
-        if (self.count == 0) return null;
-        return &self.rows[self.selected];
+        if (self.view_count == 0) return null;
+        return &self.rows[self.view[self.selected]];
     }
 
     pub fn moveUp(self: *Model) void {
         if (self.selected > 0) self.selected -= 1;
     }
     pub fn moveDown(self: *Model) void {
-        if (self.selected + 1 < self.count) self.selected += 1;
+        if (self.selected + 1 < self.view_count) self.selected += 1;
     }
     pub fn moveTop(self: *Model) void {
         self.selected = 0;
     }
     pub fn moveBottom(self: *Model) void {
-        self.selected = if (self.count > 0) self.count - 1 else 0;
+        self.selected = if (self.view_count > 0) self.view_count - 1 else 0;
+    }
+
+    pub fn cycleSort(self: *Model) void {
+        self.sort_mode = self.sort_mode.next();
+        self.refresh(0);
+    }
+    pub fn cycleFilter(self: *Model) void {
+        self.filter_mode = self.filter_mode.next();
+        self.rebuildView();
+    }
+    pub fn searchAppend(self: *Model, ch: u8) void {
+        if (self.search_len < self.search_buf.len) {
+            self.search_buf[self.search_len] = ch;
+            self.search_len += 1;
+            self.rebuildView();
+        }
+    }
+    pub fn searchBackspace(self: *Model) void {
+        if (self.search_len > 0) {
+            self.search_len -= 1;
+            self.rebuildView();
+        }
+    }
+    pub fn searchClear(self: *Model) void {
+        self.search_len = 0;
+        self.rebuildView();
     }
 };
 
-fn less(a: Row, b: Row) bool {
-    const ra = a.state.rank();
-    const rb = b.state.rank();
-    if (ra != rb) return ra < rb;
-    const ca = a.cost_usd orelse 0;
-    const cb = b.cost_usd orelse 0;
-    if (ca != cb) return ca > cb; // higher cost first
+fn less(a: Row, b: Row, mode: SortMode) bool {
+    switch (mode) {
+        .state => {
+            if (a.state.rank() != b.state.rank()) return a.state.rank() < b.state.rank();
+            const ca = a.cost_usd orelse 0;
+            const cb = b.cost_usd orelse 0;
+            if (ca != cb) return ca > cb;
+        },
+        .cost => {
+            const ca = a.cost_usd orelse 0;
+            const cb = b.cost_usd orelse 0;
+            if (ca != cb) return ca > cb;
+        },
+        .tokens => {
+            if (a.tokensTotal() != b.tokensTotal()) return a.tokensTotal() > b.tokensTotal();
+        },
+        .ctx => {
+            const ka = a.context_used orelse 0;
+            const kb = b.context_used orelse 0;
+            if (ka != kb) return ka > kb;
+        },
+        .session => {},
+    }
     if (a.session != b.session) return a.session < b.session;
     return a.pane_id < b.pane_id;
 }
@@ -234,62 +395,92 @@ fn less(a: Row, b: Row) bool {
 
 const testing = std.testing;
 
-test "applyLine upserts, sticky-merges usage, and sorts by state then cost" {
+test "applyLine upserts, sticky-merges usage, sorts by state then cost" {
     const a = testing.allocator;
     var m = Model{};
-    m.applyLine(a, "{\"session\":1,\"pane_id\":3,\"state\":\"working\",\"usage\":{\"input_tokens\":100,\"cost_usd\":0.10}}");
-    m.applyLine(a, "{\"session\":1,\"pane_id\":8,\"state\":\"input\",\"usage\":{}}");
-    m.applyLine(a, "{\"session\":2,\"pane_id\":5,\"state\":\"working\",\"usage\":{\"input_tokens\":50,\"cost_usd\":0.50}}");
+    m.applyLine(a, "{\"session\":1,\"pane_id\":3,\"state\":\"working\",\"usage\":{\"input_tokens\":100,\"cost_usd\":0.10}}", 0);
+    m.applyLine(a, "{\"session\":1,\"pane_id\":8,\"state\":\"input\",\"usage\":{}}", 0);
+    m.applyLine(a, "{\"session\":2,\"pane_id\":5,\"state\":\"working\",\"usage\":{\"input_tokens\":50,\"cost_usd\":0.50}}", 0);
     try testing.expectEqual(@as(usize, 3), m.count);
-    // input first, then working sorted by cost desc (0.50 before 0.10).
+    try testing.expectEqual(@as(usize, 3), m.view_count);
     try testing.expectEqual(State.input, m.rows[0].state);
-    try testing.expectEqual(@as(u32, 5), m.rows[1].pane_id);
-    try testing.expectEqual(@as(u32, 3), m.rows[2].pane_id);
-    try testing.expectEqual(@as(usize, 1), m.n_input);
-    try testing.expectEqual(@as(usize, 2), m.n_working);
+    try testing.expectEqual(@as(u32, 5), m.rows[1].pane_id); // 0.50 before 0.10
     try testing.expectApproxEqAbs(@as(f64, 0.60), m.total_cost, 1e-9);
 
-    // Status-only frame must keep prior usage (sticky).
-    m.applyLine(a, "{\"session\":2,\"pane_id\":5,\"state\":\"idle\"}");
+    m.applyLine(a, "{\"session\":2,\"pane_id\":5,\"state\":\"idle\"}", 0);
     const r = blk: {
         for (m.rows[0..m.count]) |*x| if (x.session == 2 and x.pane_id == 5) break :blk x;
         unreachable;
     };
-    try testing.expectEqual(@as(?u64, 50), r.input_tokens);
+    try testing.expectEqual(@as(?u64, 50), r.input_tokens); // sticky
     try testing.expectEqual(State.idle, r.state);
 }
 
-test "applyLine removes a row on state none and fixes selection" {
+test "elapsed: state_since_ms stamps on new row and on state change only" {
     const a = testing.allocator;
     var m = Model{};
-    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"working\"}");
-    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"state\":\"working\"}");
+    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"working\"}", 1000);
+    try testing.expectEqual(@as(i64, 1000), m.rows[0].state_since_ms);
+    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"working\",\"usage\":{\"input_tokens\":5}}", 2000);
+    try testing.expectEqual(@as(i64, 1000), m.rows[0].state_since_ms); // unchanged state
+    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"input\"}", 3000);
+    try testing.expectEqual(@as(i64, 3000), m.rows[0].state_since_ms); // changed
+}
+
+test "filter narrows the view; totals stay over all rows" {
+    const a = testing.allocator;
+    var m = Model{};
+    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"working\"}", 0);
+    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"state\":\"input\"}", 0);
+    m.applyLine(a, "{\"session\":1,\"pane_id\":3,\"state\":\"idle\"}", 0);
+    try testing.expectEqual(@as(usize, 3), m.visibleCount());
+    m.cycleFilter(); // all → needs-input
+    try testing.expectEqual(FilterMode.input, m.filter_mode);
+    try testing.expectEqual(@as(usize, 1), m.visibleCount());
+    try testing.expectEqual(State.input, m.selectedRow().?.state);
+}
+
+test "search matches model and message, case-insensitive" {
+    const a = testing.allocator;
+    var m = Model{};
+    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"working\",\"message\":\"Editing parser\",\"usage\":{\"model\":\"opus-4.8\"}}", 0);
+    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"state\":\"working\",\"message\":\"running tests\",\"usage\":{\"model\":\"gpt-5\"}}", 0);
+    for ("OPUS") |c| m.searchAppend(c);
+    try testing.expectEqual(@as(usize, 1), m.visibleCount());
+    m.searchClear();
+    try testing.expectEqual(@as(usize, 2), m.visibleCount());
+    for ("tests") |c| m.searchAppend(c);
+    try testing.expectEqual(@as(usize, 1), m.visibleCount());
+    try testing.expectEqual(@as(u32, 2), m.selectedRow().?.pane_id);
+}
+
+test "cycleSort reorders the view (tokens)" {
+    const a = testing.allocator;
+    var m = Model{};
+    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"idle\",\"usage\":{\"input_tokens\":10}}", 0);
+    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"state\":\"idle\",\"usage\":{\"input_tokens\":999}}", 0);
+    m.sort_mode = .tokens;
+    m.refresh(0);
+    try testing.expectEqual(@as(u32, 2), m.rowAt(0).pane_id); // most tokens first
+}
+
+test "remove on none fixes selection; movement clamps to view" {
+    const a = testing.allocator;
+    var m = Model{};
+    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"working\"}", 0);
+    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"state\":\"working\"}", 0);
     m.selected = 1;
-    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"state\":\"none\"}");
+    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"state\":\"none\"}", 0);
     try testing.expectEqual(@as(usize, 1), m.count);
     try testing.expectEqual(@as(usize, 0), m.selected);
-}
-
-test "selection movement clamps" {
-    const a = testing.allocator;
-    var m = Model{};
-    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"working\"}");
-    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"state\":\"working\"}");
-    m.moveUp();
-    try testing.expectEqual(@as(usize, 0), m.selected);
-    m.moveBottom();
-    try testing.expectEqual(@as(usize, 1), m.selected);
     m.moveDown();
-    try testing.expectEqual(@as(usize, 1), m.selected); // clamped
-    m.moveTop();
-    try testing.expectEqual(@as(usize, 0), m.selected);
+    try testing.expectEqual(@as(usize, 0), m.selected); // clamped to view
 }
 
-test "malformed and non-object lines are ignored" {
+test "malformed lines ignored" {
     const a = testing.allocator;
     var m = Model{};
-    m.applyLine(a, "not json");
-    m.applyLine(a, "");
-    m.applyLine(a, "{bad");
+    m.applyLine(a, "not json", 0);
+    m.applyLine(a, "", 0);
     try testing.expectEqual(@as(usize, 0), m.count);
 }

--- a/src/ipc/dashboard/render.zig
+++ b/src/ipc/dashboard/render.zig
@@ -14,17 +14,18 @@ const State = model.State;
 // Column display widths and the 2-col gutter between them.
 const gutter = "  ";
 const gw: u16 = 2;
-const mark_w: u16 = 2; // selection marker + space
-const session_w: u16 = 8;
+const mark_w: u16 = 2;
+const session_w: u16 = 10;
 const pane_w: u16 = 5;
-const model_w: u16 = 18;
+const model_w: u16 = 16;
 const state_w: u16 = 8;
+const age_w: u16 = 6;
 const in_w: u16 = 8;
 const out_w: u16 = 8;
 const ctx_w: u16 = 14;
 const cost_w: u16 = 10;
-// 8 body columns => 7 gutters.
-pub const table_w: u16 = mark_w + session_w + pane_w + model_w + state_w + in_w + out_w + ctx_w + cost_w + gw * 7;
+// 10 body columns => 9 gutters.
+pub const table_w: u16 = mark_w + session_w + pane_w + model_w + state_w + age_w + in_w + out_w + ctx_w + cost_w + gw * 9;
 
 const ellipsis = "\xe2\x80\xa6"; // …
 
@@ -36,6 +37,50 @@ const rev = "\x1b[7m";
 const c_idle = "\x1b[38;2;96;208;120m";
 const c_working = "\x1b[38;2;255;170;64m";
 const c_input = "\x1b[38;2;176;112;255m";
+
+/// id→name lookup for the session column. Populated by run.zig from
+/// `session_list`; the model stays id-based.
+pub const NameCache = struct {
+    ids: [64]u32 = undefined,
+    names: [64][24]u8 = undefined,
+    lens: [64]u8 = undefined,
+    n: usize = 0,
+
+    pub fn clear(self: *NameCache) void {
+        self.n = 0;
+    }
+    pub fn set(self: *NameCache, id: u32, name: []const u8) void {
+        for (0..self.n) |i| {
+            if (self.ids[i] == id) {
+                self.lens[i] = copyName(&self.names[i], name);
+                return;
+            }
+        }
+        if (self.n >= self.ids.len) return;
+        self.ids[self.n] = id;
+        self.lens[self.n] = copyName(&self.names[self.n], name);
+        self.n += 1;
+    }
+    pub fn get(self: *const NameCache, id: u32) ?[]const u8 {
+        for (0..self.n) |i| {
+            if (self.ids[i] == id and self.lens[i] > 0) return self.names[i][0..self.lens[i]];
+        }
+        return null;
+    }
+};
+fn copyName(buf: *[24]u8, s: []const u8) u8 {
+    const n = @min(s.len, buf.len);
+    @memcpy(buf[0..n], s[0..n]);
+    return @intCast(n);
+}
+
+pub const Ctx = struct {
+    now_ms: i64 = 0,
+    names: ?*const NameCache = null,
+    connected: bool = true,
+    detail: bool = false,
+    confirm_close: bool = false,
+};
 
 fn stateColor(s: State) []const u8 {
     return switch (s) {
@@ -52,6 +97,15 @@ fn stateLabel(s: State) []const u8 {
         .input => "input",
         .none => "none",
     };
+}
+
+/// Human elapsed since `since_ms` (e.g. "5s", "1m12s", "2h3m"). "-" if unknown.
+fn fmtAge(buf: []u8, now_ms: i64, since_ms: i64) []const u8 {
+    if (since_ms == 0 or now_ms < since_ms) return "-";
+    const secs: u64 = @intCast(@divTrunc(now_ms - since_ms, 1000));
+    if (secs < 60) return std.fmt.bufPrint(buf, "{d}s", .{secs}) catch "-";
+    if (secs < 3600) return std.fmt.bufPrint(buf, "{d}m{d}s", .{ secs / 60, secs % 60 }) catch "-";
+    return std.fmt.bufPrint(buf, "{d}h{d}m", .{ secs / 3600, (secs % 3600) / 60 }) catch "-";
 }
 
 fn appendCol(buf: *std.ArrayList(u8), a: std.mem.Allocator, s: []const u8, width: u16, right: bool) !void {
@@ -73,53 +127,44 @@ fn appendCol(buf: *std.ArrayList(u8), a: std.mem.Allocator, s: []const u8, width
     if (!right) try buf.appendNTimes(a, ' ', pad);
 }
 
-/// Build one table line (no ANSI): marker + session/pane/model/state/in/out/ctx/cost.
-fn buildLine(a: std.mem.Allocator, marker: []const u8, session: []const u8, pane: []const u8, model_s: []const u8, state_s: []const u8, in: []const u8, out: []const u8, ctx: []const u8, cost: []const u8) ![]const u8 {
+fn buildLine(a: std.mem.Allocator, cols: [10][]const u8, rights: [10]bool) ![]const u8 {
+    const widths = [10]u16{ mark_w, session_w, pane_w, model_w, state_w, age_w, in_w, out_w, ctx_w, cost_w };
     var b = std.ArrayList(u8){};
-    try appendCol(&b, a, marker, mark_w, false);
-    try appendCol(&b, a, session, session_w, false);
-    try b.appendSlice(a, gutter);
-    try appendCol(&b, a, pane, pane_w, false);
-    try b.appendSlice(a, gutter);
-    try appendCol(&b, a, model_s, model_w, false);
-    try b.appendSlice(a, gutter);
-    try appendCol(&b, a, state_s, state_w, false);
-    try b.appendSlice(a, gutter);
-    try appendCol(&b, a, in, in_w, true);
-    try b.appendSlice(a, gutter);
-    try appendCol(&b, a, out, out_w, true);
-    try b.appendSlice(a, gutter);
-    try appendCol(&b, a, ctx, ctx_w, true);
-    try b.appendSlice(a, gutter);
-    try appendCol(&b, a, cost, cost_w, true);
+    for (cols, widths, rights, 0..) |c, width, r, i| {
+        try appendCol(&b, a, c, width, r);
+        if (i + 1 < cols.len) try b.appendSlice(a, gutter);
+    }
     return b.items;
 }
 
-fn rowLine(a: std.mem.Allocator, r: *const Row, marker: []const u8) ![]const u8 {
-    var sb: [16]u8 = undefined;
+fn rowLine(a: std.mem.Allocator, r: *const Row, marker: []const u8, ctx: Ctx) ![]const u8 {
+    var sb: [24]u8 = undefined;
     var pb: [16]u8 = undefined;
+    var ab: [16]u8 = undefined;
     var ib: [16]u8 = undefined;
     var ob: [16]u8 = undefined;
     var cb: [24]u8 = undefined;
     var kb: [24]u8 = undefined;
-    const session = std.fmt.bufPrint(&sb, "s{d}", .{r.session}) catch "s?";
-    const pane = std.fmt.bufPrint(&pb, "{d}", .{r.pane_id}) catch "?";
-    return buildLine(
-        a,
+    const session = if (ctx.names != null and ctx.names.?.get(r.session) != null)
+        ctx.names.?.get(r.session).?
+    else
+        std.fmt.bufPrint(&sb, "s{d}", .{r.session}) catch "s?";
+    return buildLine(a, .{
         marker,
         session,
-        pane,
+        std.fmt.bufPrint(&pb, "{d}", .{r.pane_id}) catch "?",
         if (r.model_len > 0) r.model() else "\xe2\x80\x94",
         stateLabel(r.state),
+        fmtAge(&ab, ctx.now_ms, r.state_since_ms),
         fmt.tokensOpt(&ib, r.input_tokens),
         fmt.tokensOpt(&ob, r.output_tokens),
         fmt.ctx(&kb, r.context_used, r.context_max),
         fmt.cost(&cb, r.cost_usd, r.cost_is_estimate),
-    );
+    }, .{ false, false, false, false, false, true, true, true, true, true });
 }
 
 fn headerLine(a: std.mem.Allocator) ![]const u8 {
-    return buildLine(a, " ", "session", "pane", "model", "state", "in", "out", "ctx", "cost");
+    return buildLine(a, .{ " ", "session", "pane", "model", "state", "age", "in", "out", "ctx", "cost" }, .{ false, false, false, false, false, true, true, true, true, true });
 }
 
 fn totalsLine(a: std.mem.Allocator, m: *const Model) ![]const u8 {
@@ -127,113 +172,148 @@ fn totalsLine(a: std.mem.Allocator, m: *const Model) ![]const u8 {
     var ob: [16]u8 = undefined;
     var cb: [24]u8 = undefined;
     const cost = std.fmt.bufPrint(&cb, "{s}${d:.2}", .{ if (m.any_estimate) "~" else "", m.total_cost }) catch "$?";
-    return buildLine(a, " ", "TOTAL", "", "", "", fmt.tokens(&ib, m.total_input), fmt.tokens(&ob, m.total_output), "", cost);
+    return buildLine(a, .{ " ", "TOTAL", "", "", "", "", fmt.tokens(&ib, m.total_input), fmt.tokens(&ob, m.total_output), "", cost }, .{ false, false, false, false, false, true, true, true, true, true });
 }
 
 /// Plain-text table to `writer` (for `--once` / non-TTY). No ANSI.
-pub fn snapshot(writer: anytype, a: std.mem.Allocator, m: *const Model) !void {
+pub fn snapshot(writer: anytype, a: std.mem.Allocator, m: *const Model, ctx: Ctx) !void {
     try writer.print("{d} agents \xc2\xb7 {d} working \xc2\xb7 {d} need input \xc2\xb7 ${d:.2}{s}\n", .{
         m.count, m.n_working, m.n_input, m.total_cost, if (m.any_estimate) " (incl. est)" else "",
     });
     try writer.print("{s}\n", .{try headerLine(a)});
-    if (m.count == 0) {
-        try writer.writeAll("  (no agents running)\n");
+    if (m.visibleCount() == 0) {
+        try writer.writeAll("  (no agents)\n");
     } else {
-        for (m.rows[0..m.count]) |*r| try writer.print("{s}\n", .{try rowLine(a, r, " ")});
+        var i: usize = 0;
+        while (i < m.visibleCount()) : (i += 1) try writer.print("{s}\n", .{try rowLine(a, m.rowAt(i), " ", ctx)});
     }
     try writer.print("{s}\n", .{try totalsLine(a, m)});
 }
 
-/// Full-screen ANSI frame into `buf` (for the interactive TUI). Rows are colored
-/// by state; the selected row is reverse-video. Lines are clipped to `cols`.
-pub fn frame(buf: *std.ArrayList(u8), a: std.mem.Allocator, m: *const Model, rows: u16, cols: u16, connected: bool) !void {
+/// Full-screen ANSI frame into `buf` (for the interactive TUI).
+pub fn frame(buf: *std.ArrayList(u8), a: std.mem.Allocator, m: *const Model, rows: u16, cols: u16, ctx: Ctx) !void {
     _ = cols;
     const w = buf.writer(a);
-    try w.writeAll("\x1b[2J\x1b[H"); // clear + home
+    try w.writeAll("\x1b[2J\x1b[H");
     var line: u16 = 1;
-    // Header bar.
     try moveTo(w, line);
     try w.print("{s}Attyx \xe2\x80\x94 Agents{s}   {d} running \xc2\xb7 {s}{d} need input{s} \xc2\xb7 ${d:.2}{s}\x1b[K", .{
-        bold,                            reset,
-        m.n_working + m.n_input,         if (m.n_input > 0) c_input else dim,
-        m.n_input,                       reset,
-        m.total_cost,                    if (m.any_estimate) " (~est)" else "",
+        bold,                    reset,
+        m.n_working + m.n_input, if (m.n_input > 0) c_input else dim,
+        m.n_input,               reset,
+        m.total_cost,            if (m.any_estimate) " (~est)" else "",
     });
     line += 1;
-    // Column header.
     try moveTo(w, line);
     try w.print("{s}{s}{s}\x1b[K", .{ dim, try headerLine(a), reset });
     line += 1;
 
-    const body_rows = if (rows > 5) rows - 4 else 1; // header(2) + totals + help
-    if (m.count == 0) {
+    // Reserve rows: 2 header + totals + help (+ up to 5 detail lines).
+    const detail_rows: u16 = if (ctx.detail and m.selectedRow() != null) 5 else 0;
+    const reserved: u16 = 4 + detail_rows;
+    const body_rows = if (rows > reserved + 1) rows - reserved else 1;
+    if (m.visibleCount() == 0) {
         try moveTo(w, line);
-        try w.print("{s}  no agents running \xe2\x80\x94 launch claude/codex/opencode/pi in any pane{s}\x1b[K", .{ dim, reset });
+        try w.print("{s}  no agents \xe2\x80\x94 launch claude/codex/opencode/pi in any pane{s}\x1b[K", .{ dim, reset });
     } else {
         var i: usize = 0;
-        while (i < m.count and i < body_rows) : (i += 1) {
-            const r = &m.rows[i];
+        while (i < m.visibleCount() and i < body_rows) : (i += 1) {
+            const r = m.rowAt(i);
             try moveTo(w, line);
             if (i == m.selected) {
-                try w.print("{s}{s}\x1b[K{s}", .{ rev, try rowLine(a, r, "\xe2\x96\xb6"), reset });
+                try w.print("{s}{s}\x1b[K{s}", .{ rev, try rowLine(a, r, "\xe2\x96\xb6", ctx), reset });
             } else {
-                try w.print("{s}{s}{s}\x1b[K", .{ stateColor(r.state), try rowLine(a, r, " "), reset });
+                try w.print("{s}{s}{s}\x1b[K", .{ stateColor(r.state), try rowLine(a, r, " ", ctx), reset });
             }
             line += 1;
         }
     }
-    // Totals + help on the last two rows.
+
+    if (detail_rows > 0) try detailPanel(w, a, m.selectedRow().?, rows - reserved + 1, ctx);
+
     if (rows >= 2) {
         try moveTo(w, rows - 1);
         try w.print("{s}{s}{s}\x1b[K", .{ bold, try totalsLine(a, m), reset });
         try moveTo(w, rows);
-        if (connected) {
-            try w.print("{s}  \xe2\x86\x91\xe2\x86\x93 select  \xe2\x8f\x8e focus pane  r refresh  q quit{s}\x1b[K", .{ dim, reset });
-        } else {
-            try w.print("{s}  {s}disconnected{s}{s} \xc2\xb7 q quit{s}\x1b[K", .{ dim, c_input, reset, dim, reset });
+        try helpLine(w, m, ctx);
+    }
+}
+
+fn detailPanel(w: anytype, a: std.mem.Allocator, r: *const Row, at: u16, ctx: Ctx) !void {
+    _ = a;
+    var ab: [16]u8 = undefined;
+    var ib: [16]u8 = undefined;
+    var ob: [16]u8 = undefined;
+    var kb: [24]u8 = undefined;
+    var cb: [24]u8 = undefined;
+    const name = if (ctx.names != null and ctx.names.?.get(r.session) != null) ctx.names.?.get(r.session).? else "";
+    try moveTo(w, at);
+    try w.print("{s}\xe2\x94\x80\xe2\x94\x80 detail \xe2\x94\x80\xe2\x94\x80{s}\x1b[K", .{ dim, reset });
+    try moveTo(w, at + 1);
+    try w.print("  session {d}{s}{s}{s} \xc2\xb7 pane {d} \xc2\xb7 {s}{s}{s} \xc2\xb7 {s}\x1b[K", .{
+        r.session, if (name.len > 0) " (" else "", name, if (name.len > 0) ")" else "",
+        r.pane_id, stateColor(r.state), stateLabel(r.state), reset, fmtAge(&ab, ctx.now_ms, r.state_since_ms),
+    });
+    try moveTo(w, at + 2);
+    try w.print("  {s} \xc2\xb7 in {s} \xc2\xb7 out {s} \xc2\xb7 ctx {s} \xc2\xb7 {s}\x1b[K", .{
+        if (r.model_len > 0) r.model() else "\xe2\x80\x94",
+        fmt.tokensOpt(&ib, r.input_tokens), fmt.tokensOpt(&ob, r.output_tokens),
+        fmt.ctx(&kb, r.context_used, r.context_max), fmt.cost(&cb, r.cost_usd, r.cost_is_estimate),
+    });
+    try moveTo(w, at + 3);
+    const msg = if (r.msg_len > 0) r.message() else "\xe2\x80\x94";
+    try w.print("  {s}{s}{s}\x1b[K", .{ dim, msg, reset });
+}
+
+fn helpLine(w: anytype, m: *const Model, ctx: Ctx) !void {
+    if (ctx.confirm_close) {
+        if (m.selectedRow()) |r| {
+            try w.print("{s}close pane {d}? {s}y/N{s}\x1b[K", .{ c_input, r.pane_id, bold, reset });
+            return;
         }
     }
+    const q = m.searchQuery();
+    if (q.len > 0) {
+        try w.print("{s}  /{s}  \xc2\xb7  sort:{s} filter:{s}  \xc2\xb7  esc clear{s}\x1b[K", .{ dim, q, m.sort_mode.label(), m.filter_mode.label(), reset });
+        return;
+    }
+    if (!ctx.connected) {
+        try w.print("{s}  {s}disconnected{s}{s} \xc2\xb7 reconnecting \xc2\xb7 q quit{s}\x1b[K", .{ dim, c_input, reset, dim, reset });
+        return;
+    }
+    try w.print("{s}  \xe2\x86\x91\xe2\x86\x93 sel  \xe2\x8f\x8e focus  z zoom  x close  s sort:{s}  f filter:{s}  / search  \xe2\x87\xa5 detail  q quit{s}\x1b[K", .{ dim, m.sort_mode.label(), m.filter_mode.label(), reset });
 }
 
 fn moveTo(w: anytype, row: u16) !void {
     try w.print("\x1b[{d};1H", .{row});
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 const testing = std.testing;
 
-test "snapshot renders a header, rows, and totals" {
-    const ally = testing.allocator;
-    var m = Model{};
-    m.applyLine(ally, "{\"session\":1,\"pane_id\":3,\"state\":\"working\",\"usage\":{\"input_tokens\":1200000,\"output_tokens\":842000,\"context_used\":82000,\"context_max\":200000,\"cost_usd\":0.42,\"model\":\"opus-4.8\"}}");
-    var arena = std.heap.ArenaAllocator.init(ally);
-    defer arena.deinit();
-    var out = std.ArrayList(u8){};
-    try snapshot(out.writer(arena.allocator()), arena.allocator(), &m);
-    const s = out.items;
-    try testing.expect(std.mem.indexOf(u8, s, "session") != null);
-    try testing.expect(std.mem.indexOf(u8, s, "s1") != null);
-    try testing.expect(std.mem.indexOf(u8, s, "opus-4.8") != null);
-    try testing.expect(std.mem.indexOf(u8, s, "1.2M") != null);
-    try testing.expect(std.mem.indexOf(u8, s, "$0.42") != null);
-    try testing.expect(std.mem.indexOf(u8, s, "TOTAL") != null);
-}
-
-test "frame produces ANSI and is non-empty for empty + populated models" {
-    const ally = testing.allocator;
-    var arena = std.heap.ArenaAllocator.init(ally);
+test "frame renders without overflow; view-based; age + detail" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
     var m = Model{};
     var buf = std.ArrayList(u8){};
-    try frame(&buf, a, &m, 24, 100, true); // empty
-    try testing.expect(std.mem.indexOf(u8, buf.items, "\x1b[2J") != null);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "no agents") != null);
+    try frame(&buf, a, &m, 24, 100, .{}); // empty
     buf.clearRetainingCapacity();
-    m.applyLine(ally, "{\"session\":2,\"pane_id\":5,\"state\":\"input\"}");
-    try frame(&buf, a, &m, 24, 100, true);
-    try testing.expect(std.mem.indexOf(u8, buf.items, "input") != null);
+    m.applyLine(a, "{\"session\":1,\"pane_id\":3,\"state\":\"working\",\"usage\":{\"model\":\"opus-4.8\",\"input_tokens\":1200000}}", 5000);
+    try frame(&buf, a, &m, 24, 100, .{ .now_ms = 65000, .detail = true });
+    try testing.expect(std.mem.indexOf(u8, buf.items, "opus-4.8") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "1m0s") != null); // age 60s
+    try testing.expect(std.mem.indexOf(u8, buf.items, "detail") != null);
+}
+
+test "name cache resolves the session column" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var m = Model{};
+    m.applyLine(a, "{\"session\":7,\"pane_id\":1,\"state\":\"idle\"}", 0);
+    var names = NameCache{};
+    names.set(7, "build");
+    var buf = std.ArrayList(u8){};
+    try frame(&buf, a, &m, 24, 100, .{ .names = &names });
+    try testing.expect(std.mem.indexOf(u8, buf.items, "build") != null);
 }

--- a/src/ipc/dashboard/run.zig
+++ b/src/ipc/dashboard/run.zig
@@ -1,8 +1,7 @@
 //! `attyx dashboard` entry point. Opens a cross-session `watch_agents` stream,
-//! renders a live full-screen table, and lets you jump to an agent's session.
-//! Connection: the daemon (all-sessions sentinel) when available, else the
-//! attached window (its session only). Frames are protocol-agnostic length-
-//! prefixed payloads; each payload is fed to the model, which ignores non-records.
+//! renders a live full-screen table, and lets you navigate/jump/zoom/close
+//! agents. Connection: the daemon (all-sessions sentinel) when available, else
+//! the attached window (its session only); reconnects with backoff if dropped.
 const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
@@ -24,7 +23,6 @@ pub const Options = struct {
     once: bool = false,
 };
 
-// --- signal-safe terminal restore -----------------------------------------
 var g_term: ?*term_mod.Term = null;
 var g_winch: bool = false;
 
@@ -35,14 +33,15 @@ fn onTermSignal(_: i32) callconv(.c) void {
 fn onWinch(_: i32) callconv(.c) void {
     g_winch = true;
 }
-
 fn stderrMsg(s: []const u8) void {
     _ = posix.write(posix.STDERR_FILENO, s) catch {};
+}
+fn nowMs() i64 {
+    return std.time.milliTimestamp();
 }
 
 const Source = enum { daemon, window };
 
-/// Daemon all-sessions watch: payload [session:u32 = sentinel][pane_filter:u32].
 fn openDaemon(sock_buf: *[256]u8) ?posix.fd_t {
     const sock = session_connect.getSocketPath(sock_buf) orelse return null;
     const fd = client.connectToSocket(sock) catch return null;
@@ -61,7 +60,6 @@ fn openDaemon(sock_buf: *[256]u8) ?posix.fd_t {
     return fd;
 }
 
-/// Attached-window watch (its session only): payload [pane_filter:u32].
 fn openWindow(sock_buf: *[256]u8) ?posix.fd_t {
     const sock = client.discoverSocket(sock_buf, null) orelse return null;
     const fd = client.connectToSocket(sock) catch return null;
@@ -81,51 +79,59 @@ fn openWindow(sock_buf: *[256]u8) ?posix.fd_t {
 
 /// Briefly read the daemon stream; if it errors or closes before any record (an
 /// older daemon that doesn't understand the all-sessions sentinel), report that
-/// we should fall back to the window. Silence (a live daemon with no agents) is
-/// fine — keep it.
+/// we should fall back to the window. Silence (a live daemon, no agents) is fine.
 fn daemonRejected(stream: *Stream, m: *model_mod.Model, gpa: std.mem.Allocator) bool {
     var pf = [_]posix.pollfd{.{ .fd = stream.fd, .events = POLLIN, .revents = 0 }};
     var rounds: usize = 0;
     while (rounds < 3) : (rounds += 1) {
         const ready = posix.poll(&pf, 250) catch return false;
-        if (ready == 0) return false; // open but quiet → working daemon
-        const alive = stream.pump(m, gpa);
-        if (stream.records > 0) return false; // got data → daemon is fine
-        if (!alive or stream.errored) return true; // closed/errored with no data
+        if (ready == 0) return false;
+        const alive = stream.pump(m, gpa, nowMs());
+        if (stream.records > 0) return false;
+        if (!alive or stream.errored) return true;
     }
     return false;
 }
 
-/// Accumulates stream bytes and feeds complete length-prefixed frames to the
-/// model. Frame = [len:u32 LE][type:u8][payload:len]. Type is ignored — the
-/// payload is an NDJSON agent record (or an error, which the model ignores).
+/// Connect: daemon (all sessions) if it accepts the sentinel, else the window.
+/// Returns null if no instance is reachable.
+fn connect(sock_buf: *[256]u8, m: *model_mod.Model, gpa: std.mem.Allocator) ?Stream {
+    if (openDaemon(sock_buf)) |fd| {
+        var s = Stream{ .fd = fd };
+        if (!daemonRejected(&s, m, gpa)) return s;
+        io.closeFd(s.fd);
+        m.* = .{};
+    }
+    if (openWindow(sock_buf)) |fd| return Stream{ .fd = fd };
+    return null;
+}
+
 const Stream = struct {
     fd: posix.fd_t,
     buf: [64 * 1024]u8 = undefined,
     len: usize = 0,
-    records: usize = 0, // agent records applied (frames starting with '{')
-    errored: bool = false, // saw a non-record frame (an error reply)
+    records: usize = 0,
+    errored: bool = false,
 
-    /// Read available bytes and apply any complete frames. Returns false on
-    /// EOF/error (stream dropped).
-    fn pump(self: *Stream, m: *model_mod.Model, gpa: std.mem.Allocator) bool {
+    /// Read available bytes and apply complete frames. Returns false on EOF/error.
+    fn pump(self: *Stream, m: *model_mod.Model, gpa: std.mem.Allocator, now_ms: i64) bool {
         const n = posix.read(self.fd, self.buf[self.len..]) catch return false;
-        if (n == 0) return false; // EOF
+        if (n == 0) return false;
         self.len += n;
         var off: usize = 0;
         while (self.len - off >= io.header_size) {
             const plen = std.mem.readInt(u32, self.buf[off..][0..4], .little);
-            if (plen > self.buf.len) { // unparseable; resync by dropping buffer
+            if (plen > self.buf.len) {
                 self.len = 0;
                 return true;
             }
-            if (self.len - off - io.header_size < plen) break; // incomplete
+            if (self.len - off - io.header_size < plen) break;
             const payload = self.buf[off + io.header_size ..][0..plen];
             if (plen > 0 and payload[0] == '{') {
-                m.applyLine(gpa, payload);
+                m.applyLine(gpa, payload, now_ms);
                 self.records += 1;
             } else if (plen > 0) {
-                self.errored = true; // an error reply (e.g. old daemon, no sentinel)
+                self.errored = true;
             }
             off += io.header_size + plen;
         }
@@ -137,73 +143,92 @@ const Stream = struct {
     }
 };
 
-/// Jump to the selected agent's session by asking the attached window to switch
-/// to it (one-shot session_switch on the window socket). Pane-level focus within
-/// the session is a follow-up. Best-effort; ignores failure.
-fn jumpToSession(session_id: u32) void {
+/// Switch the attached window to `session`, then send a pane-targeted op
+/// (`.pane_focus_targeted` / `.pane_zoom_targeted` / `.pane_close_targeted`) for
+/// `pane_id`. Best-effort; ignores failure. Switching first means the op lands on
+/// the right session's tab manager even when it isn't the attached one.
+fn switchAndPane(session: u32, pane_id: u32, op: ipc_proto.MessageType) void {
     var sock_buf: [256]u8 = undefined;
     const sock = client.discoverSocket(&sock_buf, null) orelse return;
     const fd = client.connectToSocket(sock) catch return;
     defer io.closeFd(fd);
-    var payload: [4]u8 = undefined;
-    std.mem.writeInt(u32, payload[0..4], session_id, .little);
-    var frame_buf: [ipc_proto.header_size + 4]u8 = undefined;
-    const frame = ipc_proto.encodeMessage(&frame_buf, .session_switch, &payload) catch return;
-    io.writeAll(fd, frame) catch return;
-    // Read and discard the ack so the window processes it before we exit.
     var hdr: [ipc_proto.header_size]u8 = undefined;
+
+    var p1: [4]u8 = undefined;
+    std.mem.writeInt(u32, &p1, session, .little);
+    var fb1: [ipc_proto.header_size + 4]u8 = undefined;
+    const f1 = ipc_proto.encodeMessage(&fb1, .session_switch, &p1) catch return;
+    io.writeAll(fd, f1) catch return;
+    io.readExact(fd, &hdr) catch return; // ack — ensure the switch applied first
+
+    var p2: [4]u8 = undefined;
+    std.mem.writeInt(u32, &p2, pane_id, .little);
+    var fb2: [ipc_proto.header_size + 4]u8 = undefined;
+    const f2 = ipc_proto.encodeMessage(&fb2, op, &p2) catch return;
+    io.writeAll(fd, f2) catch return;
     io.readExact(fd, &hdr) catch {};
+}
+
+/// Populate `names` from the window's `session_list` (TSV: `id\tname\t...`).
+fn resolveNames(names: *render.NameCache) void {
+    var sock_buf: [256]u8 = undefined;
+    const sock = client.discoverSocket(&sock_buf, null) orelse return;
+    const fd = client.connectToSocket(sock) catch return;
+    defer io.closeFd(fd);
+    var fb: [ipc_proto.header_size]u8 = undefined;
+    const frame = ipc_proto.encodeMessage(&fb, .session_list, "") catch return;
+    io.writeAll(fd, frame) catch return;
+    var hdr: [ipc_proto.header_size]u8 = undefined;
+    io.readExact(fd, &hdr) catch return;
+    const h = ipc_proto.decodeHeader(&hdr) catch return;
+    if (h.payload_len == 0 or h.payload_len > 8192) return;
+    var pbuf: [8192]u8 = undefined;
+    io.readExact(fd, pbuf[0..h.payload_len]) catch return;
+    var lines = std.mem.splitScalar(u8, pbuf[0..h.payload_len], '\n');
+    while (lines.next()) |ln| {
+        if (ln.len == 0) continue;
+        var fields = std.mem.splitScalar(u8, ln, '\t');
+        const id_s = fields.next() orelse continue;
+        const name = fields.next() orelse continue;
+        const id = std.fmt.parseInt(u32, std.mem.trim(u8, id_s, " "), 10) catch continue;
+        if (name.len > 0) names.set(id, name);
+    }
 }
 
 pub fn run(gpa: std.mem.Allocator, opts: Options) void {
     var sock_buf: [256]u8 = undefined;
     var m = model_mod.Model{};
-
-    // Prefer the daemon (all sessions); fall back to the attached window (its
-    // session) if there's no daemon, or if the daemon is too old to understand
-    // the all-sessions sentinel (it rejects the request).
-    var source: Source = .daemon;
-    var stream: Stream = if (openDaemon(&sock_buf)) |fd| Stream{ .fd = fd } else blk: {
-        source = .window;
-        break :blk Stream{ .fd = openWindow(&sock_buf) orelse {
-            stderrMsg("error: no running Attyx instance found\n");
-            std.process.exit(1);
-        } };
+    var stream = connect(&sock_buf, &m, gpa) orelse {
+        stderrMsg("error: no running Attyx instance found\n");
+        std.process.exit(1);
     };
-    if (source == .daemon and daemonRejected(&stream, &m, gpa)) {
-        io.closeFd(stream.fd);
-        source = .window;
-        m = .{};
-        stream = Stream{ .fd = openWindow(&sock_buf) orelse {
-            stderrMsg("error: no running Attyx instance found\n");
-            std.process.exit(1);
-        } };
-    }
     defer io.closeFd(stream.fd);
 
-    const tty = term_mod.isTty(posix.STDOUT_FILENO) and term_mod.isTty(posix.STDIN_FILENO);
+    var names = render.NameCache{};
+    resolveNames(&names);
 
-    // --once or non-TTY: drain the snapshot (read until briefly idle), print a
-    // plain table, and exit. No raw mode.
+    const tty = term_mod.isTty(posix.STDOUT_FILENO) and term_mod.isTty(posix.STDIN_FILENO);
     if (opts.once or !tty) {
         var fds = [_]posix.pollfd{.{ .fd = stream.fd, .events = POLLIN, .revents = 0 }};
         while (true) {
             const ready = posix.poll(&fds, 200) catch break;
-            if (ready == 0) break; // ~200ms idle → snapshot complete
-            if (!stream.pump(&m, gpa)) break;
+            if (ready == 0) break;
+            if (!stream.pump(&m, gpa, nowMs())) break;
         }
         var arena = std.heap.ArenaAllocator.init(gpa);
         defer arena.deinit();
         var out = std.ArrayList(u8){};
-        render.snapshot(out.writer(arena.allocator()), arena.allocator(), &m) catch {};
+        render.snapshot(out.writer(arena.allocator()), arena.allocator(), &m, .{ .now_ms = nowMs(), .names = &names }) catch {};
         _ = posix.write(posix.STDOUT_FILENO, out.items) catch {};
         return;
     }
 
-    runInteractive(gpa, &stream, &m) catch {};
+    runInteractive(gpa, &stream, &m, &names) catch {};
 }
 
-fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model) !void {
+const Mode = enum { normal, search, confirm };
+
+fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model, names: *render.NameCache) !void {
     var t = try term_mod.Term.init();
     g_term = &t;
     installSignals();
@@ -215,6 +240,11 @@ fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model) 
     var dec = input.Decoder{};
     var dirty = true;
     var connected = true;
+    var mode: Mode = .normal;
+    var detail = false;
+    var next_retry: i64 = 0;
+    var backoff: i64 = 500;
+    var last_names = nowMs();
 
     var fds = [_]posix.pollfd{
         .{ .fd = stream.fd, .events = POLLIN, .revents = 0 },
@@ -226,13 +256,17 @@ fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model) 
             var arena = std.heap.ArenaAllocator.init(gpa);
             defer arena.deinit();
             var buf = std.ArrayList(u8){};
-            render.frame(&buf, arena.allocator(), m, size.rows, size.cols, connected) catch {};
+            render.frame(&buf, arena.allocator(), m, size.rows, size.cols, .{
+                .now_ms = nowMs(),
+                .names = names,
+                .connected = connected,
+                .detail = detail,
+                .confirm_close = mode == .confirm,
+            }) catch {};
             t.write(buf.items);
             dirty = false;
         }
 
-        // Only poll the stream while connected; -1 makes poll ignore the slot so
-        // a dropped stream doesn't busy-loop. The fd is owned/closed by run().
         fds[0].fd = if (connected) stream.fd else -1;
         _ = posix.poll(&fds, 1000) catch {};
 
@@ -241,47 +275,123 @@ fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model) 
             size = t.size();
             dirty = true;
         }
+        // Refresh elapsed/age (and re-resolve names) on a steady tick.
+        const now = nowMs();
+        if (now - last_names >= 5000) {
+            resolveNames(names);
+            last_names = now;
+            dirty = true;
+        }
+        dirty = true; // 1 Hz idle redraw so the age/elapsed column ticks
+
         if (connected and fds[0].revents & POLLIN != 0) {
-            if (!stream.pump(m, gpa)) {
-                // Stream dropped — keep the last table visible with a banner; the
-                // user quits with q. (Auto-reconnect is a follow-up.)
+            if (!stream.pump(m, gpa, now)) {
                 connected = false;
+                next_retry = now + backoff;
             }
             dirty = true;
         }
+
+        // Reconnect with backoff while disconnected.
+        if (!connected and now >= next_retry) {
+            var sb: [256]u8 = undefined;
+            const saved_sort = m.sort_mode;
+            const saved_filter = m.filter_mode;
+            if (connect(&sb, m, gpa)) |ns| {
+                io.closeFd(stream.fd);
+                stream.* = ns;
+                m.sort_mode = saved_sort;
+                m.filter_mode = saved_filter;
+                m.refresh(now);
+                connected = true;
+                backoff = 500;
+            } else {
+                backoff = @min(backoff * 2, 5000);
+                next_retry = now + backoff;
+            }
+            dirty = true;
+        }
+
         if (fds[1].revents & POLLIN != 0) {
             var ib: [256]u8 = undefined;
             const n = posix.read(posix.STDIN_FILENO, &ib) catch 0;
             if (n == 0) break;
             for (ib[0..n]) |b| {
-                if (dec.feed(b)) |key| switch (key) {
-                    .quit => return,
-                    .up => {
-                        m.moveUp();
-                        dirty = true;
-                    },
-                    .down => {
-                        m.moveDown();
-                        dirty = true;
-                    },
-                    .top => {
-                        m.moveTop();
-                        dirty = true;
-                    },
-                    .bottom => {
-                        m.moveBottom();
-                        dirty = true;
-                    },
-                    .refresh => dirty = true,
-                    .enter => {
-                        if (m.selectedRow()) |r| {
-                            t.restore(); // leave the TUI before switching the window
-                            jumpToSession(r.session);
-                            return;
+                switch (mode) {
+                    .search => {
+                        switch (b) {
+                            0x1b => {
+                                m.searchClear();
+                                mode = .normal;
+                            },
+                            '\r', '\n' => mode = .normal, // keep the query
+                            0x7f, 0x08 => m.searchBackspace(),
+                            else => if (b >= 0x20 and b < 0x7f) m.searchAppend(b),
                         }
+                        dirty = true;
                     },
-                    .help, .none => {},
-                };
+                    .confirm => {
+                        if (b == 'y' or b == 'Y') {
+                            if (m.selectedRow()) |r| switchAndPane(r.session, r.pane_id, .pane_close_targeted);
+                        }
+                        mode = .normal;
+                        dirty = true;
+                    },
+                    .normal => if (dec.feed(b)) |key| switch (key) {
+                        .quit => return,
+                        .up => {
+                            m.moveUp();
+                            dirty = true;
+                        },
+                        .down => {
+                            m.moveDown();
+                            dirty = true;
+                        },
+                        .top => {
+                            m.moveTop();
+                            dirty = true;
+                        },
+                        .bottom => {
+                            m.moveBottom();
+                            dirty = true;
+                        },
+                        .sort => {
+                            m.cycleSort();
+                            dirty = true;
+                        },
+                        .filter => {
+                            m.cycleFilter();
+                            dirty = true;
+                        },
+                        .search => {
+                            m.searchClear();
+                            mode = .search;
+                            dirty = true;
+                        },
+                        .detail => {
+                            detail = !detail;
+                            dirty = true;
+                        },
+                        .zoom => {
+                            if (m.selectedRow()) |r| switchAndPane(r.session, r.pane_id, .pane_zoom_targeted);
+                        },
+                        .close => {
+                            if (m.selectedRow()) |_| {
+                                mode = .confirm;
+                                dirty = true;
+                            }
+                        },
+                        .refresh => dirty = true,
+                        .enter => {
+                            if (m.selectedRow()) |r| {
+                                t.restore(); // leave the TUI before switching the window
+                                switchAndPane(r.session, r.pane_id, .pane_focus_targeted);
+                                return;
+                            }
+                        },
+                        .help, .none => {},
+                    },
+                }
             }
         }
     }

--- a/src/ipc/handler.zig
+++ b/src/ipc/handler.zig
@@ -136,6 +136,7 @@ pub fn handle(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
             sendOk(cmd, "");
         },
         .pane_zoom_targeted => handler_cmd.handlePaneZoomTargeted(cmd, ctx),
+        .pane_focus_targeted => handler_cmd.handlePaneFocusTargeted(cmd, ctx),
 
         // ── Focus commands (silent success) ──
         .focus_up => {

--- a/src/ipc/handler_cmd.zig
+++ b/src/ipc/handler_cmd.zig
@@ -462,6 +462,31 @@ pub fn handlePaneZoomTargeted(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
     sendOk(cmd, "");
 }
 
+/// Focus a pane by IPC id: make its tab the active tab and select it within the
+/// tab's layout. Payload: [pane_id:u32 LE]. Used by `attyx dashboard`'s jump.
+pub fn handlePaneFocusTargeted(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
+    if (cmd.payload_len < 4) {
+        sendError(cmd, "missing pane ID");
+        return;
+    }
+    const pane_id = std.mem.readInt(u32, cmd.payload[0..4], .little);
+    const mgr = ctx.tab_mgr;
+    const found = mgr.findPaneWithLayout(pane_id) orelse {
+        sendError(cmd, "pane not found");
+        return;
+    };
+    found.layout.focused = found.pool_idx;
+    for (0..mgr.count) |i| {
+        const lp = &(mgr.tabs[i] orelse continue);
+        if (lp == found.layout) {
+            mgr.active = @intCast(i);
+            break;
+        }
+    }
+    actions.switchActiveTab(ctx);
+    sendOk(cmd, "");
+}
+
 /// Rotate panes in a tab containing the given pane. Payload: [pane_id:u32 LE]
 /// If no pane ID given (payload_len < 4), rotates the active tab.
 pub fn handlePaneRotateTargeted(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {

--- a/src/ipc/protocol.zig
+++ b/src/ipc/protocol.zig
@@ -83,6 +83,7 @@ pub const MessageType = enum(u8) {
     pane_close_targeted = 0x49,
     pane_zoom_targeted = 0x4A,
     pane_rotate_targeted = 0x4B,
+    pane_focus_targeted = 0xB3, // focus a pane by id (0x4C..0x51 taken; next free)
     // Tab-targeted (payload: [tab_idx:u8][data...])
     tab_close_targeted = 0x4C,
     tab_rename_targeted = 0x4D,


### PR DESCRIPTION
Builds out every deferred `attyx dashboard` interaction (except Windows, which is dropped) and adds the missing CLI parity for image attach.

## Dashboard (`attyx dashboard`)
- **Jump to the pane** — Enter switches to the agent's session *and* focuses its exact pane, via a new `pane_focus_targeted` IPC op (protocol + handler + dispatch).
- **Session names** — resolved from `session_list` into a small `NameCache` (the model stays id-based); the session column shows names, falling back to `s<id>`.
- **Elapsed `age` column** — the model stamps `state_since_ms` on each state change; the TUI redraws at 1 Hz so it ticks.
- **Sort / filter / search** — a filtered+sorted *view* layer in the model: `s` cycles sort (state · cost · tokens · ctx · session), `f` cycles a state filter, `/` searches model/message. Unit-tested.
- **Act on a pane** — `z` zooms, `x` closes (with a `y/N` confirm) the selected agent's pane (session switch + targeted op); `Tab` toggles a detail panel with full usage + the latest message.
- **Reconnect** — a dropped stream shows a "disconnected" banner and **reconnects with backoff** (preserving sort/filter), instead of just sitting idle.

## CLI
- **`attyx send-image <path> [-p <id>]`** — the IPC/handler/MCP plumbing already existed; this wires up the CLI subcommand + help (root, per-command, top-level).

## Deliberately skipped
- **cost_estimates toggle** — estimates are applied in two layers (server serialize + client reformat), so a correct gate means threading a flag through ~8 sites with shaky config access; the `~` prefix already marks estimates. Low value, high cost.
- **currency option** — cost data is USD with no FX conversion, so a currency label would only mislabel the numbers.
- **GPT-5-family price rates** — left for manual verification against OpenAI's pricing (unchanged here).

## Testing
`zig build test` green except the pre-existing flaky daemon-timing test. New unit tests cover the model's sort/filter/search/elapsed view, the render (age + detail + name cache, arena-clean), the input decoder's new keys, and the `send-image` parse. Verified live: `dashboard --once` renders the new columns; `send-image --help`/no-arg behave. The interactive TUI paths (modal, search-as-you-type, reconnect) follow the existing patterns but aren't unit-testable headless — worth a manual pass after rebuilding the daemon/window.