### PR TITLE
Add attyx CLI dir to popup PATH

### DIFF
--- a/src/app/path_env.zig
+++ b/src/app/path_env.zig
@@ -1,0 +1,96 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const is_windows = builtin.os.tag == .windows;
+pub const path_separator: u8 = if (is_windows) ';' else ':';
+
+const posix_ffi = if (!is_windows) struct {
+    extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+    extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+    extern "c" fn _NSGetExecutablePath(buf: [*]u8, bufsize: *u32) c_int;
+    extern "c" fn readlink(path: [*:0]const u8, buf: [*]u8, bufsiz: usize) isize;
+} else struct {};
+
+pub fn pathContainsDir(path: []const u8, dir: []const u8) bool {
+    if (dir.len == 0) return false;
+    var iter = std.mem.splitScalar(u8, path, path_separator);
+    while (iter.next()) |entry| {
+        if (std.mem.eql(u8, entry, dir)) return true;
+    }
+    return false;
+}
+
+pub fn prependDir(allocator: std.mem.Allocator, base_path: []const u8, dir: []const u8) ![]u8 {
+    if (dir.len == 0 or pathContainsDir(base_path, dir)) {
+        return allocator.dupe(u8, base_path);
+    }
+    if (base_path.len == 0) return allocator.dupe(u8, dir);
+    return std.fmt.allocPrint(allocator, "{s}{c}{s}", .{ dir, path_separator, base_path });
+}
+
+pub fn allocPathWithAttyxBinDir(allocator: std.mem.Allocator, base_path: ?[]const u8) ?[]u8 {
+    var exe_buf: [1024]u8 = undefined;
+    if (getExeDir(&exe_buf)) |dir| {
+        return prependDir(allocator, base_path orelse "", dir) catch null;
+    }
+    if (base_path) |path| return allocator.dupe(u8, path) catch null;
+    return null;
+}
+
+pub fn prependAttyxBinDirToEnv() void {
+    if (comptime is_windows) return;
+
+    var exe_buf: [1024]u8 = undefined;
+    const exe_dir = getExeDir(&exe_buf) orelse return;
+    const existing = std.mem.sliceTo(posix_ffi.getenv("PATH") orelse "/usr/bin:/bin", 0);
+    if (pathContainsDir(existing, exe_dir)) return;
+
+    var path_buf: [4096]u8 = undefined;
+    const new_path = if (existing.len == 0)
+        std.fmt.bufPrintZ(&path_buf, "{s}", .{exe_dir}) catch return
+    else
+        std.fmt.bufPrintZ(&path_buf, "{s}:{s}", .{ exe_dir, existing }) catch return;
+    _ = posix_ffi.setenv("PATH", new_path, 1);
+}
+
+pub fn getExeDir(buf: *[1024]u8) ?[]const u8 {
+    const exe_path = getExePath(buf) orelse return null;
+    var last_slash: usize = 0;
+    for (exe_path, 0..) |ch, i| {
+        if (ch == '/') last_slash = i;
+    }
+    if (last_slash == 0) return null;
+    return exe_path[0..last_slash];
+}
+
+fn getExePath(buf: *[1024]u8) ?[]const u8 {
+    if (comptime builtin.os.tag == .macos) {
+        var size: u32 = buf.len;
+        if (posix_ffi._NSGetExecutablePath(buf, &size) == 0) {
+            return std.mem.sliceTo(@as([*:0]const u8, @ptrCast(buf)), 0);
+        }
+    } else if (comptime is_windows) {
+        return null;
+    } else {
+        const n = posix_ffi.readlink("/proc/self/exe", buf, buf.len);
+        if (n > 0) return buf[0..@intCast(n)];
+    }
+    return null;
+}
+
+test "pathContainsDir matches complete path entries" {
+    try std.testing.expect(pathContainsDir("/bin:/opt/attyx/bin:/usr/bin", "/opt/attyx/bin"));
+    try std.testing.expect(!pathContainsDir("/bin:/opt/attyx/bin-extra:/usr/bin", "/opt/attyx/bin"));
+}
+
+test "prependDir prepends only when missing" {
+    const allocator = std.testing.allocator;
+
+    const added = try prependDir(allocator, "/usr/bin:/bin", "/opt/attyx/bin");
+    defer allocator.free(added);
+    try std.testing.expectEqualStrings("/opt/attyx/bin:/usr/bin:/bin", added);
+
+    const unchanged = try prependDir(allocator, "/opt/attyx/bin:/usr/bin", "/opt/attyx/bin");
+    defer allocator.free(unchanged);
+    try std.testing.expectEqualStrings("/opt/attyx/bin:/usr/bin", unchanged);
+}

--- a/src/app/popup.zig
+++ b/src/app/popup.zig
@@ -12,6 +12,7 @@ const Engine = attyx.Engine;
 const color_mod = attyx.render_color;
 const Pty = @import("pty.zig").Pty;
 const Pane = @import("pane.zig").Pane;
+const path_env = @import("path_env.zig");
 
 const RingBuffer = attyx.RingBuffer;
 const theme_registry_mod = @import("../theme/registry.zig");
@@ -183,15 +184,19 @@ pub const PopupState = struct {
             }
         } else {
             // POSIX: $SHELL -c '<command>'
-            // Prepend an export to restore the full PATH before the command.
+            // Restore the shell PATH and ensure the attyx CLI dir is present.
             const shell_env = std.posix.getenv("SHELL") orelse "/bin/sh";
             const shell_z = try allocator.dupeZ(u8, shell_env);
             defer allocator.free(shell_z);
             const c_flag: [:0]const u8 = "-c";
 
-            const cmd_z = if (shell_path) |sp| blk: {
-                const w = std.fmt.allocPrint(allocator,
-                    "export PATH='{s}'; {s}", .{ sp, cfg.command }) catch break :blk try allocator.dupeZ(u8, cfg.command);
+            const base_path: ?[]const u8 = shell_path orelse if (std.posix.getenv("PATH")) |p| p else null;
+            const popup_path = path_env.allocPathWithAttyxBinDir(allocator, base_path);
+            defer if (popup_path) |p| allocator.free(p);
+
+            const cmd_z = if (popup_path) |pp| blk: {
+                if (pp.len == 0) break :blk try allocator.dupeZ(u8, cfg.command);
+                const w = std.fmt.allocPrint(allocator, "export PATH='{s}'; {s}", .{ pp, cfg.command }) catch break :blk try allocator.dupeZ(u8, cfg.command);
                 defer allocator.free(w);
                 break :blk try allocator.dupeZ(u8, w);
             } else try allocator.dupeZ(u8, cfg.command);

--- a/src/app/pty_posix.zig
+++ b/src/app/pty_posix.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const posix = std.posix;
 const platform = @import("../platform/platform.zig");
+const path_env = @import("path_env.zig");
 const ShellIntegration = @import("shell_integration.zig");
 
 const Winsize = extern struct {
@@ -150,7 +151,9 @@ pub const Pty = struct {
             }
 
             var argv_override: ShellIntegration.ArgvOverride = .{};
-            if (!opts.skip_shell_integration) {
+            if (opts.skip_shell_integration) {
+                path_env.prependAttyxBinDirToEnv();
+            } else {
                 argv_override = ShellIntegration.setup();
             }
 

--- a/src/app/shell_integration.zig
+++ b/src/app/shell_integration.zig
@@ -9,14 +9,13 @@
 /// On Windows: shell integration is handled differently (Phase 1+).
 const std = @import("std");
 const builtin = @import("builtin");
+const path_env = @import("path_env.zig");
 const is_windows = builtin.os.tag == .windows;
 
 // POSIX-only extern declarations — guarded so they don't resolve on Windows.
 const posix_ffi = if (!is_windows) struct {
     extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
     extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
-    extern "c" fn _NSGetExecutablePath(buf: [*]u8, bufsize: *u32) c_int;
-    extern "c" fn readlink(path: [*:0]const u8, buf: [*]u8, bufsiz: usize) isize;
 } else struct {};
 
 pub const Shell = enum {
@@ -69,7 +68,7 @@ pub fn setup() ArgvOverride {
     if (comptime is_windows) return .{};
 
     var exe_buf: [1024]u8 = undefined;
-    const exe_dir = getExeDir(&exe_buf) orelse return .{};
+    const exe_dir = path_env.getExeDir(&exe_buf) orelse return .{};
 
     // Set __ATTYX_BIN_DIR for integration scripts
     var dir_buf: [1024]u8 = undefined;
@@ -355,11 +354,12 @@ const nu_env_config_flag: [:0]const u8 = "--env-config";
 
 fn appendExeDirToPath(exe_dir: []const u8) void {
     const existing = std.mem.sliceTo(posix_ffi.getenv("PATH") orelse "/usr/bin:/bin", 0);
-    if (std.mem.indexOf(u8, existing, exe_dir) != null) return;
+    if (path_env.pathContainsDir(existing, exe_dir)) return;
     var path_buf: [4096]u8 = undefined;
-    const new_path = std.fmt.bufPrintZ(&path_buf, "{s}:{s}", .{
-        exe_dir, existing,
-    }) catch return;
+    const new_path = if (existing.len == 0)
+        std.fmt.bufPrintZ(&path_buf, "{s}", .{exe_dir}) catch return
+    else
+        std.fmt.bufPrintZ(&path_buf, "{s}:{s}", .{ exe_dir, existing }) catch return;
     _ = posix_ffi.setenv("PATH", new_path, 1);
 }
 
@@ -391,34 +391,6 @@ fn mkdirp(path_z: [*:0]const u8) void {
         }
     }
     _ = std.posix.mkdiratZ(std.posix.AT.FDCWD, path_z, 0o755) catch {};
-}
-
-fn getExeDir(buf: *[1024]u8) ?[]const u8 {
-    const exe_path = getExePath(buf) orelse return null;
-    var last_slash: usize = 0;
-    for (exe_path, 0..) |ch, i| {
-        if (ch == '/') last_slash = i;
-    }
-    if (last_slash == 0) return null;
-    return exe_path[0..last_slash];
-}
-
-fn getExePath(buf: *[1024]u8) ?[]const u8 {
-    if (comptime builtin.os.tag == .macos) {
-        var size: u32 = buf.len;
-        if (posix_ffi._NSGetExecutablePath(buf, &size) == 0) {
-            return std.mem.sliceTo(@as([*:0]const u8, @ptrCast(buf)), 0);
-        }
-    } else if (comptime is_windows) {
-        // Windows exe path resolution (Phase 1+)
-        return null;
-    } else {
-        const n = posix_ffi.readlink("/proc/self/exe", buf, buf.len);
-        if (n > 0) {
-            return buf[0..@intCast(n)];
-        }
-    }
-    return null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- prepend the Attyx executable directory when building popup PATH values
- apply the same PATH injection to direct popup exec paths
- share executable-dir PATH helpers with shell integration

## Tests
- `zig test src/app/path_env.zig -lc`
- `zig build`
- `zig build test` *(fails: existing daemon agent-status timeout in `daemon: agent status re-shipped when a pane becomes newly active`)*