### PR TITLE
Add agent send / agent await — drive another agent and await its turn

### DIFF
--- a/releases/v0.4.14.md
+++ b/releases/v0.4.14.md
@@ -118,3 +118,15 @@ attyx get-text -p 3 --since "$cur"        # only what's new since last time
 ```
 
 For scripts and agents, `--json` returns it all in one object — `{ "cursor", "text", "truncated", "reset", "rows" }` — feed `cursor` back next time. It also surfaces when output scrolled past the retained scrollback (`truncated`) or the layout changed (`reset`, e.g. a resize or full clear — the text is then a fresh baseline). The same `since` parameter is available on the MCP `get_text` tool. Works on background sessions too (`-s <id>`).
+
+## Drive another agent — `agent send` / `agent await`
+
+Orchestrating agents no longer means hand-rolling send-keys + a `watch agents` loop + `get-text`. `attyx agent send -p <id> "<prompt>" --wait` sends a prompt to the agent in a pane and **blocks until that agent's turn finishes**, then reports the outcome:
+
+```bash
+attyx agent send -p 3 "run the tests and fix any failures" --wait
+attyx agent send -p 3 "summarize src/api" --wait --capture --json
+attyx agent await -p 3 --state any        # just wait — send nothing
+```
+
+The prompt is pasted (so multi-line prompts and `{`/`}` are literal) and submitted; the agent is never interrupted. Outcomes — `done`, `needs_input`, `timeout`, `no_turn`, `ended` — map to exit codes (0/2/3/4), so `attyx agent send -p 3 "build" --wait && attyx agent send -p 5 "deploy" --wait` chains turns only on success. Add `--capture` for just the output the turn produced (built on `get-text --since`) and `--tokens` for the per-turn token/cost. `agent await` is the formalized version of "block until the agent in pane N is idle." It's also the MCP `agent_send` / `agent_await` tools — the clean way for one agent to drive another.

--- a/skills/claude/attyx/SKILL.md
+++ b/skills/claude/attyx/SKILL.md
@@ -356,10 +356,9 @@ attyx watch agents -p 3             # only pane 3's agent
 # {"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"working","message":"..."}
 # {"pane_id":3,"tab_id":3,"session":1,"pid":48213,"state":"idle","message":""}
 
-# Block until a specific agent finishes its current turn
-attyx watch agents -p 3 | while read -r line; do
-  echo "$line" | grep -q '"state":"idle"' && break
-done
+# Block until a specific agent finishes its current turn — use `agent await`
+# (the formalized version of the hand-rolled `watch … | while read` loop):
+attyx agent await -p 3 --state idle
 ```
 The pane ID is the `pane_id` from `attyx list agents` (or the ID returned when you created the pane). `0`/omitted means all agents.
 
@@ -369,6 +368,22 @@ To check one pane's agent without streaming, pass its stable pane ID:
 attyx list agents -p 3              # just pane 3's agent (one line, or empty if none)
 attyx list agents -p 3 --json      # same, as a JSON array
 ```
+
+### Driving another agent — `agent send` / `agent await`
+To send a prompt to an agent in another pane and **block until its turn finishes**, use `agent send --wait` instead of hand-rolling send-keys + a watch loop + get-text. It pastes the prompt (multi-line safe), presses Enter, waits for the turn, and reports the outcome.
+```bash
+# Send a prompt and wait; exit code encodes the outcome.
+attyx agent send -p 3 "run the tests and fix any failures" --wait
+
+# Capture just the turn's output (uses get-text --since) as JSON:
+attyx agent send -p 3 "summarize src/api" --wait --capture --json
+# {"pane":3,"session":1,"outcome":"done","duration_ms":48213,"message":"…",
+#  "output":"…only the rows this turn produced…","truncated":false}
+
+# Just wait (send nothing) until an agent is done or needs you:
+attyx agent await -p 3 --state any
+```
+**Outcomes** (and exit codes): `done` (0) · `needs_input` (2) · `timeout` (3) · `no_turn`/`ended` (4). So `attyx agent send -p 3 "build" --wait && attyx agent send -p 5 "deploy" --wait` chains turns only on success. Add `--tokens` for the per-turn token/cost delta. Outcomes are honest: `no_turn` means the agent never started (wrong pane / it didn't accept the input), `timeout` means it's still working (the agent is never interrupted — we just stop waiting). Over MCP this is the `agent_send` tool. (Currently targets the attached session; `-s` background sessions are a follow-up.)
 `-p`/`--pane` works on both `list agents` and `watch agents`; omit it for all agents.
 
 ## Argument Handling

--- a/src/config/cli.zig
+++ b/src/config/cli.zig
@@ -396,6 +396,7 @@ fn isIpcSubcommand(arg: []const u8) bool {
         "scroll-to", "list",      "session",    "popup",  "run",
         "watch", // stream agent status: `watch agents`
         "send-image", // attach an image file to a pane
+        "agent", // drive another agent: `agent send` / `agent await`
         "--target", // --target <pid> before subcommand
         "--json", // --json before subcommand
         "-s",      "--session", // -s/--session <id> before subcommand

--- a/src/config/cli_help.zig
+++ b/src/config/cli_help.zig
@@ -106,6 +106,7 @@ const ipc_misc =
     "  " ++ d ++ "Utilities" ++ r ++ "\n" ++
     cmd("list [tabs|splits|sessions|agents] [--json]   ", "Query tabs, panes, sessions, or agents") ++
     cmd("watch agents [--json]   ", "Stream agent status/usage changes (live)") ++
+    cmd("agent send|await -p <id> ...   ", "Drive another agent: send a prompt, await its turn") ++
     cmd("scroll-to <top|bottom|page-up|page-down>   ", "Scroll the viewport") ++
     cmd("reload                 ", "Hot-reload config from disk") ++
     cmd("theme <name>           ", "Switch to a named theme") ++

--- a/src/config/cli_ipc.zig
+++ b/src/config/cli_ipc.zig
@@ -35,6 +35,8 @@ pub const IpcCommand = enum {
     send_keys,
     send_image,
     get_text,
+    agent_send,
+    agent_await,
     config_reload,
     theme_set,
     scroll_to_top,
@@ -83,7 +85,15 @@ pub const IpcRequest = struct {
     since_line: u64 = 0,
     /// get-text --cursor-only: print just the next cursor, no text.
     cursor_only: bool = false,
+    /// agent send/await options. Prompt text rides in `text_arg`.
+    agent_capture: bool = false,
+    agent_tokens: bool = false,
+    agent_timeout_s: u32 = 0, // 0 = default
+    agent_submit_key: []const u8 = "", // "" = {Enter}
+    agent_await_state: AwaitState = .idle,
 };
+
+pub const AwaitState = enum { idle, input, any };
 
 /// Incremental-capture cursor: an opaque ASCII token `g<gen>.l<line>`. The client
 /// treats it as a blob; only the CLI/MCP arg parsers and the server decode it.
@@ -301,6 +311,7 @@ pub fn parse(args: []const [:0]const u8) ?IpcRequest {
         if (std.mem.eql(u8, sub, "list")) break :blk parseList(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "watch")) break :blk parseWatch(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "session")) break :blk parseSession(fargs, start, target_pid, json_output);
+        if (std.mem.eql(u8, sub, "agent")) break :blk parseAgent(fargs, start, target_pid, json_output);
         if (std.mem.eql(u8, sub, "run")) {
             if (hasHelp(fargs, start)) showHelp(help.run);
             if (start + 1 >= fargs.len) {
@@ -724,6 +735,79 @@ fn parseWatch(args: []const [:0]const u8, start: usize, target_pid: ?u32, json_o
 // ---------------------------------------------------------------------------
 // Session
 // ---------------------------------------------------------------------------
+
+fn parseAgent(args: []const [:0]const u8, start: usize, target_pid: ?u32, json_output: bool) ?IpcRequest {
+    if (start + 1 >= args.len or isHelp(args[start + 1])) {
+        if (start + 1 < args.len and isHelp(args[start + 1])) showHelp(help.agent);
+        printHelp(help.agent);
+        return null;
+    }
+    const action = args[start + 1];
+    if (std.mem.eql(u8, action, "send")) {
+        if (hasHelp(args, start + 1)) showHelp(help.agent);
+        var r = IpcRequest{ .command = .agent_send, .target_pid = target_pid, .json_output = json_output };
+        var prompt: []const u8 = "";
+        var i = start + 2;
+        while (i < args.len) : (i += 1) {
+            const arg = args[i];
+            if (std.mem.eql(u8, arg, "--pane") or std.mem.eql(u8, arg, "-p")) {
+                if (i + 1 >= args.len) fatal("--pane requires a pane ID");
+                i += 1;
+                parsePaneArg(args[i], &r);
+            } else if (std.mem.eql(u8, arg, "--wait")) {
+                r.wait = true;
+            } else if (std.mem.eql(u8, arg, "--capture")) {
+                r.agent_capture = true;
+            } else if (std.mem.eql(u8, arg, "--tokens")) {
+                r.agent_tokens = true;
+            } else if (std.mem.eql(u8, arg, "--timeout")) {
+                if (i + 1 >= args.len) fatal("--timeout requires seconds");
+                i += 1;
+                r.agent_timeout_s = std.fmt.parseInt(u32, args[i], 10) catch fatal("--timeout: invalid seconds");
+            } else if (std.mem.eql(u8, arg, "--submit-key")) {
+                if (i + 1 >= args.len) fatal("--submit-key requires a key");
+                i += 1;
+                r.agent_submit_key = args[i];
+            } else if (prompt.len == 0) {
+                prompt = args[i];
+            }
+        }
+        if (r.pane_id == 0) fatal("agent send requires --pane <id>");
+        if (prompt.len == 0) {
+            printHelp(help.agent);
+            return null;
+        }
+        // --capture / --tokens only make sense once the turn completes.
+        if (r.agent_capture or r.agent_tokens) r.wait = true;
+        r.text_arg = prompt;
+        return r;
+    } else if (std.mem.eql(u8, action, "await")) {
+        if (hasHelp(args, start + 1)) showHelp(help.agent);
+        var r = IpcRequest{ .command = .agent_await, .target_pid = target_pid, .json_output = json_output };
+        var i = start + 2;
+        while (i < args.len) : (i += 1) {
+            const arg = args[i];
+            if (std.mem.eql(u8, arg, "--pane") or std.mem.eql(u8, arg, "-p")) {
+                if (i + 1 >= args.len) fatal("--pane requires a pane ID");
+                i += 1;
+                parsePaneArg(args[i], &r);
+            } else if (std.mem.eql(u8, arg, "--state")) {
+                if (i + 1 >= args.len) fatal("--state requires idle|input|any");
+                i += 1;
+                const v = args[i];
+                r.agent_await_state = if (std.mem.eql(u8, v, "idle")) .idle else if (std.mem.eql(u8, v, "input")) .input else if (std.mem.eql(u8, v, "any")) .any else fatal("--state must be idle, input, or any");
+            } else if (std.mem.eql(u8, arg, "--timeout")) {
+                if (i + 1 >= args.len) fatal("--timeout requires seconds");
+                i += 1;
+                r.agent_timeout_s = std.fmt.parseInt(u32, args[i], 10) catch fatal("--timeout: invalid seconds");
+            }
+        }
+        if (r.pane_id == 0) fatal("agent await requires --pane <id>");
+        return r;
+    }
+    printHelp(help.agent);
+    return null;
+}
 
 fn parseSession(args: []const [:0]const u8, start: usize, target_pid: ?u32, json_output: bool) ?IpcRequest {
     if (start + 1 >= args.len or isHelp(args[start + 1])) {

--- a/src/config/cli_ipc_help.zig
+++ b/src/config/cli_ipc_help.zig
@@ -27,6 +27,7 @@ pub const top_level =
     \\  scroll-to    Scroll the viewport (top, bottom, page-up, page-down)
     \\  list         Query tabs, panes, sessions, and agents (supports --json)
     \\  watch        Stream agent status/usage changes live (table; --json for NDJSON)
+    \\  agent        Drive another agent: send a prompt and await its turn
     \\  popup        Open a popup terminal overlay
     \\  run          Open a new tab with a command (shorthand for tab create --cmd)
     \\
@@ -627,5 +628,50 @@ pub const run =
     \\  attyx run htop
     \\  attyx run "make test" --wait
     \\  attyx run claude
+    \\
+;
+
+pub const agent =
+    \\Drive another agent: send it a prompt and wait for its turn to finish.
+    \\
+    \\Usage:
+    \\  attyx agent send -p <id> "<prompt>" [--wait] [--capture] [--tokens]
+    \\                   [--timeout <s>] [--submit-key <key>] [--json]
+    \\  attyx agent await -p <id> [--state idle|input|any] [--timeout <s>] [--json]
+    \\
+    \\`agent send` types the prompt into the pane's agent (as a bracketed paste,
+    \\so multi-line prompts and `{`/`}`/`\` are literal) and presses the submit
+    \\key. Without --wait it returns immediately. With --wait it blocks until the
+    \\agent's turn completes and reports the outcome.
+    \\
+    \\`agent await` sends nothing — it just blocks until the pane's agent reaches
+    \\a state (the formalized `watch agents | while …` pattern).
+    \\
+    \\Options (send):
+    \\  --pane, -p <id>     Target pane (required). From 'attyx list agents'.
+    \\  --wait              Block until the turn completes (implied by --capture
+    \\                      and --tokens).
+    \\  --capture           Include only the output the turn produced (uses
+    \\                      get-text --since under the hood).
+    \\  --tokens            Include the per-turn token/cost delta.
+    \\  --timeout <s>       Stop waiting after N seconds (default 600). The agent
+    \\                      is never interrupted — we just stop watching.
+    \\  --submit-key <key>  Key that submits the prompt (default {Enter}).
+    \\Options (await):
+    \\  --pane, -p <id>     Target pane (required).
+    \\  --state <s>         Wait for idle (default), input, or any.
+    \\  --timeout <s>       Stop waiting after N seconds (default 600).
+    \\
+    \\Outcomes (and exit codes): done (0) · needs_input (2) · timeout (3) ·
+    \\no_turn / ended (4). So `attyx agent send -p 3 "run tests" --wait && deploy`
+    \\runs deploy only if the turn finished cleanly.
+    \\
+    \\Plain output: a one-line summary to stderr; with --capture the turn's output
+    \\goes to stdout (so it pipes). --json returns the full result object.
+    \\
+    \\Examples:
+    \\  attyx agent send -p 3 "run the tests and fix failures" --wait
+    \\  attyx agent send -p 3 "summarize src/api" --wait --capture --json
+    \\  attyx agent await -p 3 --state any        # block until done or needs input
     \\
 ;

--- a/src/ipc/client.zig
+++ b/src/ipc/client.zig
@@ -165,6 +165,11 @@ pub fn run(args: []const [:0]const u8) void {
         client_daemon.run(parsed);
         return;
     }
+    // agent send/await: client-side orchestration (resolves its own socket and
+    // handles the -s rejection itself). run() is noreturn.
+    if (parsed.command == .agent_send or parsed.command == .agent_await) {
+        @import("client_agent.zig").run(parsed);
+    }
 
     // Discover socket early — needed for both paths
     var sock_buf: [256]u8 = undefined;
@@ -350,6 +355,9 @@ fn buildSendKeysRequest(buf: []u8, payload: []const u8, pane_id: u32, target_ses
 
 pub fn buildRequest(buf: []u8, parsed: @import("../config/cli_ipc.zig").IpcRequest) ![]u8 {
     return switch (parsed.command) {
+        // agent send/await are client-side orchestration, never a single wire
+        // request — client.run routes them to client_agent before buildRequest.
+        .agent_send, .agent_await => error.UnsupportedCommand,
         .tab_create => protocol.encodeMessage(buf, if (parsed.wait) .tab_create_wait else .tab_create, parsed.text_arg),
         .tab_close => blk: {
             if (parsed.tab_idx != 0xFF) {

--- a/src/ipc/client_agent.zig
+++ b/src/ipc/client_agent.zig
@@ -1,0 +1,542 @@
+// Attyx — agent orchestration client (`attyx agent send` / `attyx agent await`)
+//
+// Submits a prompt to the agent in a pane and blocks until that agent's turn
+// completes, returning the outcome (and optionally the turn's output + token
+// cost). Pure client-side orchestration over existing IPC primitives — a
+// precondition `list_agents` snapshot, `send_keys` to submit, the `watch agents`
+// stream to detect completion, and `get_text --since` to capture output. No
+// server blocking, no new long-lived server state.
+//
+// The turn detector (`Machine`) is a pure function over status frames so it can
+// be unit-tested without a real agent. Orchestration is added below it.
+
+const std = @import("std");
+const posix = std.posix;
+const protocol = @import("protocol.zig");
+const client = @import("client.zig");
+const IpcRequest = @import("../config/cli_ipc.zig").IpcRequest;
+
+const POLLIN: i16 = 0x0001;
+
+/// Agent run-state as reported on the watch stream.
+pub const State = enum {
+    idle,
+    working,
+    input,
+    none,
+
+    pub fn fromStr(s: []const u8) State {
+        if (std.mem.eql(u8, s, "working")) return .working;
+        if (std.mem.eql(u8, s, "input")) return .input;
+        if (std.mem.eql(u8, s, "idle")) return .idle;
+        return .none;
+    }
+};
+
+/// The result of a driven turn. Exit codes let scripts branch:
+/// `attyx agent send -p 3 "run tests" --wait && deploy`.
+pub const Outcome = enum {
+    done, // working → idle: the agent finished its turn
+    needs_input, // working → input: paused for permission/a question
+    timeout, // still working past --timeout (we stop waiting; agent untouched)
+    no_turn, // the agent never started working (wrong pane, modal, ignored input)
+    ended, // the agent exited mid-wait (state none)
+
+    pub fn exitCode(self: Outcome) u8 {
+        return switch (self) {
+            .done => 0,
+            .needs_input => 2,
+            .timeout => 3,
+            .no_turn, .ended => 4,
+        };
+    }
+    pub fn label(self: Outcome) []const u8 {
+        return switch (self) {
+            .done => "done",
+            .needs_input => "needs_input",
+            .timeout => "timeout",
+            .no_turn => "no_turn",
+            .ended => "ended",
+        };
+    }
+};
+
+/// Pure turn detector. The watch stream emits the pane's current state on
+/// connect (a snapshot) then a frame per transition. We open it before sending,
+/// so we must not mistake the pre-submit snapshot for completion: feed every
+/// frame to `feed`, and clock checks to `tick`.
+///
+/// `initial` is the pane's state at submit time (from the precondition snapshot).
+/// Until we observe `working`, frames equal to `initial` are the snapshot and are
+/// ignored; a transition to `working` starts the turn; a transition to a
+/// *different* terminal state (fast turn with no observed `working`) resolves it.
+pub const Machine = struct {
+    initial: State,
+    submit_ms: i64,
+    start_grace_ms: i64,
+    timeout_ms: i64,
+    saw_working: bool = false,
+
+    /// Apply one status frame. Returns an Outcome when the turn resolves, else
+    /// null to keep waiting.
+    pub fn feed(self: *Machine, state: State) ?Outcome {
+        if (state == .none) return .ended;
+        if (self.saw_working) {
+            return switch (state) {
+                .idle => .done,
+                .input => .needs_input,
+                .working => null,
+                .none => .ended,
+            };
+        }
+        switch (state) {
+            .working => {
+                self.saw_working = true;
+                return null;
+            },
+            // A change away from the pre-submit state without an observed
+            // `working` = an instant turn; same state = the connect snapshot.
+            .idle => return if (state != self.initial) .done else null,
+            .input => return if (state != self.initial) .needs_input else null,
+            .none => return .ended,
+        }
+    }
+
+    /// Apply a clock check (called on poll timeouts). `no_turn` before the turn
+    /// starts, `timeout` after.
+    pub fn tick(self: *const Machine, now_ms: i64) ?Outcome {
+        if (!self.saw_working) {
+            if (now_ms - self.submit_ms >= self.start_grace_ms) return .no_turn;
+        } else {
+            if (now_ms - self.submit_ms >= self.timeout_ms) return .timeout;
+        }
+        return null;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Orchestration (attached/window path). Composes one-shot list_agents /
+// get_text --since / send_keys with the watch stream. -s (background sessions)
+// is a follow-up; rejected cleanly for now.
+// ---------------------------------------------------------------------------
+
+const keys = @import("keys.zig");
+const json = std.json;
+
+const Usage = struct {
+    input_tokens: ?u64 = null,
+    output_tokens: ?u64 = null,
+    cache_read_tokens: ?u64 = null,
+    cost_usd: ?f64 = null,
+    cost_is_estimate: bool = false,
+};
+const Rec = struct {
+    pane_id: u32 = 0,
+    session: u32 = 0,
+    state: []const u8 = "none",
+    message: []const u8 = "",
+    usage: Usage = .{},
+};
+const SinceResp = struct {
+    cursor: []const u8 = "",
+    text: []const u8 = "",
+    truncated: bool = false,
+    reset: bool = false,
+    rows: u64 = 0,
+};
+
+pub const Result = struct {
+    pane: u32,
+    session: u32,
+    outcome: Outcome,
+    duration_ms: i64,
+    message: []const u8 = "",
+    output: ?[]const u8 = null,
+    truncated: bool = false,
+    tokens: ?TokenDelta = null,
+};
+const TokenDelta = struct {
+    input: u64,
+    output: u64,
+    cache_read: u64,
+    cost_usd: ?f64,
+    cost_is_estimate: bool,
+};
+
+const default_start_grace_ms: i64 = 3000;
+const default_timeout_ms: i64 = 600_000;
+const poll_ms: i32 = 250;
+
+const Error = error{ NoInstance, IpcFailed, NotAnAgent, Busy, SessionUnsupported };
+
+/// A persistent watch-stream connection, polled with a timeout so the state
+/// machine's deadlines can fire between frames.
+const WatchStream = struct {
+    fd: posix.fd_t,
+    payload_buf: [65536]u8 = undefined,
+
+    fn open(sock: []const u8, pane_id: u32) !WatchStream {
+        const fd = try client.connectToSocket(sock);
+        var pl: [4]u8 = undefined;
+        std.mem.writeInt(u32, &pl, pane_id, .little);
+        var rb: [protocol.header_size + 4]u8 = undefined;
+        const req = try protocol.encodeMessage(&rb, .watch_agents, &pl);
+        try protocol.writeAll(fd, req);
+        return .{ .fd = fd };
+    }
+    fn close(self: *WatchStream) void {
+        protocol.closeFd(self.fd);
+    }
+
+    const Next = union(enum) { frame: []const u8, none, eof };
+    fn pollNext(self: *WatchStream, timeout: i32) Next {
+        var pfd = [_]posix.pollfd{.{ .fd = self.fd, .events = POLLIN, .revents = 0 }};
+        const r = posix.poll(&pfd, timeout) catch return .eof;
+        if (r == 0) return .none;
+        var hdr: [protocol.header_size]u8 = undefined;
+        protocol.readExact(self.fd, &hdr) catch return .eof;
+        const h = protocol.decodeHeader(&hdr) catch return .eof;
+        if (h.payload_len == 0) return .none;
+        if (h.payload_len > self.payload_buf.len) return .eof;
+        protocol.readExact(self.fd, self.payload_buf[0..h.payload_len]) catch return .eof;
+        return .{ .frame = self.payload_buf[0..h.payload_len] };
+    }
+};
+
+fn parseRec(a: std.mem.Allocator, line: []const u8) ?Rec {
+    const t = std.mem.trim(u8, line, " \t\r\n");
+    if (t.len == 0 or t[0] != '{') return null;
+    return json.parseFromSliceLeaky(Rec, a, t, .{ .ignore_unknown_fields = true }) catch null;
+}
+
+/// One-shot request → response payload (owned by `a`), or null on error.
+fn oneShot(a: std.mem.Allocator, sock: []const u8, req: IpcRequest, resp_cap: usize) ?[]const u8 {
+    var rb: [protocol.header_size + 4096]u8 = undefined;
+    const request = client.buildRequest(&rb, req) catch return null;
+    const resp_buf = a.alloc(u8, resp_cap) catch return null;
+    const resp = client.sendCommand(sock, request, resp_buf) catch return null;
+    if (resp.msg_type != .success) return null;
+    return resp.payload;
+}
+
+/// Write raw bytes to a pane's PTY (no escape/token processing).
+fn sendRaw(sock: []const u8, pane_id: u32, bytes: []const u8) bool {
+    var pl: [4 + 8192]u8 = undefined;
+    std.mem.writeInt(u32, pl[0..4], pane_id, .little);
+    const n = @min(bytes.len, pl.len - 4);
+    @memcpy(pl[4 .. 4 + n], bytes[0..n]);
+    var rb: [protocol.header_size + 4 + 8192]u8 = undefined;
+    const req = protocol.encodeMessage(&rb, .send_keys_pane, pl[0 .. 4 + n]) catch return false;
+    var resp: [256]u8 = undefined;
+    const r = client.sendCommand(sock, req, &resp) catch return false;
+    return r.msg_type != .err;
+}
+
+fn resolveSubmitKey(spec: []const u8, out: []u8) []const u8 {
+    const s = if (spec.len == 0) "{Enter}" else spec;
+    var iter = keys.KeyTokenIter{ .input = s };
+    if (iter.next(out)) |tok| return out[0..tok.len];
+    return "\r";
+}
+
+fn snapshotPane(a: std.mem.Allocator, sock: []const u8, pane_id: u32) ?Rec {
+    const body = oneShot(a, sock, .{ .command = .list_agents, .pane_id = pane_id, .json_output = true }, 1 << 16) orelse return null;
+    const arr = json.parseFromSliceLeaky([]Rec, a, std.mem.trim(u8, body, " \t\r\n"), .{ .ignore_unknown_fields = true }) catch return null;
+    for (arr) |rec| if (pane_id == 0 or rec.pane_id == pane_id) return rec;
+    return null;
+}
+
+fn seedCursor(a: std.mem.Allocator, sock: []const u8, pane_id: u32) []const u8 {
+    const body = oneShot(a, sock, .{ .command = .get_text, .pane_id = pane_id, .has_since = true }, 1 << 20) orelse return "";
+    const r = json.parseFromSliceLeaky(SinceResp, a, body, .{ .ignore_unknown_fields = true }) catch return "";
+    return r.cursor;
+}
+
+fn captureSince(a: std.mem.Allocator, sock: []const u8, pane_id: u32, cursor: []const u8) SinceResp {
+    var req = IpcRequest{ .command = .get_text, .pane_id = pane_id, .has_since = true };
+    if (Cursor_parse(cursor)) |c| {
+        req.since_gen = c.gen;
+        req.since_line = c.line;
+    }
+    const body = oneShot(a, sock, req, 1 << 20) orelse return .{};
+    return json.parseFromSliceLeaky(SinceResp, a, body, .{ .ignore_unknown_fields = true }) catch .{};
+}
+
+// Local copy of the cursor parse (cli_ipc.Cursor) to avoid a config import here.
+fn Cursor_parse(tok: []const u8) ?struct { gen: u32, line: u64 } {
+    if (tok.len < 4 or tok[0] != 'g') return null;
+    const dot = std.mem.indexOfScalar(u8, tok, '.') orelse return null;
+    if (dot + 1 >= tok.len or tok[dot + 1] != 'l') return null;
+    const gen = std.fmt.parseInt(u32, tok[1..dot], 10) catch return null;
+    const line = std.fmt.parseInt(u64, tok[dot + 2 ..], 10) catch return null;
+    return .{ .gen = gen, .line = line };
+}
+
+/// `agent send` core. Submits the prompt and (with --wait) drives the turn to an
+/// outcome. Returns a Result owned by `a`.
+pub fn runSend(a: std.mem.Allocator, parsed: IpcRequest) Error!Result {
+    if (parsed.target_session != 0) return Error.SessionUnsupported;
+    var sock_buf: [256]u8 = undefined;
+    const sock = client.discoverSocket(&sock_buf, parsed.target_pid) orelse return Error.NoInstance;
+
+    const snap = snapshotPane(a, sock, parsed.pane_id) orelse return Error.NotAnAgent;
+    const s0 = State.fromStr(snap.state);
+    if (s0 == .none) return Error.NotAnAgent;
+    if (s0 == .working) return Error.Busy;
+    const session = snap.session;
+
+    const want_capture = parsed.agent_capture;
+    const cursor: []const u8 = if (want_capture) seedCursor(a, sock, parsed.pane_id) else "";
+
+    // Open the watch stream BEFORE submitting so we can't miss the `working` edge.
+    var ws = WatchStream.open(sock, parsed.pane_id) catch return Error.IpcFailed;
+    defer ws.close();
+
+    // Submit: prompt body as a bracketed paste, then the submit key discretely.
+    var paste: [8192]u8 = undefined;
+    var ps = std.io.fixedBufferStream(&paste);
+    ps.writer().writeAll("\x1b[200~") catch {};
+    ps.writer().writeAll(parsed.text_arg[0..@min(parsed.text_arg.len, paste.len - 12)]) catch {};
+    ps.writer().writeAll("\x1b[201~") catch {};
+    _ = sendRaw(sock, parsed.pane_id, ps.getWritten());
+    var key_buf: [64]u8 = undefined;
+    const submit = resolveSubmitKey(parsed.agent_submit_key, &key_buf);
+    const submit_ms = std.time.milliTimestamp();
+    _ = sendRaw(sock, parsed.pane_id, submit);
+
+    if (!parsed.wait) {
+        return .{ .pane = parsed.pane_id, .session = session, .outcome = .done, .duration_ms = 0 };
+    }
+
+    const timeout_ms: i64 = if (parsed.agent_timeout_s > 0) @as(i64, parsed.agent_timeout_s) * 1000 else default_timeout_ms;
+    var m = Machine{ .initial = s0, .submit_ms = submit_ms, .start_grace_ms = default_start_grace_ms, .timeout_ms = timeout_ms };
+    var outcome: Outcome = .timeout;
+    var end_message: []const u8 = "";
+    loop: while (true) {
+        switch (ws.pollNext(poll_ms)) {
+            .frame => |p| {
+                var fa = std.heap.ArenaAllocator.init(a);
+                defer fa.deinit();
+                if (parseRec(fa.allocator(), p)) |rec| {
+                    if (rec.pane_id == parsed.pane_id) {
+                        if (m.feed(State.fromStr(rec.state))) |o| {
+                            outcome = o;
+                            end_message = a.dupe(u8, rec.message) catch "";
+                            break :loop;
+                        }
+                    }
+                }
+            },
+            .none => if (m.tick(std.time.milliTimestamp())) |o| {
+                outcome = o;
+                break :loop;
+            },
+            .eof => {
+                outcome = .ended;
+                break :loop;
+            },
+        }
+    }
+    const duration_ms = std.time.milliTimestamp() - submit_ms;
+
+    var result = Result{ .pane = parsed.pane_id, .session = session, .outcome = outcome, .duration_ms = duration_ms, .message = end_message };
+
+    if (want_capture and (outcome == .done or outcome == .needs_input or outcome == .timeout)) {
+        const cap = captureSince(a, sock, parsed.pane_id, cursor);
+        result.output = cap.text;
+        result.truncated = cap.truncated;
+    }
+    if (parsed.agent_tokens) {
+        if (snapshotPane(a, sock, parsed.pane_id)) |end_snap| {
+            result.tokens = .{
+                .input = (end_snap.usage.input_tokens orelse 0) -| (snap.usage.input_tokens orelse 0),
+                .output = (end_snap.usage.output_tokens orelse 0) -| (snap.usage.output_tokens orelse 0),
+                .cache_read = (end_snap.usage.cache_read_tokens orelse 0) -| (snap.usage.cache_read_tokens orelse 0),
+                .cost_usd = end_snap.usage.cost_usd,
+                .cost_is_estimate = end_snap.usage.cost_is_estimate,
+            };
+        }
+    }
+    return result;
+}
+
+/// `agent await` core. Observes (no input) until the pane's agent reaches the
+/// target state, ends, or times out.
+pub fn runAwait(a: std.mem.Allocator, parsed: IpcRequest) Error!Result {
+    if (parsed.target_session != 0) return Error.SessionUnsupported;
+    var sock_buf: [256]u8 = undefined;
+    const sock = client.discoverSocket(&sock_buf, parsed.target_pid) orelse return Error.NoInstance;
+    const snap = snapshotPane(a, sock, parsed.pane_id) orelse return Error.NotAnAgent;
+    const session = snap.session;
+
+    var ws = WatchStream.open(sock, parsed.pane_id) catch return Error.IpcFailed;
+    defer ws.close();
+    const start_ms = std.time.milliTimestamp();
+    const timeout_ms: i64 = if (parsed.agent_timeout_s > 0) @as(i64, parsed.agent_timeout_s) * 1000 else default_timeout_ms;
+
+    while (true) {
+        switch (ws.pollNext(poll_ms)) {
+            .frame => |p| {
+                var fa = std.heap.ArenaAllocator.init(a);
+                defer fa.deinit();
+                if (parseRec(fa.allocator(), p)) |rec| {
+                    if (rec.pane_id == parsed.pane_id) {
+                        const st = State.fromStr(rec.state);
+                        if (st == .none) return mkAwaitResult(parsed.pane_id, session, .ended, start_ms);
+                        const hit = switch (parsed.agent_await_state) {
+                            .idle => st == .idle,
+                            .input => st == .input,
+                            .any => st == .idle or st == .input,
+                        };
+                        if (hit) return mkAwaitResult(parsed.pane_id, session, if (st == .input) .needs_input else .done, start_ms);
+                    }
+                }
+            },
+            .none => if (std.time.milliTimestamp() - start_ms >= timeout_ms) return mkAwaitResult(parsed.pane_id, session, .timeout, start_ms),
+            .eof => return mkAwaitResult(parsed.pane_id, session, .ended, start_ms),
+        }
+    }
+}
+fn mkAwaitResult(pane: u32, session: u32, outcome: Outcome, start_ms: i64) Result {
+    return .{ .pane = pane, .session = session, .outcome = outcome, .duration_ms = std.time.milliTimestamp() - start_ms };
+}
+
+pub fn errMsg(e: Error) []const u8 {
+    return switch (e) {
+        Error.NoInstance => "no running Attyx instance found",
+        Error.IpcFailed => "failed to communicate with Attyx instance",
+        Error.NotAnAgent => "pane is not running an agent",
+        Error.Busy => "the pane's agent is busy (working); wait for it to finish first",
+        Error.SessionUnsupported => "agent send/await is not supported with -s yet; run it against the attached session",
+    };
+}
+
+/// Serialize a Result as the §5 JSON object (owned by `a`).
+pub fn resultJson(a: std.mem.Allocator, r: Result) []const u8 {
+    var buf = std.ArrayList(u8){};
+    const w = buf.writer(a);
+    w.print("{{\"pane\":{d},\"session\":{d},\"outcome\":\"{s}\",\"duration_ms\":{d},\"message\":\"", .{ r.pane, r.session, r.outcome.label(), r.duration_ms }) catch {};
+    writeJsonStr(w, r.message);
+    w.writeAll("\"") catch {};
+    if (r.output) |out| {
+        w.writeAll(",\"output\":\"") catch {};
+        writeJsonStr(w, out);
+        w.print("\",\"truncated\":{}", .{r.truncated}) catch {};
+    }
+    if (r.tokens) |t| {
+        w.print(",\"tokens\":{{\"input\":{d},\"output\":{d},\"cache_read\":{d}", .{ t.input, t.output, t.cache_read }) catch {};
+        if (t.cost_usd) |c| w.print(",\"cost_usd\":{d},\"cost_is_estimate\":{}", .{ c, t.cost_is_estimate }) catch {};
+        w.writeAll("}") catch {};
+    }
+    w.writeAll("}") catch {};
+    return buf.items;
+}
+
+fn writeJsonStr(w: anytype, s: []const u8) void {
+    for (s) |ch| switch (ch) {
+        '"' => w.writeAll("\\\"") catch {},
+        '\\' => w.writeAll("\\\\") catch {},
+        '\n' => w.writeAll("\\n") catch {},
+        '\r' => w.writeAll("\\r") catch {},
+        '\t' => w.writeAll("\\t") catch {},
+        else => if (ch < 0x20) {
+            w.print("\\u{x:0>4}", .{ch}) catch {};
+        } else w.writeByte(ch) catch {},
+    };
+}
+
+/// CLI entry: orchestrate, print result, exit with the outcome's code.
+pub fn run(parsed: IpcRequest) noreturn {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const r = (if (parsed.command == .agent_await) runAwait(a, parsed) else runSend(a, parsed)) catch |e| {
+        std.fs.File.stderr().writeAll("error: ") catch {};
+        std.fs.File.stderr().writeAll(errMsg(e)) catch {};
+        std.fs.File.stderr().writeAll("\n") catch {};
+        std.process.exit(1);
+    };
+    const stdout = std.fs.File.stdout();
+    if (parsed.json_output) {
+        stdout.writeAll(resultJson(a, r)) catch {};
+        stdout.writeAll("\n") catch {};
+    } else {
+        // Human: summary to stderr, captured output to stdout (so it pipes).
+        var sb: [256]u8 = undefined;
+        const summary = std.fmt.bufPrint(&sb, "pane {d}: {s} in {d:.1}s\n", .{ r.pane, r.outcome.label(), @as(f64, @floatFromInt(r.duration_ms)) / 1000.0 }) catch "done\n";
+        std.fs.File.stderr().writeAll(summary) catch {};
+        if (r.output) |out| stdout.writeAll(out) catch {};
+    }
+    std.process.exit(r.outcome.exitCode());
+}
+
+/// MCP entry: orchestrate and return the §5 JSON (no print/exit).
+pub fn runForMcp(a: std.mem.Allocator, parsed: IpcRequest) ![]const u8 {
+    const r = if (parsed.command == .agent_await) try runAwait(a, parsed) else try runSend(a, parsed);
+    return resultJson(a, r);
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the state machine, no socket/agent required.
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn machine(initial: State) Machine {
+    return .{ .initial = initial, .submit_ms = 0, .start_grace_ms = 3000, .timeout_ms = 600_000 };
+}
+
+test "working then idle = done; working then input = needs_input" {
+    var a = machine(.idle);
+    try testing.expectEqual(@as(?Outcome, null), a.feed(.working));
+    try testing.expectEqual(@as(?Outcome, .done), a.feed(.idle));
+
+    var b = machine(.idle);
+    _ = b.feed(.working);
+    try testing.expectEqual(@as(?Outcome, .needs_input), b.feed(.input));
+}
+
+test "pre-submit snapshot of the same state does not false-fire" {
+    var a = machine(.idle);
+    try testing.expectEqual(@as(?Outcome, null), a.feed(.idle)); // connect snapshot
+    try testing.expectEqual(@as(?Outcome, null), a.feed(.working)); // turn starts
+    try testing.expectEqual(@as(?Outcome, .done), a.feed(.idle)); // turn ends
+}
+
+test "no working within start grace = no_turn" {
+    var a = machine(.idle);
+    _ = a.feed(.idle); // snapshot only
+    try testing.expectEqual(@as(?Outcome, null), a.tick(2999));
+    try testing.expectEqual(@as(?Outcome, .no_turn), a.tick(3000));
+}
+
+test "working then silence past deadline = timeout" {
+    var a = machine(.idle);
+    _ = a.feed(.working);
+    try testing.expectEqual(@as(?Outcome, null), a.tick(599_999));
+    try testing.expectEqual(@as(?Outcome, .timeout), a.tick(600_000));
+}
+
+test "agent exits mid-turn = ended" {
+    var a = machine(.idle);
+    _ = a.feed(.working);
+    try testing.expectEqual(@as(?Outcome, .ended), a.feed(.none));
+}
+
+test "instant turn (input straight after submit, no observed working)" {
+    var a = machine(.idle);
+    try testing.expectEqual(@as(?Outcome, .needs_input), a.feed(.input));
+
+    var b = machine(.input); // answering a paused agent
+    try testing.expectEqual(@as(?Outcome, null), b.feed(.input)); // snapshot (==initial)
+    _ = b.feed(.working);
+    try testing.expectEqual(@as(?Outcome, .done), b.feed(.idle));
+}
+
+test "outcome exit codes" {
+    try testing.expectEqual(@as(u8, 0), Outcome.done.exitCode());
+    try testing.expectEqual(@as(u8, 2), Outcome.needs_input.exitCode());
+    try testing.expectEqual(@as(u8, 3), Outcome.timeout.exitCode());
+    try testing.expectEqual(@as(u8, 4), Outcome.no_turn.exitCode());
+    try testing.expectEqual(@as(u8, 4), Outcome.ended.exitCode());
+}

--- a/src/ipc/mcp.zig
+++ b/src/ipc/mcp.zig
@@ -106,7 +106,14 @@ fn handleToolCall(a: std.mem.Allocator, params_opt: ?std.json.Value, id: ?std.js
         mcp_tools.fill(name_v.string, args) orelse
             return respondError(a, id, -32602, "unknown tool or missing required argument");
 
-    const out = callIpc(a, req);
+    // agent_send/agent_await are multi-step client orchestration (snapshot →
+    // send_keys → watch stream → get_text), not a single round-trip — run them
+    // through client_agent and return the result JSON.
+    const out: CallOut = if (req.command == .agent_send or req.command == .agent_await) blk: {
+        const ca = @import("client_agent.zig");
+        const text = ca.runForMcp(a, req) catch |e| break :blk .{ .is_error = true, .text = ca.errMsg(e) };
+        break :blk .{ .is_error = false, .text = text };
+    } else callIpc(a, req);
     const text_json = std.json.Stringify.valueAlloc(a, std.json.Value{ .string = out.text }, .{}) catch "\"\"";
     const result = std.fmt.allocPrint(
         a,

--- a/src/ipc/mcp_tools.zig
+++ b/src/ipc/mcp_tools.zig
@@ -28,6 +28,8 @@ const TOOLS_RAW =
     \\{"name":"get_text","description":"Capture a pane's screen text. With 'lines', captures that many trailing rows from scrollback. Pass the 'cursor' from a previous result as 'since' to get ONLY the new output since that read (incremental tailing) — the result is {cursor,text,truncated,reset,rows}; feed 'cursor' back next time. Use since:\"\" to seed (returns the current screen + a starting cursor).","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"lines":{"type":"integer","description":"Trailing rows to capture (omit for visible screen)."},"since":{"type":"string","description":"Cursor from a previous get_text result; returns only new rows since then. Empty string seeds from the current screen."},"cursor_only":{"type":"boolean","description":"Return just the next cursor, no text."},"session":{"type":"integer"}}}},
     \\{"name":"send_keys","description":"Send keystrokes/text to a pane. Supports C-style escapes (\\n, \\t, \\x03) and named keys like {Enter} {Down}.","inputSchema":{"type":"object","properties":{"text":{"type":"string"},"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"session":{"type":"integer"}},"required":["text"]}},
     \\{"name":"send_image","description":"Attach an image to a pane as if a file were dragged/pasted into the terminal (e.g. to give Claude Code a screenshot). Provide either 'path' (an image file already on disk) or 'data' (base64-encoded image bytes, materialized to a temp file). The image's file path is injected as a bracketed paste; Enter is NOT pressed.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Absolute path to an image file on disk."},"data":{"type":"string","description":"Base64-encoded image bytes (used when no path is available)."},"filename":{"type":"string","description":"Optional original filename; its extension names the temp file when using 'data'."},"pane":{"type":"integer","description":"Pane id (omit for focused pane)."},"session":{"type":"integer"}}}},
+    \\{"name":"agent_send","description":"Send a prompt to the AI agent running in a pane and (by default) wait for its turn to finish. Use to drive another agent. Returns {outcome (done|needs_input|timeout|no_turn|ended), duration_ms, message, output, tokens}. The prompt is pasted (multi-line safe) and submitted; the agent is never interrupted.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer","description":"Target pane id (from list_agents)."},"text":{"type":"string","description":"The prompt to send."},"wait":{"type":"boolean","description":"Block until the turn completes (default true)."},"capture":{"type":"boolean","description":"Include the output the turn produced (default true)."},"tokens":{"type":"boolean","description":"Include the per-turn token/cost delta."},"timeout":{"type":"integer","description":"Seconds to wait before giving up (default 600)."},"session":{"type":"integer"}},"required":["pane","text"]}},
+    \\{"name":"agent_await","description":"Block until the agent in a pane reaches a state (idle, input, or any), without sending anything. Returns the outcome.","inputSchema":{"type":"object","properties":{"pane":{"type":"integer"},"state":{"type":"string","enum":["idle","input","any"],"description":"State to wait for (default idle)."},"timeout":{"type":"integer","description":"Seconds (default 600)."},"session":{"type":"integer"}},"required":["pane"]}},
     \\{"name":"focus","description":"Move keyboard focus between panes.","inputSchema":{"type":"object","properties":{"direction":{"type":"string","enum":["up","down","left","right"]},"session":{"type":"integer"}},"required":["direction"]}},
     \\{"name":"scroll","description":"Scroll the focused pane.","inputSchema":{"type":"object","properties":{"to":{"type":"string","enum":["top","bottom","page_up","page_down"]},"session":{"type":"integer"}},"required":["to"]}},
     \\{"name":"tab_create","description":"Open a new tab, optionally running a command. With wait=true, blocks until the command exits and returns its exit code + output.","inputSchema":{"type":"object","properties":{"command":{"type":"string"},"wait":{"type":"boolean"},"session":{"type":"integer"}}}},
@@ -82,6 +84,12 @@ fn getBool(args: ?std.json.ObjectMap, key: []const u8) bool {
     return v == .bool and v.bool;
 }
 
+fn getBoolOr(args: ?std.json.ObjectMap, key: []const u8, default: bool) bool {
+    const a = args orelse return default;
+    const v = a.get(key) orelse return default;
+    return if (v == .bool) v.bool else default;
+}
+
 fn u32Of(args: ?std.json.ObjectMap, key: []const u8) u32 {
     const n = getInt(args, key) orelse return 0;
     return if (n < 0) 0 else @intCast(n);
@@ -118,6 +126,19 @@ pub fn fill(name: []const u8, args: ?std.json.ObjectMap) ?IpcRequest {
             }
         }
         r.cursor_only = getBool(args, "cursor_only");
+    } else if (eql(u8, name, "agent_send")) {
+        r.command = .agent_send;
+        r.text_arg = getStr(args, "text") orelse return null;
+        r.wait = getBoolOr(args, "wait", true);
+        r.agent_capture = getBoolOr(args, "capture", true);
+        r.agent_tokens = getBool(args, "tokens");
+        r.agent_timeout_s = u32Of(args, "timeout");
+    } else if (eql(u8, name, "agent_await")) {
+        r.command = .agent_await;
+        if (getStr(args, "state")) |s| {
+            r.agent_await_state = if (eql(u8, s, "input")) .input else if (eql(u8, s, "any")) .any else .idle;
+        }
+        r.agent_timeout_s = u32Of(args, "timeout");
     } else if (eql(u8, name, "send_keys")) {
         r.command = .send_keys;
         r.text_arg = getStr(args, "text") orelse return null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -350,6 +350,7 @@ test {
     _ = @import("config/config.zig");
     _ = @import("config/cli_ipc.zig");
     _ = @import("ipc/client.zig");
+    _ = @import("ipc/client_agent.zig");
     _ = @import("ipc/mcp.zig");
     _ = @import("ipc/image_paste.zig");
     if (!is_windows) _ = @import("ipc/mcp_http.zig");


### PR DESCRIPTION
Implements `docs/agent-send-await.md`. A first-class way for one agent (or a script) to **send a prompt to another agent in a pane and block until that agent's turn completes**, returning the outcome, the output the turn produced, and (optionally) the tokens it spent. Replaces the hand-rolled send-keys + `watch agents | while read … idle` + `get-text` dance.

Targets release **0.4.14** (PR base `release-0.4.14`). Both dependencies — incremental `get-text --since` (#282) and usage telemetry — are already in this release, so `--capture` and `--tokens` are fully wired.

## Design — client-side orchestration
"Turn complete" is an agent lifecycle event (working → idle/input), already pushed on the agent-status stream. So this composes existing primitives — `list_agents`, `send_keys`, `get_text --since`, the `watch agents -p` stream — with **no PTY/server blocking** and no new long-lived server state.

## What's new
- **`src/ipc/client_agent.zig`** (new): a **pure, unit-tested turn state machine** (`Machine.feed`/`tick` over status frames → `done`/`needs_input`/`timeout`/`no_turn`/`ended`; snapshot-first safe so a pre-submit `idle` isn't mistaken for completion), plus the orchestration: precondition `list_agents` snapshot → seed a `get_text --since` cursor → open the watch stream *before* sending → paste the prompt (bracketed, so multi-line and `{`/`}` are literal) + a discrete submit key → drive the machine → capture the delta → diff token usage. Result as JSON (§5) or a human summary; **exit codes 0/2/3/4** per outcome.
- **MCP**: `agent_send` / `agent_await` tools, special-cased in `mcp.zig` to run the orchestration in the (socket-based, blocking) tool handler — the clean way for one agent to drive another.
- **CLI**: `agent send` / `agent await` parsing + `IpcRequest` fields + help; `cli.zig isIpcSubcommand += "agent"`; `client.run` routes to `client_agent`.
- **SKILL.md** replaces the hand-rolled await snippet with `agent send --wait` / `agent await` (outcomes + exit codes); release note added.

## Safety
Never interrupts/kills the target (on timeout we just stop watching). No focus stealing (targets by pane id). Honest outcomes — `no_turn` (agent never started) and `timeout` (still going) are first-class, not errors.

## Scope
v1 targets the **attached session**; `-s` background sessions are rejected with a clear message (documented follow-up — needs the daemon watch/raw-send duplication). All CLI subcommands/flags are kebab-case; MCP tool names stay snake_case per existing convention.

## Testing
Headless unit tests for the state machine: `working→idle`=done, `working→input`=needs_input, no-working-in-grace=no_turn, working-then-silence=timeout, `working→none`=ended, snapshot-first doesn't false-fire, instant-turn, exit-code mapping. `zig build test` is green except two **pre-existing** local flakes (`agent_status_test` daemon timing, `commands_test.actionFromName`) that also fail on the untouched base and pass in CI. Manual smoke (driving a real agent) needs a rebuilt instance.