### PR TITLE
Incremental capture — get-text --since <cursor>

### DIFF
--- a/releases/v0.4.14.md
+++ b/releases/v0.4.14.md
@@ -105,3 +105,16 @@ The agent dashboard gained the interactions it was missing:
 ## Attach images from the CLI — `send-image`
 
 `attyx send-image <path> [-p <pane>]` drops an image into a pane as if it were dragged in — e.g. handing Claude Code a screenshot from a script. (Previously available only over MCP.)
+
+## Incremental capture — `get-text --since`
+
+Reading a busy pane no longer means re-capturing the whole screen every time. `attyx get-text --since <cursor>` returns **only the rows produced since your last read**, so tailing a build, a test loop, or another agent is cheap — a quiet pane returns nothing.
+
+Each read hands back a small cursor token; pass it to the next read to get just the new output. Seed with `--since ""` (returns the current screen plus a starting cursor), then feed the cursor forward:
+
+```bash
+attyx get-text -p 3 --since "" 2>cur; cur=$(cut -d' ' -f2 <cur)
+attyx get-text -p 3 --since "$cur"        # only what's new since last time
+```
+
+For scripts and agents, `--json` returns it all in one object — `{ "cursor", "text", "truncated", "reset", "rows" }` — feed `cursor` back next time. It also surfaces when output scrolled past the retained scrollback (`truncated`) or the layout changed (`reset`, e.g. a resize or full clear — the text is then a fresh baseline). The same `since` parameter is available on the MCP `get_text` tool. Works on background sessions too (`-s <id>`).

--- a/skills/claude/attyx/SKILL.md
+++ b/skills/claude/attyx/SKILL.md
@@ -226,6 +226,24 @@ attyx -s 1 get-text -p 5 -n 1000   # last 1000 rows from pane 5 in session 1
 
 The count is clamped to the pane's available scrollback depth. Use this when a long-running command's output has scrolled off-screen, or when you need to inspect history beyond the current viewport.
 
+### Incremental Capture — `--since <cursor>`
+When babysitting a long-running pane (a build, a test loop, another agent), don't re-read the whole screen every poll. `--since` returns **only the rows produced since your last read**, so a quiet pane returns nothing. Each read prints the next cursor (an opaque token) to stderr; pass it back next time. An empty/omitted token (`--since ""`) seeds: it returns the current screen and a starting cursor.
+
+```bash
+# Seed a cursor (printed to stderr as "cursor: g<gen>.l<line>").
+attyx get-text -p 3 --since "" 2>cur; cur=$(cut -d' ' -f2 <cur)
+# Later: only the new rows since last time. Advance the cursor each read.
+new=$(attyx get-text -p 3 --since "$cur" 2>c2); cur=$(cut -d' ' -f2 <c2)
+```
+
+The cleaner path for agents is `--json`, which returns everything in one object:
+
+```json
+{ "cursor": "g3.l10581", "text": "  CC parser.o\n", "truncated": false, "reset": false, "rows": 1 }
+```
+
+Feed `cursor` back as the next `--since`. `truncated: true` means output scrolled past the retained scrollback between reads (read more often, or raise `--scrollback-lines`). `reset: true` means the layout changed (resize, clear, or alt-screen) and `text` is a fresh baseline, not a delta. Semantics are append-only (new scrolled output) — for a full-screen TUI that redraws in place, use plain `get-text` instead. Cursors are per-pane; don't reuse one across panes.
+
 ### Reading Output — Use `--wait-stable`
 Instead of blind `sleep N && attyx get-text`, use `--wait-stable` to send keys and automatically wait for output to settle:
 

--- a/src/app/daemon/handler_ctl.zig
+++ b/src/app/daemon/handler_ctl.zig
@@ -49,6 +49,7 @@ pub fn handle(
     switch (op) {
         .write_input => handleWriteInput(cl, session, req.body),
         .get_text => handleGetText(cl, session, req.body, allocator),
+        .get_text_since => handleGetTextSince(cl, session, req.body, allocator),
         .list => handleList(cl, session, req.body),
         .tab_create => handler_ctl_layout.tabCreate(cl, session, req.body, next_pane_id, allocator, clients),
         .tab_select => handler_ctl_layout.tabSelect(cl, session, req.body, clients),
@@ -261,6 +262,85 @@ fn handleGetText(
     }
 
     cl.sendCtlResponse(0, stream.getWritten());
+}
+
+/// Emit `n` rows from the ring at abs `start`, trailing-space trimmed + UTF-8,
+/// `\n` per row — mirrors the window-side get-text formatting.
+fn emitRows(w: anytype, ring: anytype, start: usize, n: usize) void {
+    const cols = ring.cols;
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        const row_cells = ring.getRow(start + i);
+        var last: usize = cols;
+        while (last > 0 and row_cells[last - 1].char == ' ') last -= 1;
+        for (row_cells[0..last]) |cell| {
+            var cp: [4]u8 = undefined;
+            const len = std.unicode.utf8Encode(cell.char, &cp) catch continue;
+            w.writeAll(cp[0..len]) catch break;
+        }
+        w.writeAll("\n") catch break;
+    }
+}
+
+fn writeJsonStr(w: anytype, s: []const u8) void {
+    for (s) |ch| {
+        switch (ch) {
+            '"' => w.writeAll("\\\"") catch {},
+            '\\' => w.writeAll("\\\\") catch {},
+            '\n' => w.writeAll("\\n") catch {},
+            '\r' => w.writeAll("\\r") catch {},
+            '\t' => w.writeAll("\\t") catch {},
+            else => if (ch < 0x20) {
+                w.print("\\u{x:0>4}", .{ch}) catch {};
+            } else w.writeByte(ch) catch {},
+        }
+    }
+}
+
+/// Incremental capture for a daemon-backed session (`-s ... get-text --since`).
+/// Mirrors handler_query.buildGetTextSince against the session's own engine ring.
+fn handleGetTextSince(cl: *DaemonClient, session: *DaemonSession, body: []const u8, allocator: std.mem.Allocator) void {
+    if (body.len < 20) {
+        cl.sendCtlResponse(1, "malformed get_text_since payload");
+        return;
+    }
+    const pane_id = std.mem.readInt(u32, body[0..4], .little);
+    const gen = std.mem.readInt(u32, body[4..8], .little);
+    const line = std.mem.readInt(u64, body[8..16], .little);
+    const lines = std.mem.readInt(u32, body[16..20], .little);
+    const pane = selectPane(session, pane_id) orelse {
+        cl.sendCtlResponse(1, "pane not found");
+        return;
+    };
+    ensureActive(pane, session);
+    const eng = pane.engine orelse {
+        cl.sendCtlResponse(1, "pane has no screen yet");
+        return;
+    };
+    const ring = &eng.state.ring;
+    const res = ring.sinceRange(line != 0, gen, line, @as(usize, lines));
+
+    const max_row_bytes = ring.cols * 4 + 1;
+    const text_buf = allocator.alloc(u8, res.row_count * max_row_bytes + 64) catch {
+        cl.sendCtlResponse(1, "out of memory");
+        return;
+    };
+    defer allocator.free(text_buf);
+    var ts = std.io.fixedBufferStream(text_buf);
+    emitRows(ts.writer(), ring, res.start_abs, res.row_count);
+    const text = ts.getWritten();
+
+    const json_buf = allocator.alloc(u8, text.len * 6 + 256) catch {
+        cl.sendCtlResponse(1, "out of memory");
+        return;
+    };
+    defer allocator.free(json_buf);
+    var js = std.io.fixedBufferStream(json_buf);
+    const w = js.writer();
+    w.print("{{\"cursor\":\"g{d}.l{d}\",\"text\":\"", .{ res.gen, res.next_line }) catch {};
+    writeJsonStr(w, text);
+    w.print("\",\"truncated\":{},\"reset\":{},\"rows\":{d}}}", .{ res.truncated, res.reset, res.row_count }) catch {};
+    cl.sendCtlResponse(0, js.getWritten());
 }
 
 fn handleList(cl: *DaemonClient, session: *DaemonSession, body: []const u8) void {

--- a/src/app/daemon/protocol.zig
+++ b/src/app/daemon/protocol.zig
@@ -241,6 +241,10 @@ pub const CtlOp = enum(u8) {
     /// rows. pane_filter != 0 restricts output to that pane. Replies with the
     /// listing built from the session's live engines.
     list_agents = 0x0F,
+    /// op_body: [pane_id:u32][gen:u32][line:u64][lines:u32] — incremental capture.
+    /// Replies with the JSON {cursor,text,truncated,reset,rows} object (§ get-text
+    /// --since). `line == 0` seeds from the current screen.
+    get_text_since = 0x10,
 };
 
 /// `list` ctl op kinds (first byte of op_body).

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -77,6 +77,35 @@ pub const IpcRequest = struct {
     /// get-text: number of trailing rows from scrollback+screen to capture.
     /// 0 = visible screen (default behavior).
     lines: u32 = 0,
+    /// get-text --since: incremental-capture cursor (opaque `g<gen>.l<line>`).
+    has_since: bool = false,
+    since_gen: u32 = 0,
+    since_line: u64 = 0,
+    /// get-text --cursor-only: print just the next cursor, no text.
+    cursor_only: bool = false,
+};
+
+/// Incremental-capture cursor: an opaque ASCII token `g<gen>.l<line>`. The client
+/// treats it as a blob; only the CLI/MCP arg parsers and the server decode it.
+pub const Cursor = struct {
+    gen: u32 = 0,
+    line: u64 = 0,
+
+    /// Format into `buf`, returns the slice. Buffer should be >= 32 bytes.
+    pub fn format(self: Cursor, buf: []u8) []const u8 {
+        return std.fmt.bufPrint(buf, "g{d}.l{d}", .{ self.gen, self.line }) catch "g0.l0";
+    }
+
+    /// Parse `g<gen>.l<line>`. An empty token means "seed from now" → null (the
+    /// caller treats null as has_since with gen/line 0, i.e. no prior cursor).
+    pub fn parse(tok: []const u8) ?Cursor {
+        if (tok.len < 4 or tok[0] != 'g') return null;
+        const dot = std.mem.indexOfScalar(u8, tok, '.') orelse return null;
+        if (dot + 1 >= tok.len or tok[dot + 1] != 'l') return null;
+        const gen = std.fmt.parseInt(u32, tok[1..dot], 10) catch return null;
+        const line = std.fmt.parseInt(u64, tok[dot + 2 ..], 10) catch return null;
+        return .{ .gen = gen, .line = line };
+    }
 };
 
 /// Returns true if the string looks like a filesystem path rather than a plain name.
@@ -217,6 +246,18 @@ pub fn parse(args: []const [:0]const u8) ?IpcRequest {
                     const n = std.fmt.parseInt(u32, fargs[gi], 10) catch fatal("--lines: invalid count");
                     if (n == 0) fatal("--lines: count must be >= 1");
                     gt_result.lines = n;
+                } else if (std.mem.eql(u8, fargs[gi], "--since")) {
+                    if (gi + 1 >= fargs.len) fatal("--since requires a cursor (use \"\" to seed)");
+                    gi += 1;
+                    gt_result.has_since = true;
+                    const tok = fargs[gi];
+                    if (tok.len > 0) {
+                        const c = Cursor.parse(tok) orelse fatal("--since: malformed cursor token");
+                        gt_result.since_gen = c.gen;
+                        gt_result.since_line = c.line;
+                    }
+                } else if (std.mem.eql(u8, fargs[gi], "--cursor-only")) {
+                    gt_result.cursor_only = true;
                 }
                 gi += 1;
             }
@@ -821,4 +862,33 @@ test "watch agents -s carries target session" {
     const parsed = parse(&args).?;
     try std.testing.expectEqual(IpcCommand.watch_agents, parsed.command);
     try std.testing.expectEqual(@as(u32, 4), parsed.target_session);
+}
+
+test "Cursor token round-trips and rejects malformed input" {
+    var buf: [32]u8 = undefined;
+    const tok = (Cursor{ .gen = 3, .line = 10581 }).format(&buf);
+    try std.testing.expectEqualStrings("g3.l10581", tok);
+    const c = Cursor.parse(tok).?;
+    try std.testing.expectEqual(@as(u32, 3), c.gen);
+    try std.testing.expectEqual(@as(u64, 10581), c.line);
+    try std.testing.expect(Cursor.parse("") == null);
+    try std.testing.expect(Cursor.parse("garbage") == null);
+    try std.testing.expect(Cursor.parse("g3") == null);
+    try std.testing.expect(Cursor.parse("g3.x5") == null);
+}
+
+test "get-text --since parses cursor and --cursor-only" {
+    const args = [_][:0]const u8{ "attyx", "get-text", "-p", "3", "--since", "g2.l40", "--cursor-only" };
+    const r = parse(&args).?;
+    try std.testing.expectEqual(IpcCommand.get_text, r.command);
+    try std.testing.expect(r.has_since);
+    try std.testing.expectEqual(@as(u32, 2), r.since_gen);
+    try std.testing.expectEqual(@as(u64, 40), r.since_line);
+    try std.testing.expect(r.cursor_only);
+    try std.testing.expectEqual(@as(u32, 3), r.pane_id);
+
+    // Empty token seeds (has_since true, gen/line 0).
+    const args2 = [_][:0]const u8{ "attyx", "get-text", "--since", "" };
+    const r2 = parse(&args2).?;
+    try std.testing.expect(r2.has_since and r2.since_line == 0);
 }

--- a/src/config/cli_ipc_help.zig
+++ b/src/config/cli_ipc_help.zig
@@ -394,7 +394,8 @@ pub const send_keys =
 pub const get_text =
     \\Read visible text (or scrollback history) from a pane.
     \\
-    \\Usage: attyx get-text [--pane <target>] [--lines <N>] [--json]
+    \\Usage: attyx get-text [--pane <target>] [--lines <N>] [--since <cursor>]
+    \\                      [--cursor-only] [--json]
     \\
     \\By default, returns the current screen content of the specified pane
     \\(or the focused pane if --pane is not given). With --lines N, returns
@@ -407,18 +408,34 @@ pub const get_text =
     \\  --lines, -n <N>       Return the last N rows from scrollback + visible
     \\                        screen, instead of just the visible screen. Capped
     \\                        at the pane's scrollback depth.
+    \\  --since <cursor>      Incremental capture: return only rows produced since
+    \\                        the cursor from a previous read. Use "" to seed
+    \\                        (returns the current screen + a starting cursor). The
+    \\                        next cursor prints to stderr as `cursor: g<gen>.l<n>`;
+    \\                        pass it back next time. Treat it as opaque. With
+    \\                        --lines, caps a long catch-up read to the last N rows.
+    \\  --cursor-only         With --since, print just the next cursor to stdout
+    \\                        (no text) — advance without consuming output.
     \\
     \\Output format (plain text):
-    \\  One line per row. Trailing whitespace is trimmed per row.
+    \\  One line per row. Trailing whitespace is trimmed per row. With --since, new
+    \\  rows go to stdout and the next cursor to stderr; `truncated` (output
+    \\  scrolled past retained scrollback) and `reset` (layout changed — text is a
+    \\  fresh baseline) show as stderr notes.
     \\
     \\Output format (--json):
-    \\  { "lines": ["row1", "row2", ...] }
+    \\  { "lines": ["row1", "row2", ...] }   — or, with --since:
+    \\  { "cursor":"g3.l10581", "text":"...", "truncated":false, "reset":false,
+    \\    "rows":2 }
     \\
     \\Examples:
     \\  attyx get-text                         Print screen content
     \\  attyx get-text --pane 3                Read from pane 3
     \\  attyx get-text -n 100                  Last 100 rows (scrollback + screen)
     \\  attyx get-text -p 5 -n 500             Last 500 rows from pane 5
+    \\  # Tail a build: seed once, then read only the new output each tick.
+    \\  attyx get-text -p 3 --since "" 2>cur   Seed; cursor saved to file `cur`
+    \\  attyx get-text -p 3 --since "$(cut -d' ' -f2 cur)" 2>cur   New rows only
     \\
     \\Tip: After running a command with send-keys, wait briefly before
     \\calling get-text to give the command time to produce output.

--- a/src/ipc/client.zig
+++ b/src/ipc/client.zig
@@ -206,7 +206,7 @@ pub fn run(args: []const [:0]const u8) void {
     var heap_resp_buf: ?[]u8 = null;
     defer if (heap_resp_buf) |b| std.heap.page_allocator.free(b);
     var stack_resp_buf: [max_response]u8 = undefined;
-    const resp_buf: []u8 = if (parsed.command == .get_text and parsed.lines > 0) blk: {
+    const resp_buf: []u8 = if (parsed.command == .get_text and (parsed.lines > 0 or parsed.has_since)) blk: {
         const buf = std.heap.page_allocator.alloc(u8, 8 * 1024 * 1024) catch {
             writeStderr("error: out of memory for response buffer\n");
             std.process.exit(1);
@@ -226,7 +226,11 @@ pub fn run(args: []const [:0]const u8) void {
     const stdout = std.fs.File.stdout();
     switch (resp.msg_type) {
         .success => {
-            if (resp.payload.len > 0) {
+            // get-text --since: the payload is a JSON {cursor,text,...} object.
+            // In plain mode, split text→stdout, cursor→stderr (clean pipelines).
+            if (parsed.command == .get_text and parsed.has_since and !parsed.json_output) {
+                printSince(resp.payload, parsed.cursor_only);
+            } else if (resp.payload.len > 0) {
                 if (parsed.json_output) {
                     // JSON mode: pass through raw payload
                     stdout.writeAll(resp.payload) catch {};
@@ -425,6 +429,15 @@ pub fn buildRequest(buf: []u8, parsed: @import("../config/cli_ipc.zig").IpcReque
             break :blk protocol.encodeMessage(buf, .send_image, payload_buf[0 .. 4 + plen]);
         },
         .get_text => blk: {
+            if (parsed.has_since) {
+                // [pane_id:u32][gen:u32][line:u64][lines:u32]
+                var payload: [20]u8 = undefined;
+                std.mem.writeInt(u32, payload[0..4], parsed.pane_id, .little);
+                std.mem.writeInt(u32, payload[4..8], parsed.since_gen, .little);
+                std.mem.writeInt(u64, payload[8..16], parsed.since_line, .little);
+                std.mem.writeInt(u32, payload[16..20], parsed.lines, .little);
+                break :blk protocol.encodeMessage(buf, .get_text_since, &payload);
+            }
             if (parsed.pane_id != 0) {
                 var payload: [8]u8 = undefined;
                 std.mem.writeInt(u32, payload[0..4], parsed.pane_id, .little);
@@ -611,6 +624,37 @@ fn buildGetTextRequest(buf: []u8, pane_id: u32, target_session: u32) ![]u8 {
 
 fn writeStderr(msg: []const u8) void {
     std.fs.File.stderr().writeAll(msg) catch {};
+}
+
+/// Unwrap a `get_text --since` JSON response for plain (non-`--json`) output:
+/// new text → stdout, next cursor → stderr (`cursor: g<gen>.l<line>`), with
+/// `truncated`/`reset` as stderr notes. `--cursor-only` prints just the cursor.
+pub fn printSince(payload: []const u8, cursor_only: bool) void {
+    const Resp = struct {
+        cursor: []const u8 = "",
+        text: []const u8 = "",
+        truncated: bool = false,
+        reset: bool = false,
+        rows: u64 = 0,
+    };
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const r = std.json.parseFromSliceLeaky(Resp, arena.allocator(), payload, .{ .ignore_unknown_fields = true }) catch {
+        std.fs.File.stdout().writeAll(payload) catch {};
+        return;
+    };
+    const stdout = std.fs.File.stdout();
+    if (cursor_only) {
+        stdout.writeAll(r.cursor) catch {};
+        stdout.writeAll("\n") catch {};
+    } else {
+        stdout.writeAll(r.text) catch {};
+        writeStderr("cursor: ");
+        writeStderr(r.cursor);
+        writeStderr("\n");
+    }
+    if (r.reset) writeStderr("note: reset — layout changed; text is a fresh baseline\n");
+    if (r.truncated) writeStderr("note: truncated — output scrolled past retained scrollback\n");
 }
 
 /// Write a string with JSON escaping (quotes, backslashes, control chars).

--- a/src/ipc/client_daemon.zig
+++ b/src/ipc/client_daemon.zig
@@ -109,7 +109,7 @@ pub fn call(a: std.mem.Allocator, parsed: IpcRequest) CallResult {
     var stack_buf: [65536]u8 = undefined;
     var heap: ?[]u8 = null;
     defer if (heap) |h| std.heap.page_allocator.free(h);
-    const resp_buf: []u8 = if (parsed.command == .get_text and parsed.lines > 0) blk: {
+    const resp_buf: []u8 = if (parsed.command == .get_text and (parsed.lines > 0 or parsed.has_since)) blk: {
         const b = std.heap.page_allocator.alloc(u8, 8 * 1024 * 1024) catch
             return .{ .is_error = true, .text = "out of memory for response buffer" };
         heap = b;
@@ -157,6 +157,13 @@ const OpReq = struct { op: dproto.CtlOp, body: []const u8 };
 fn buildOp(parsed: IpcRequest, buf: []u8) ?OpReq {
     switch (parsed.command) {
         .get_text => {
+            if (parsed.has_since) {
+                std.mem.writeInt(u32, buf[0..4], parsed.pane_id, .little);
+                std.mem.writeInt(u32, buf[4..8], parsed.since_gen, .little);
+                std.mem.writeInt(u64, buf[8..16], parsed.since_line, .little);
+                std.mem.writeInt(u32, buf[16..20], parsed.lines, .little);
+                return .{ .op = .get_text_since, .body = buf[0..20] };
+            }
             std.mem.writeInt(u32, buf[0..4], parsed.pane_id, .little);
             std.mem.writeInt(u32, buf[4..8], parsed.lines, .little);
             return .{ .op = .get_text, .body = buf[0..8] };
@@ -491,15 +498,11 @@ fn sendKeys(sock: []const u8, parsed: IpcRequest) void {
 }
 
 fn getText(sock: []const u8, parsed: IpcRequest) void {
-    var op_body: [8]u8 = undefined;
-    std.mem.writeInt(u32, op_body[0..4], parsed.pane_id, .little);
-    std.mem.writeInt(u32, op_body[4..8], parsed.lines, .little);
-
-    // With --lines the screen + scrollback can be large; heap-allocate.
+    // With --lines or --since a catch-up read can be large; heap-allocate.
     var heap: ?[]u8 = null;
     defer if (heap) |h| std.heap.page_allocator.free(h);
     var stack_buf: [65536]u8 = undefined;
-    const resp_buf: []u8 = if (parsed.lines > 0) blk: {
+    const resp_buf: []u8 = if (parsed.lines > 0 or parsed.has_since) blk: {
         const b = std.heap.page_allocator.alloc(u8, 8 * 1024 * 1024) catch {
             stderr("error: out of memory for response buffer\n");
             std.process.exit(1);
@@ -508,6 +511,24 @@ fn getText(sock: []const u8, parsed: IpcRequest) void {
         break :blk b;
     } else stack_buf[0..];
 
+    if (parsed.has_since) {
+        var ob: [20]u8 = undefined;
+        std.mem.writeInt(u32, ob[0..4], parsed.pane_id, .little);
+        std.mem.writeInt(u32, ob[4..8], parsed.since_gen, .little);
+        std.mem.writeInt(u64, ob[8..16], parsed.since_line, .little);
+        std.mem.writeInt(u32, ob[16..20], parsed.lines, .little);
+        const reply = ctlOrExit(sock, parsed.target_session, .get_text_since, &ob, resp_buf);
+        if (reply.status != 0) {
+            reportError(reply.body);
+            std.process.exit(1);
+        }
+        if (parsed.json_output) printBody(reply.body) else @import("client.zig").printSince(reply.body, parsed.cursor_only);
+        return;
+    }
+
+    var op_body: [8]u8 = undefined;
+    std.mem.writeInt(u32, op_body[0..4], parsed.pane_id, .little);
+    std.mem.writeInt(u32, op_body[4..8], parsed.lines, .little);
     const reply = ctlOrExit(sock, parsed.target_session, .get_text, &op_body, resp_buf);
     if (reply.status != 0) {
         reportError(reply.body);

--- a/src/ipc/handler.zig
+++ b/src/ipc/handler.zig
@@ -215,6 +215,7 @@ pub fn handle(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
         .send_image => handleSendImage(cmd, ctx),
         .get_text => handler_query.buildGetText(cmd, ctx),
         .get_text_pane => handler_query.buildGetTextPane(cmd, ctx),
+        .get_text_since => handler_query.buildGetTextSince(cmd, ctx),
 
         // ── Popup ──
         .popup => handler_cmd.handlePopup(cmd, ctx),

--- a/src/ipc/handler_query.zig
+++ b/src/ipc/handler_query.zig
@@ -200,33 +200,16 @@ pub fn buildGetTextPane(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
     writeScreenText(cmd, pane, lines);
 }
 
-fn writeScreenText(cmd: *queue.IpcCommand, pane: anytype, lines: u32) void {
-    const ring = &pane.engine.state.ring;
+/// Emit `row_count` rows from the ring starting at absolute index `start_abs`,
+/// trailing-space trimmed, UTF-8 encoded, one `\n` per row. Shared by every
+/// get-text variant so `--since` output is byte-identical to a full capture.
+fn emitRows(w: anytype, ring: anytype, start_abs: usize, row_count: usize) void {
     const cols = ring.cols;
-
-    // Determine row range. lines == 0 → visible screen only.
-    // lines > 0 → last N rows from the ring (scrollback + screen).
-    const total_rows: usize = if (lines == 0) ring.screen_rows else @min(@as(usize, lines), ring.count);
-    const start_abs: usize = if (lines == 0) ring.scrollbackCount() else ring.count - total_rows;
-
-    // Allocate output buffer sized for worst-case UTF-8 output.
-    const max_row_bytes = cols * 4 + 1;
-    const buf_size = total_rows * max_row_bytes + 64;
-    const buf = pane.allocator.alloc(u8, buf_size) catch {
-        sendError(cmd, "out of memory");
-        return;
-    };
-    defer pane.allocator.free(buf);
-    var stream = std.io.fixedBufferStream(buf);
-    const w = stream.writer();
-
     var i: usize = 0;
-    while (i < total_rows) : (i += 1) {
+    while (i < row_count) : (i += 1) {
         const row_cells = ring.getRow(start_abs + i);
-        // Find last non-space cell to trim trailing whitespace
         var last: usize = cols;
         while (last > 0 and row_cells[last - 1].char == ' ') last -= 1;
-
         for (row_cells[0..last]) |cell| {
             var codepoint_buf: [4]u8 = undefined;
             const len = std.unicode.utf8Encode(cell.char, &codepoint_buf) catch continue;
@@ -234,8 +217,76 @@ fn writeScreenText(cmd: *queue.IpcCommand, pane: anytype, lines: u32) void {
         }
         w.writeAll("\n") catch break;
     }
+}
 
+fn writeScreenText(cmd: *queue.IpcCommand, pane: anytype, lines: u32) void {
+    const ring = &pane.engine.state.ring;
+
+    // Determine row range. lines == 0 → visible screen only.
+    // lines > 0 → last N rows from the ring (scrollback + screen).
+    const total_rows: usize = if (lines == 0) ring.screen_rows else @min(@as(usize, lines), ring.count);
+    const start_abs: usize = if (lines == 0) ring.scrollbackCount() else ring.count - total_rows;
+
+    const max_row_bytes = ring.cols * 4 + 1;
+    const buf = pane.allocator.alloc(u8, total_rows * max_row_bytes + 64) catch {
+        sendError(cmd, "out of memory");
+        return;
+    };
+    defer pane.allocator.free(buf);
+    var stream = std.io.fixedBufferStream(buf);
+    emitRows(stream.writer(), ring, start_abs, total_rows);
     sendOk(cmd, stream.getWritten());
+}
+
+/// `get_text --since`: payload `[pane_id:u32][gen:u32][line:u64][lines:u32]`.
+/// `line == 0` means "seed" (no prior cursor → return the current screen). Always
+/// responds with a JSON object `{cursor,text,truncated,reset,rows}` — the cursor
+/// must travel with the text, so the CLI/MCP layer unwraps it.
+pub fn buildGetTextSince(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
+    if (cmd.payload_len < 20) {
+        sendError(cmd, "malformed get_text_since payload");
+        return;
+    }
+    const pane_id = std.mem.readInt(u32, cmd.payload[0..4], .little);
+    const gen = std.mem.readInt(u32, cmd.payload[4..8], .little);
+    const line = std.mem.readInt(u64, cmd.payload[8..16], .little);
+    const lines = std.mem.readInt(u32, cmd.payload[16..20], .little);
+
+    const pane = if (pane_id == 0)
+        ctx.tab_mgr.activePane()
+    else
+        ctx.tab_mgr.findPaneById(pane_id) orelse {
+            sendError(cmd, "pane not found");
+            return;
+        };
+
+    const ring = &pane.engine.state.ring;
+    const res = ring.sinceRange(line != 0, gen, line, @as(usize, lines));
+
+    // Render the delta rows to a temp buffer, then wrap (JSON-escaped) in the
+    // response object. Sized for worst-case UTF-8 + escape expansion.
+    const max_row_bytes = ring.cols * 4 + 1;
+    const text_cap = res.row_count * max_row_bytes + 64;
+    const text_buf = pane.allocator.alloc(u8, text_cap) catch {
+        sendError(cmd, "out of memory");
+        return;
+    };
+    defer pane.allocator.free(text_buf);
+    var text_stream = std.io.fixedBufferStream(text_buf);
+    emitRows(text_stream.writer(), ring, res.start_abs, res.row_count);
+    const text = text_stream.getWritten();
+
+    const json_buf = pane.allocator.alloc(u8, text.len * 6 + 256) catch {
+        sendError(cmd, "out of memory");
+        return;
+    };
+    defer pane.allocator.free(json_buf);
+    var json = std.io.fixedBufferStream(json_buf);
+    const w = json.writer();
+    w.print("{{\"cursor\":\"g{d}.l{d}\",\"text\":\"", .{ res.gen, res.next_line }) catch {};
+    agents.writeJsonEscaped(w, text) catch {};
+    w.print("\",\"truncated\":{},\"reset\":{},\"rows\":{d}}}", .{ res.truncated, res.reset, res.row_count }) catch {};
+    sendOk(cmd, json.getWritten());
 }
 
 pub fn handleSessionList(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {

--- a/src/ipc/mcp_tools.zig
+++ b/src/ipc/mcp_tools.zig
@@ -25,7 +25,7 @@ const TOOLS_RAW =
     \\{"name":"list_tabs","description":"List tabs in the current (or targeted) session.","inputSchema":{"type":"object","properties":{"session":{"type":"integer"}}}},
     \\{"name":"list_panes","description":"List panes (splits) with their stable IPC ids.","inputSchema":{"type":"object","properties":{"session":{"type":"integer"}}}},
     \\{"name":"list_agents","description":"List AI agents running in panes with status and usage. Returns JSON: each agent has pane_id, tab_id, session, pid, state (idle|working|input), message, and a usage object with input_tokens, output_tokens, context_used, context_max (context window size), cost_usd, cost_is_estimate, and model. Unknown usage fields are omitted (absent = unknown, not zero).","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Restrict to one pane id."},"session":{"type":"integer"}}}},
-    \\{"name":"get_text","description":"Capture visible screen text of a pane. With 'lines', captures that many trailing rows from scrollback.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"lines":{"type":"integer","description":"Trailing rows to capture (omit for visible screen)."},"session":{"type":"integer"}}}},
+    \\{"name":"get_text","description":"Capture a pane's screen text. With 'lines', captures that many trailing rows from scrollback. Pass the 'cursor' from a previous result as 'since' to get ONLY the new output since that read (incremental tailing) — the result is {cursor,text,truncated,reset,rows}; feed 'cursor' back next time. Use since:\"\" to seed (returns the current screen + a starting cursor).","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"lines":{"type":"integer","description":"Trailing rows to capture (omit for visible screen)."},"since":{"type":"string","description":"Cursor from a previous get_text result; returns only new rows since then. Empty string seeds from the current screen."},"cursor_only":{"type":"boolean","description":"Return just the next cursor, no text."},"session":{"type":"integer"}}}},
     \\{"name":"send_keys","description":"Send keystrokes/text to a pane. Supports C-style escapes (\\n, \\t, \\x03) and named keys like {Enter} {Down}.","inputSchema":{"type":"object","properties":{"text":{"type":"string"},"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"session":{"type":"integer"}},"required":["text"]}},
     \\{"name":"send_image","description":"Attach an image to a pane as if a file were dragged/pasted into the terminal (e.g. to give Claude Code a screenshot). Provide either 'path' (an image file already on disk) or 'data' (base64-encoded image bytes, materialized to a temp file). The image's file path is injected as a bracketed paste; Enter is NOT pressed.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute path to an image file on disk."},"data":{"type":"string","description":"Base64-encoded image bytes (used when no path is available)."},"filename":{"type":"string","description":"Optional original filename; its extension names the temp file when using 'data'."},"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"session":{"type":"integer"}}}},
     \\{"name":"focus","description":"Move keyboard focus between panes.","inputSchema":{"type":"object","properties":{"direction":{"type":"string","enum":["up","down","left","right"]},"session":{"type":"integer"}},"required":["direction"]}},
@@ -109,6 +109,15 @@ pub fn fill(name: []const u8, args: ?std.json.ObjectMap) ?IpcRequest {
     } else if (eql(u8, name, "get_text")) {
         r.command = .get_text;
         r.lines = u32Of(args, "lines");
+        if (getStr(args, "since")) |tok| {
+            r.has_since = true;
+            if (tok.len > 0) {
+                const c = @import("../config/cli_ipc.zig").Cursor.parse(tok) orelse return null;
+                r.since_gen = c.gen;
+                r.since_line = c.line;
+            }
+        }
+        r.cursor_only = getBool(args, "cursor_only");
     } else if (eql(u8, name, "send_keys")) {
         r.command = .send_keys;
         r.text_arg = getStr(args, "text") orelse return null;

--- a/src/ipc/protocol.zig
+++ b/src/ipc/protocol.zig
@@ -77,6 +77,7 @@ pub const MessageType = enum(u8) {
     send_keys_pane = 0x46,
     send_text_pane = 0x47, // Deprecated alias for send_keys_pane — kept for wire compat
     get_text_pane = 0x48,
+    get_text_since = 0x52, // incremental capture: [pane_id:u32][gen:u32][line:u64][lines:u32]
 
     // ── Targeted operations ──
     // Pane-targeted (payload: [pane_id:u32 LE])

--- a/src/term/ring.zig
+++ b/src/term/ring.zig
@@ -17,6 +17,16 @@ pub const RingBuffer = struct {
     count: usize, // total rows written (≤ capacity)
     allocator: std.mem.Allocator,
 
+    /// Monotonic count of lines that have ever scrolled off the screen top into
+    /// scrollback (bumped in `advanceScreen`). The current screen's top row is
+    /// logical line `lines_total`; scrollback holds logical
+    /// `[lines_total - scrollbackCount(), lines_total)`. Drives `get_text --since`.
+    lines_total: u64 = 0,
+    /// Layout generation — bumped on resize/reflow, clear-scrollback, and
+    /// alt-screen switches. A cursor with a stale `gen` can't be deltaed, so the
+    /// server returns a fresh baseline instead. See `sinceRange`.
+    layout_gen: u32 = 0,
+
     pub const default_max_scrollback: usize = 5_000;
 
     pub fn init(
@@ -86,6 +96,62 @@ pub const RingBuffer = struct {
     /// Number of scrollback rows (rows above the visible screen).
     pub fn scrollbackCount(self: *const RingBuffer) usize {
         return if (self.count > self.screen_rows) self.count - self.screen_rows else 0;
+    }
+
+    /// The rows to emit for an incremental `get_text --since` read, plus the next
+    /// cursor and status flags. The ring maps to logical lines
+    /// `[lines_total - scrollbackCount(), lines_total + screen_rows)`, with abs
+    /// index `logical - base`.
+    pub const SinceResult = struct {
+        start_abs: usize, // first ring abs index to emit
+        row_count: usize, // rows to emit (start_abs + row_count <= count)
+        next_line: u64, // new cursor line (one past the last screen row)
+        gen: u32, // current layout generation (for the new cursor)
+        reset: bool, // layout changed / future cursor → text is a fresh baseline
+        truncated: bool, // some lines scrolled past retained scrollback unseen
+    };
+
+    /// Compute the delta range. `has_prior=false` seeds from the current screen
+    /// (returns the visible screen + a cursor at the bottom). With a prior cursor:
+    /// a `gen` mismatch or a future `line` resets to the screen baseline; a `line`
+    /// older than retained scrollback clamps and flags `truncated`; otherwise it
+    /// returns logical `[line, head)`. `max_rows != 0` caps a long catch-up read to
+    /// the newest `max_rows` rows (flagging `truncated`).
+    pub fn sinceRange(self: *const RingBuffer, has_prior: bool, gen: u32, line: u64, max_rows: usize) SinceResult {
+        const sb = self.scrollbackCount();
+        const base: u64 = self.lines_total - sb;
+        const head: u64 = self.lines_total + self.screen_rows;
+
+        var reset = false;
+        var truncated = false;
+        var start_line: u64 = undefined;
+        if (!has_prior) {
+            start_line = self.lines_total; // seed: current visible screen
+        } else if (gen != self.layout_gen or line > head) {
+            reset = true;
+            start_line = self.lines_total;
+        } else if (line < base) {
+            truncated = true;
+            start_line = base;
+        } else {
+            start_line = line; // normal delta (line == head → empty)
+        }
+
+        var start_abs: usize = @intCast(start_line - base);
+        var row_count: usize = @intCast(head - start_line);
+        if (max_rows != 0 and row_count > max_rows) {
+            start_abs += row_count - max_rows;
+            row_count = max_rows;
+            truncated = true;
+        }
+        return .{
+            .start_abs = start_abs,
+            .row_count = row_count,
+            .next_line = head,
+            .gen = self.layout_gen,
+            .reset = reset,
+            .truncated = truncated,
+        };
     }
 
     /// Ring slot for absolute row `i` (0 = oldest).
@@ -247,6 +313,7 @@ pub const RingBuffer = struct {
             self.head = (self.head + 1) % self.capacity;
             // count stays at capacity
         }
+        self.lines_total +%= 1; // one more logical line scrolled into history
         // Clear the new bottom screen row
         self.clearScreenRow(self.screen_rows - 1);
         return true;
@@ -624,4 +691,87 @@ test "ring: deleteChars" {
     try testing.expectEqual(@as(u21, 'E'), ring.getScreenCell(0, 2).char);
     try testing.expectEqual(@as(u21, ' '), ring.getScreenCell(0, 3).char);
     try testing.expectEqual(@as(u21, ' '), ring.getScreenCell(0, 4).char);
+}
+
+test "sinceRange: seed returns the current screen, cursor at the bottom" {
+    var ring = try RingBuffer.init(testing.allocator, 3, 5, 5);
+    defer ring.deinit();
+    const r = ring.sinceRange(false, 0, 0, 0);
+    try testing.expectEqual(@as(usize, 0), r.start_abs);
+    try testing.expectEqual(@as(usize, 3), r.row_count); // screen_rows
+    try testing.expectEqual(@as(u64, 3), r.next_line); // head = 0 + 3
+    try testing.expect(!r.reset and !r.truncated);
+}
+
+test "sinceRange: append delta returns only newly scrolled lines" {
+    var ring = try RingBuffer.init(testing.allocator, 3, 5, 5);
+    defer ring.deinit();
+    const seed = ring.sinceRange(false, 0, 0, 0); // cursor at line 3
+    _ = ring.advanceScreen();
+    _ = ring.advanceScreen(); // 2 lines scrolled → lines_total = 2
+    const d = ring.sinceRange(true, seed.gen, seed.next_line, 0);
+    try testing.expectEqual(@as(usize, 2), d.row_count); // exactly the 2 new lines
+    try testing.expectEqual(@as(u64, 5), d.next_line); // head = 2 + 3
+    try testing.expect(!d.reset and !d.truncated);
+
+    // No change → empty, same cursor.
+    const e = ring.sinceRange(true, d.gen, d.next_line, 0);
+    try testing.expectEqual(@as(usize, 0), e.row_count);
+    try testing.expectEqual(d.next_line, e.next_line);
+}
+
+test "sinceRange: truncation when the cursor falls behind retained scrollback" {
+    var ring = try RingBuffer.init(testing.allocator, 3, 5, 5); // capacity 8, max scrollback 5
+    defer ring.deinit();
+    const seed = ring.sinceRange(false, 0, 0, 0); // line 3
+    var i: usize = 0;
+    while (i < 10) : (i += 1) _ = ring.advanceScreen(); // lines_total = 10, scrollback caps at 5
+    const d = ring.sinceRange(true, seed.gen, seed.next_line, 0);
+    try testing.expect(d.truncated);
+    try testing.expectEqual(@as(usize, 0), d.start_abs); // clamped to oldest retained
+    // base = 10 - 5 = 5, head = 10 + 3 = 13 → 8 rows (whole ring).
+    try testing.expectEqual(@as(usize, 8), d.row_count);
+    try testing.expectEqual(@as(u64, 13), d.next_line);
+}
+
+test "sinceRange: gen mismatch resets to a fresh baseline" {
+    var ring = try RingBuffer.init(testing.allocator, 3, 5, 5);
+    defer ring.deinit();
+    const seed = ring.sinceRange(false, 0, 0, 0);
+    _ = ring.advanceScreen();
+    ring.layout_gen +%= 1; // simulate resize/clear/alt-screen
+    const d = ring.sinceRange(true, seed.gen, seed.next_line, 0);
+    try testing.expect(d.reset);
+    try testing.expectEqual(ring.layout_gen, d.gen);
+    try testing.expectEqual(@as(usize, 3), d.row_count); // current screen baseline
+}
+
+test "sinceRange: a future cursor resets, no panic" {
+    var ring = try RingBuffer.init(testing.allocator, 3, 5, 5);
+    defer ring.deinit();
+    const d = ring.sinceRange(true, 0, 9999, 0); // line > head
+    try testing.expect(d.reset);
+    try testing.expectEqual(@as(usize, 3), d.row_count);
+}
+
+test "sinceRange: lines caps a long catch-up read to the newest rows" {
+    var ring = try RingBuffer.init(testing.allocator, 3, 5, 5);
+    defer ring.deinit();
+    const seed = ring.sinceRange(false, 0, 0, 0);
+    var i: usize = 0;
+    while (i < 4) : (i += 1) _ = ring.advanceScreen(); // 4 new lines, all retained
+    const d = ring.sinceRange(true, seed.gen, seed.next_line, 2); // cap at 2
+    try testing.expectEqual(@as(usize, 2), d.row_count);
+    try testing.expect(d.truncated);
+    try testing.expectEqual(@as(u64, 7), d.next_line); // head = 4 + 3, cursor still advances
+}
+
+test "advanceScreen bumps lines_total monotonically" {
+    var ring = try RingBuffer.init(testing.allocator, 2, 4, 3);
+    defer ring.deinit();
+    try testing.expectEqual(@as(u64, 0), ring.lines_total);
+    _ = ring.advanceScreen();
+    _ = ring.advanceScreen();
+    _ = ring.advanceScreen();
+    try testing.expectEqual(@as(u64, 3), ring.lines_total); // counts even after eviction
 }

--- a/src/term/state_altscreen.zig
+++ b/src/term/state_altscreen.zig
@@ -56,6 +56,7 @@ pub fn enterAltScreen(self: *TerminalState) void {
     self.saved_cursor = null;
     self.wrap_next = false;
     self.alt_active = true;
+    self.ring.layout_gen +%= 1; // screen content swapped → invalidate --since cursors
     self.kittyResetFlags();
     self.dirty.markAll(self.ring.screen_rows);
 }
@@ -64,6 +65,7 @@ pub fn leaveAltScreen(self: *TerminalState) void {
     if (!self.alt_active) return;
     swapBuffers(self);
     self.alt_active = false;
+    self.ring.layout_gen +%= 1; // screen content swapped back → invalidate cursors
     self.kittyResetFlags();
     self.dirty.markAll(self.ring.screen_rows);
 }

--- a/src/term/state_erase.zig
+++ b/src/term/state_erase.zig
@@ -75,6 +75,7 @@ pub fn eraseInDisplay(self: *TerminalState, mode: actions_mod.EraseMode) void {
             // CSI 3 J — Erase Saved Lines: clear scrollback buffer.
             if (!self.alt_active) {
                 self.ring.clearScrollback();
+                self.ring.layout_gen +%= 1; // retained range changed → invalidate cursors
                 self.viewport_offset = 0;
             }
             self.dirty.markAll(rows);

--- a/src/term/state_resize.zig
+++ b/src/term/state_resize.zig
@@ -55,6 +55,7 @@ fn clampInactiveState(self: *TerminalState, rows: usize, cols: usize) void {
 /// Resize both the ring buffer and the inactive grid.
 pub fn resize(self: *TerminalState, new_rows: usize, new_cols: usize) !void {
     if (new_rows == self.ring.screen_rows and new_cols == self.ring.cols) return;
+    const prev_gen = self.ring.layout_gen;
 
     if (self.reflow_on_resize and !self.alt_active) {
         // Full reflow through the ring (scrollback + screen)
@@ -96,6 +97,11 @@ pub fn resize(self: *TerminalState, new_rows: usize, new_cols: usize) !void {
     }
 
     try self.inactive_grid.resizeNoReflow(new_rows, new_cols);
+
+    // Reflow remaps lines, so old `--since` cursors can't be deltaed: bump the
+    // generation and rebaseline the logical counter on the fresh ring.
+    self.ring.layout_gen = prev_gen +% 1;
+    self.ring.lines_total = self.ring.scrollbackCount();
 
     self.viewport_offset = 0;
 


### PR DESCRIPTION
Implements `docs/incremental-get-text.md`. Lets an agent read **only the rows a pane produced since its last read** instead of re-capturing the whole screen each poll — the biggest token-savings-per-effort win on the agent surface. A read returns an opaque cursor; pass it back and only new rows come down. A quiet pane returns ~nothing.

Targets release **0.4.14** (PR base is `release-0.4.14`).

## How it works
A cursor is `{gen, line}` — `line` is a per-pane monotonic logical line number (every line that's ever scrolled into history), `gen` invalidates cursors when the line↔content mapping changes (resize/reflow, clear-scrollback, alt-screen). The token is opaque ASCII `g<gen>.l<line>`; clients never parse it.

## Engine (`src/term`)
- `ring.zig`: `lines_total` (bumped in `advanceScreen`, the single scroll chokepoint) + `layout_gen`, and **`sinceRange()`** — the pure logical→abs mapping that computes the delta range plus `reset` (gen mismatch / future cursor) and `truncated` (cursor behind retained scrollback) flags. Fully unit-tested.
- `layout_gen` bumps on resize/reflow (carried across the ring rebuild + rebaselined), clear-scrollback (ED3), and alt-screen enter/leave — so a stale cursor returns a fresh baseline instead of garbage.

## Surface
- `protocol .get_text_since` `[pane][gen][line][lines]`; `handler_query.buildGetTextSince` shares the row-emit loop with `writeScreenText` (byte-identical formatting) and replies with JSON `{cursor,text,truncated,reset,rows}`.
- CLI: `--since <cursor>` / `--cursor-only`, opaque `Cursor` codec; plain mode prints text→stdout, `cursor: …`→stderr (existing `get-text | grep` pipelines keep working).
- MCP `get_text` tool gains `since` / `cursor_only`.
- Daemon ctl op `get_text_since` routes `-s <session>` background sessions.

## Semantics
Append-only (new scrolled output) — a full-screen TUI that redraws in place should use plain `get-text`. `--since ""` seeds (current screen + a starting cursor). Cursors are per-pane.

## Testing
Headless: seed/append-delta, no-change, truncation, gen-reset, future-cursor, `lines`-cap, cursor token round-trip + malformed rejection, `--since` arg parse. `zig build test` is green except one **pre-existing** failure on `release-0.4.14` (`config.commands_test.actionFromName`) that also fails on the untouched base — unrelated to this change. (The server-side handler needs a rebuilt daemon/window to exercise end-to-end.)