### PR TITLE
Drive the agent-status dot for xyron shells

### DIFF
--- a/src/app/shell_integration.zig
+++ b/src/app/shell_integration.zig
@@ -86,7 +86,7 @@ pub fn setup() ArgvOverride {
         .bash => setupBash(home),
         .fish => setupFish(home),
         .nushell => setupNushell(home),
-        .xyron => setupXyron(exe_dir),
+        .xyron => setupXyron(home, exe_dir),
         .posix_sh => setupPosixSh(home, exe_dir),
         .powershell, .cmd => .{},
     };
@@ -285,10 +285,50 @@ fn setupPosixSh(_: []const u8, exe_dir: []const u8) ArgvOverride {
 /// Xyron is not POSIX and uses Lua for scripting, so it can't source one of
 /// our shell init scripts. Instead, xyron itself reads __ATTYX_STARTUP_CMD,
 /// emits OSC events natively (when ATTYX=1), and inherits PATH directly.
-/// We just need to make `attyx` reachable on PATH.
-fn setupXyron(exe_dir: []const u8) ArgvOverride {
+/// We make `attyx` reachable on PATH and drop a managed Lua module (wired into
+/// config.lua) that drives the agent-status dot via xyron's command hooks —
+/// xyron emits cwd/path natively but not agent-status.
+fn setupXyron(home: []const u8, exe_dir: []const u8) ArgvOverride {
     appendExeDirToPath(exe_dir);
+    installXyronStatus(home);
     return .{};
+}
+
+/// Write ~/.config/xyron/attyx_status.lua and ensure config.lua requires it.
+/// Resolves the config dir like xyron does (XDG_CONFIG_HOME, else ~/.config).
+fn installXyronStatus(home: []const u8) void {
+    var dir_buf: [600]u8 = undefined;
+    const dir = blk: {
+        if (posix_ffi.getenv("XDG_CONFIG_HOME")) |xdg| {
+            break :blk std.fmt.bufPrintZ(&dir_buf, "{s}/xyron", .{std.mem.sliceTo(xdg, 0)}) catch return;
+        }
+        break :blk std.fmt.bufPrintZ(&dir_buf, "{s}/.config/xyron", .{home}) catch return;
+    };
+    mkdirp(dir);
+
+    var mod_buf: [700]u8 = undefined;
+    const mod_path = std.fmt.bufPrintZ(&mod_buf, "{s}/attyx_status.lua", .{dir}) catch return;
+    writeScript(mod_path, posix_scripts.xyron_status_lua);
+
+    var cfg_buf: [700]u8 = undefined;
+    const cfg_path = std.fmt.bufPrintZ(&cfg_buf, "{s}/config.lua", .{dir}) catch return;
+    ensureXyronRequire(cfg_path);
+}
+
+/// Append the require line to config.lua unless it's already present (idempotent).
+/// Creates config.lua if it doesn't exist.
+fn ensureXyronRequire(path: [*:0]const u8) void {
+    var read_buf: [64 * 1024]u8 = undefined;
+    if (std.fs.openFileAbsoluteZ(path, .{})) |f| {
+        defer f.close();
+        const n = f.readAll(&read_buf) catch 0;
+        if (std.mem.indexOf(u8, read_buf[0..n], "attyx_status") != null) return;
+    } else |_| {}
+
+    const f = std.fs.createFileAbsoluteZ(path, .{ .truncate = false }) catch return;
+    defer f.close();
+    f.seekFromEnd(0) catch {};
+    f.writeAll(posix_scripts.xyron_require_line) catch {};
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/shell_scripts_posix.zig
+++ b/src/app/shell_scripts_posix.zig
@@ -267,6 +267,48 @@ pub const nushell_script =
     \\
 ;
 
+/// Xyron is not POSIX and sources no script, but it loads ~/.config/xyron/
+/// config.lua and exposes on_command_start/finish hooks. attyx drops this
+/// managed module and requires it from config.lua, mirroring the zsh/bash/
+/// fish/nu shell backstop: idle when a known agent launches, none when it exits.
+pub const xyron_status_lua =
+    \\-- Attyx agent-status backstop (managed by attyx; safe to delete).
+    \\-- Codex defers its own launch hook to the first turn, so the per-tab status
+    \\-- dot wouldn't appear until you prompt it. Drive the dot from the shell:
+    \\-- idle when a known agent launches, cleared when it exits.
+    \\if xyron.is_attyx() then
+    \\  local agents = { codex = true, claude = true, opencode = true, pi = true }
+    \\  local wrappers = { sudo = true, env = true, command = true, exec = true,
+    \\    nohup = true, nice = true, time = true, builtin = true }
+    \\  local function agent_of(raw)
+    \\    for word in (raw or ""):gmatch("%S+") do
+    \\      if word:find("=", 1, true) then
+    \\        -- env assignment prefix, skip
+    \\      elseif wrappers[word] then
+    \\        -- command wrapper, skip
+    \\      else
+    \\        local base = word:match("[^/]+$") or word
+    \\        return agents[base] and base or nil
+    \\      end
+    \\    end
+    \\    return nil
+    \\  end
+    \\  local function emit(state)
+    \\    io.stderr:write("\27]7337;agent-status;agent;" .. state .. "\7")
+    \\  end
+    \\  xyron.on("on_command_start", function(d)
+    \\    if agent_of(d.raw) then emit("idle") end
+    \\  end)
+    \\  xyron.on("on_command_finish", function(d)
+    \\    if agent_of(d.raw) then emit("none") end
+    \\  end)
+    \\end
+    \\
+;
+
+/// The line attyx appends to config.lua so xyron loads xyron_status_lua.
+pub const xyron_require_line = "require(\"attyx_status\") -- attyx-managed: agent status dot\n";
+
 const std = @import("std");
 const testing = std.testing;
 
@@ -281,6 +323,15 @@ test "each posix script drives the agent-status dot for all agents" {
         for ([_][]const u8{ "codex", "claude", "opencode", "pi" }) |agent|
             try testing.expect(std.mem.indexOf(u8, s, agent) != null);
     }
+}
+
+test "xyron lua module drives the agent-status dot for all agents" {
+    try testing.expect(std.mem.indexOf(u8, xyron_status_lua, "agent-status;agent;\" .. state") != null);
+    try testing.expect(std.mem.indexOf(u8, xyron_status_lua, "on_command_start") != null);
+    try testing.expect(std.mem.indexOf(u8, xyron_status_lua, "on_command_finish") != null);
+    try testing.expect(std.mem.indexOf(u8, xyron_status_lua, "is_attyx") != null);
+    for ([_][]const u8{ "codex", "claude", "opencode", "pi" }) |agent|
+        try testing.expect(std.mem.indexOf(u8, xyron_status_lua, agent) != null);
 }
 
 test "zsh registers the preexec hook and bash installs a DEBUG trap" {


### PR DESCRIPTION
Running an AI agent under the **xyron** shell showed no status dot until the first prompt. Xyron isn't POSIX and sources none of our shell scripts, so the PR #270 launch backstop never reached it — xyron emits cwd/path OSCs natively but not agent-status, and Codex defers its own launch hook to the first turn.

`setupXyron` now writes a managed `~/.config/xyron/attyx_status.lua` and idempotently appends `require("attyx_status")` to `config.lua`. The module hooks xyron's `on_command_start`/`on_command_finish` events (gated on `xyron.is_attyx()`) and emits `idle` when a known agent (codex/claude/opencode/pi) launches, `none` when it exits — the same backstop the zsh/bash/fish/nu scripts already have. Xyron core is untouched.

Verified live: fresh xyron tab, typed `codex` → dot showed `idle` immediately (before Codex's own hook), cleared on exit.