### PR TITLE
Report transcripts from opencode and Pi agents

### DIFF
--- a/src/app/agent_integration_opencode.zig
+++ b/src/app/agent_integration_opencode.zig
@@ -151,10 +151,29 @@ const plugin_fmt =
     \\// Attyx agent status plugin — reports opencode's run state to the
     \\// terminal via the attyx emitter. No-op outside attyx (emitter self-gates).
     \\import {{ spawnSync }} from "node:child_process";
+    \\import {{ appendFileSync }} from "node:fs";
+    \\import {{ tmpdir }} from "node:os";
     \\const EMIT = "{s}";
     \\const TELEMETRY = {s};
     \\function emit(state) {{
     \\  try {{ spawnSync(EMIT, [state], {{ stdio: "ignore" }}); }} catch (e) {{}}
+    \\}}
+    \\// Transcript: opencode hands us assistant text in `message.part.updated`
+    \\// events, so we buffer text parts per message id and, on finalize, append one
+    \\// line in Claude's transcript schema to a per-pane file. `agent read` parses
+    \\// that schema as-is; the path rides `tx=` on the usage emit below.
+    \\const ATTYX_PID = process.env.ATTYX_PID;
+    \\const TX = ATTYX_PID ? tmpdir() + "/attyx-tx-" + ATTYX_PID + ".jsonl" : null;
+    \\let wrote = false;
+    \\const texts = new Map();
+    \\function recordTurn(id) {{
+    \\  const parts = texts.get(id);
+    \\  if (!parts) return;
+    \\  const text = [...parts.values()].join("\n");
+    \\  texts.delete(id);
+    \\  if (!TX || !text) return;
+    \\  const line = JSON.stringify({{ type: "assistant", message: {{ content: [{{ type: "text", text }}] }} }}) + "\n";
+    \\  try {{ appendFileSync(TX, line); wrote = true; }} catch (e) {{}}
     \\}}
     \\// opencode reports per-message token/cost (incl. its own computed cost); our
     \\// schema is cumulative, so we keep the latest figures per message id (so
@@ -173,6 +192,8 @@ const plugin_fmt =
     \\  for (const v of usageTotals.values()) {{ s.in += v.in; s.out += v.out; s.cr += v.cr; s.cw += v.cw; s.rsn += v.rsn; s.cost += v.cost; }}
     \\  const kv = ["in=" + s.in, "out=" + s.out, "cr=" + s.cr, "cw=" + s.cw, "rsn=" + s.rsn, "cost=" + s.cost];
     \\  if (m.modelID) kv.push("model=" + m.modelID);
+    \\  recordTurn(m.id);
+    \\  if (TX && wrote) kv.push("tx=" + TX);
     \\  try {{ spawnSync(EMIT, ["usage", kv.join(";")], {{ stdio: "ignore" }}); }} catch (e) {{}}
     \\}}
     \\const AttyxStatus = async (ctx) => {{
@@ -190,7 +211,15 @@ const plugin_fmt =
     \\          emit("working");
     \\          break;
     \\        case "message.part.updated":
-    \\          if (props.part && props.part.type === "text") emit("working");
+    \\          if (props.part && props.part.type === "text") {{
+    \\            emit("working");
+    \\            const p = props.part;
+    \\            if (p.messageID && typeof p.text === "string") {{
+    \\              let inner = texts.get(p.messageID);
+    \\              if (!inner) {{ inner = new Map(); texts.set(p.messageID, inner); }}
+    \\              inner.set(p.id, p.text);
+    \\            }}
+    \\          }}
     \\          break;
     \\        case "message.updated": {{
     \\          const m = props.info;
@@ -256,6 +285,9 @@ test "plugin template embeds the emitter path and maps key events" {
     try testing.expect(std.mem.indexOf(u8, plugin, "function emitUsage") != null);
     try testing.expect(std.mem.indexOf(u8, plugin, "spawnSync(EMIT, [\"usage\"") != null);
     try testing.expect(std.mem.indexOf(u8, plugin, "m.time.completed") != null);
+    // Transcript: buffers text parts, writes Claude-schema lines, rides tx= on usage.
+    try testing.expect(std.mem.indexOf(u8, plugin, "function recordTurn") != null);
+    try testing.expect(std.mem.indexOf(u8, plugin, "kv.push(\"tx=\" + TX)") != null);
 }
 
 test "insert into an empty object adds the plugin key" {

--- a/src/app/agent_integration_pi.zig
+++ b/src/app/agent_integration_pi.zig
@@ -46,10 +46,32 @@ const extension_fmt =
     \\// Attyx agent status extension — reports Pi's run state to the terminal via
     \\// the attyx emitter. No-op outside attyx (emitter self-gates on ATTYX_PID).
     \\import {{ spawnSync }} from "node:child_process";
+    \\import {{ appendFileSync }} from "node:fs";
+    \\import {{ tmpdir }} from "node:os";
     \\const EMIT = "{s}";
     \\const TELEMETRY = {s};
     \\function emit(state) {{
     \\  try {{ spawnSync(EMIT, [state], {{ stdio: "ignore" }}); }} catch (e) {{}}
+    \\}}
+    \\// Transcript: Pi hands us the finalized assistant message in `message_end`,
+    \\// so we append one line in Claude's transcript schema to a per-pane file.
+    \\// `agent read` parses that schema as-is; the path rides `tx=` on the usage emit.
+    \\const ATTYX_PID = process.env.ATTYX_PID;
+    \\const TX = ATTYX_PID ? tmpdir() + "/attyx-tx-" + ATTYX_PID + ".jsonl" : null;
+    \\let wrote = false;
+    \\function messageText(m) {{
+    \\  if (!m) return "";
+    \\  if (typeof m.content === "string") return m.content;
+    \\  if (Array.isArray(m.content)) return m.content.map((b) => (b && (b.text || (typeof b === "string" ? b : ""))) || "").filter(Boolean).join("\n");
+    \\  if (typeof m.text === "string") return m.text;
+    \\  return "";
+    \\}}
+    \\function recordTurn(m) {{
+    \\  if (!TX) return;
+    \\  const text = messageText(m);
+    \\  if (!text) return;
+    \\  const line = JSON.stringify({{ type: "assistant", message: {{ content: [{{ type: "text", text }}] }} }}) + "\n";
+    \\  try {{ appendFileSync(TX, line); wrote = true; }} catch (e) {{}}
     \\}}
     \\// Per-message token/cost is cumulative-summed: message_end fires once per
     \\// finalized message (not streamed), so plain addition is correct. Context
@@ -63,6 +85,8 @@ const extension_fmt =
     \\  totCr += u.cacheRead || 0; totCw += u.cacheWrite || 0;
     \\  if (u.cost && typeof u.cost.total === "number") totCost += u.cost.total;
     \\  const kv = ["in=" + totIn, "out=" + totOut, "cr=" + totCr, "cw=" + totCw, "cost=" + totCost];
+    \\  recordTurn(message);
+    \\  if (TX && wrote) kv.push("tx=" + TX);
     \\  try {{
     \\    const cu = ctx && ctx.getContextUsage && ctx.getContextUsage();
     \\    if (cu) {{
@@ -115,6 +139,9 @@ test "extension template embeds the emitter path and maps key events" {
     try testing.expect(std.mem.indexOf(u8, ext, "message_end") != null);
     try testing.expect(std.mem.indexOf(u8, ext, "function emitUsage") != null);
     try testing.expect(std.mem.indexOf(u8, ext, "spawnSync(EMIT, [\"usage\"") != null);
+    // Transcript: writes Claude-schema lines from message_end, rides tx= on usage.
+    try testing.expect(std.mem.indexOf(u8, ext, "function recordTurn") != null);
+    try testing.expect(std.mem.indexOf(u8, ext, "kv.push(\"tx=\" + TX)") != null);
 }
 
 test "install writes the extension only when ~/.pi exists" {


### PR DESCRIPTION
## What

`agent read` and `agent send --capture` only worked for Claude Code and Codex. Those two write a native JSONL transcript file that attyx points at via `tx=` on the `agent-usage` OSC. opencode and Pi never reported a transcript path, so the commands failed with "this agent doesn't report a transcript."

## How

Both agents already hand their plugin/extension the assistant text in events. Each now appends one line in Claude's existing transcript schema to a per-pane file (`$TMPDIR/attyx-tx-<pid>.jsonl`) and adds `tx=` to the `usage` emit it already sends. The Zig reader is untouched — `extractMessages` already parses that schema.

- **opencode** — buffers `message.part.updated` text parts per message id, flushes on finalize.
- **Pi** — extracts the finalized `message_end` assistant text.

Existing users get this on their next launch, since `install()` overwrites the plugin/extension files unconditionally.

## Notes

- `tx=` rides the usage OSC, so transcripts follow telemetry being on (same as CC/codex).
- Captures only turns observed while attyx-instrumented, not prior history.