### PR TITLE
Inline agent interaction, tab names, and session grouping in the dashboard

### DIFF
--- a/releases/v0.4.15.md
+++ b/releases/v0.4.15.md
@@ -1,0 +1,23 @@
+# Attyx v0.4.15
+
+## Answer agents without leaving the dashboard
+
+`attyx dashboard` is no longer read-only. Press **`i`** on any agent row to interact with it inline — the row expands into a panel right where it sits, no jumping to the pane, no switching windows.
+
+The panel shows the agent's **last message** (scroll it with `^U` / `^D`) so you have context, and below it:
+
+- **Reply to an agent.** Type a message and press Enter; it's sent straight to that agent's input, exactly as if you'd typed it in the pane. Works for any agent in any state, so you can nudge an idle one or answer a question on the spot.
+- **Pick an option.** When an agent is waiting on a numbered prompt — a menu, a "which approach?" question — the dashboard reads its screen and shows the choices as buttons. Press the number (or move with `j` / `k` and hit Enter) to send your pick.
+- **Grant permission.** Permission requests ("Allow this command? 1. Yes  2. Yes, and don't ask again  3. No") show up the same way. Approve or deny with a single key.
+
+Selecting a row that needs input and pressing `i` opens the option picker automatically; everything else opens a reply box. `Esc` cancels.
+
+Sending never moves your window or steals focus — it targets the agent's pane directly.
+
+## See which tab each agent is in
+
+The dashboard now shows a **TAB** column with the name of the tab each agent is running in, so you can tell your agents apart at a glance — especially handy when several agents share a session. (`attyx list agents --json` carries it too, as `tab_name`.)
+
+## Grouped by session
+
+Agents are now grouped under a header for the session they belong to, so it's obvious which agents share a workspace when you're running several at once. The sort key (`s`) orders agents within each session.

--- a/src/app/daemon/agent_watch.zig
+++ b/src/app/daemon/agent_watch.zig
@@ -85,10 +85,16 @@ fn sendOne(cl: *DaemonClient, session: *DaemonSession, pane: anytype, pane_id: u
     var stream = std.io.fixedBufferStream(&json_buf);
     // No POSIX pty master fd on Windows → PID is unavailable (0 = unknown).
     const pid: u32 = if (comptime builtin.os.tag == .windows) 0 else agents.panePid(pane.pty.master);
+    var tab_name_buf: [layout_codec.max_title_len]u8 = undefined;
+    var tab_name = tabNameForPane(session, pane_id, &tab_name_buf);
+    // No serialized layout title (session never viewed, or daemon-backed pane
+    // with no stored title) → fall back to this pane's own title.
+    if (tab_name.len == 0) tab_name = eng.state.title orelse "";
     agents.writeAgentJson(
         stream.writer(),
         pane_id,
         tabIdForPane(session, pane_id),
+        tab_name,
         session.id,
         pid,
         eng.state.agent_status,
@@ -114,6 +120,27 @@ pub fn tabIdForPane(session: *DaemonSession, pane_id: u32) u32 {
         }
     }
     return pane_id;
+}
+
+/// The tab's effective title (explicit name, else the serialized fallback —
+/// the focused pane's process/title) for the tab containing `pane_id`, copied
+/// into `buf`. Empty when there's no layout or title. Mirrors tabIdForPane.
+pub fn tabNameForPane(session: *DaemonSession, pane_id: u32, buf: []u8) []const u8 {
+    if (session.layout_len == 0) return "";
+    const info = layout_codec.deserialize(session.layout_data[0..session.layout_len]) catch return "";
+    for (0..info.tab_count) |ti| {
+        const tab = &info.tabs[ti];
+        for (0..tab.node_count) |ni| {
+            const node = tab.nodes[ni];
+            if (node.tag == .leaf and node.pane_id == pane_id) {
+                const title = tab.getTitle() orelse return "";
+                const n = @min(title.len, buf.len);
+                @memcpy(buf[0..n], title[0..n]);
+                return buf[0..n];
+            }
+        }
+    }
+    return "";
 }
 
 fn tabFocusedPane(tab: *const layout_codec.TabLayout) u32 {

--- a/src/app/daemon/handler_ctl.zig
+++ b/src/app/daemon/handler_ctl.zig
@@ -15,6 +15,7 @@ const DaemonPane = @import("pane.zig").DaemonPane;
 const DaemonClient = @import("client.zig").DaemonClient;
 const platform = @import("../../platform/platform.zig");
 const layout_codec = @import("../layout_codec.zig");
+const agent_watch = @import("agent_watch.zig");
 const handler_ctl_layout = @import("handler_ctl_layout.zig");
 const agents = @import("../../ipc/agents.zig");
 
@@ -135,9 +136,11 @@ fn writeAgentRow(
     if (status == .none) return;
     // No POSIX pty master fd on Windows → PID is unavailable (0 = unknown).
     const pid: u32 = if (comptime builtin.os.tag == .windows) 0 else agents.panePid(pane.pty.master);
+    var tab_name_buf: [layout_codec.max_title_len]u8 = undefined;
+    const tab_name = agent_watch.tabNameForPane(session, pane_id, &tab_name_buf);
     if (as_json) {
         if (!first.*) w.writeAll(",") catch return;
-        agents.writeAgentJson(w, pane_id, tab_id, session.id, pid, status, eng.state.agentMsg(), eng.state.agentUsage()) catch return;
+        agents.writeAgentJson(w, pane_id, tab_id, tab_name, session.id, pid, status, eng.state.agentMsg(), eng.state.agentUsage()) catch return;
     } else {
         agents.writeAgentRow(w, pane_id, tab_id, session.id, pid, status, eng.state.agentMsg(), eng.state.agentUsage(), false) catch return;
     }

--- a/src/app/split_layout.zig
+++ b/src/app/split_layout.zig
@@ -91,6 +91,18 @@ pub const SplitLayout = struct {
         self.hint_title_len = 0;
     }
 
+    /// Tab title for display/reporting: the explicit name, else the auto hint,
+    /// else the focused pane's title, else its process name. Empty when none is
+    /// known. Mirrors the fallback `fillTabLayout` serializes for the daemon, so
+    /// the window's `list/watch agents` report the same label the tab bar shows.
+    pub fn effectiveTitle(self: *SplitLayout) []const u8 {
+        if (self.getTitle()) |t| return t;
+        if (self.getHintTitle()) |t| return t;
+        const fp = self.focusedPane();
+        if (fp.engine.state.title) |t| return t;
+        return fp.getDaemonProcName() orelse "";
+    }
+
     pub fn init(initial_pane: *Pane) SplitLayout {
         var sl = SplitLayout{};
         sl.pool[0] = .{

--- a/src/ipc/agents.zig
+++ b/src/ipc/agents.zig
@@ -33,6 +33,7 @@ pub fn writeAgentJson(
     w: anytype,
     pane_id: u32,
     tab_id: u32,
+    tab_name: []const u8,
     session: u32,
     pid: u32,
     status: AgentStatus,
@@ -40,9 +41,11 @@ pub fn writeAgentJson(
     usage: AgentUsage,
 ) !void {
     try w.print(
-        "{{\"pane_id\":{d},\"tab_id\":{d},\"session\":{d},\"pid\":{d},\"state\":\"{s}\",\"message\":\"",
-        .{ pane_id, tab_id, session, pid, stateStr(status) },
+        "{{\"pane_id\":{d},\"tab_id\":{d},\"tab_name\":\"",
+        .{ pane_id, tab_id },
     );
+    try writeJsonEscaped(w, tab_name);
+    try w.print("\",\"session\":{d},\"pid\":{d},\"state\":\"{s}\",\"message\":\"", .{ session, pid, stateStr(status) });
     try writeJsonEscaped(w, message);
     try w.writeAll("\"");
     try writeUsageJson(w, usage);
@@ -369,9 +372,9 @@ pub fn writeJsonEscaped(w: anytype, s: []const u8) !void {
 test "writeAgentJson escapes message and omits unknown usage" {
     var buf: [256]u8 = undefined;
     var stream = std.io.fixedBufferStream(&buf);
-    try writeAgentJson(stream.writer(), 3, 1, 2, 4242, .working, "say \"hi\"\nnow", .{});
+    try writeAgentJson(stream.writer(), 3, 1, "dev", 2, 4242, .working, "say \"hi\"\nnow", .{});
     try std.testing.expectEqualStrings(
-        "{\"pane_id\":3,\"tab_id\":1,\"session\":2,\"pid\":4242,\"state\":\"working\",\"message\":\"say \\\"hi\\\"\\nnow\",\"usage\":{}}",
+        "{\"pane_id\":3,\"tab_id\":1,\"tab_name\":\"dev\",\"session\":2,\"pid\":4242,\"state\":\"working\",\"message\":\"say \\\"hi\\\"\\nnow\",\"usage\":{}}",
         stream.getWritten(),
     );
 }
@@ -388,9 +391,9 @@ test "writeAgentJson emits known usage fields and skips nulls" {
         .cost_is_estimate = false,
         .model = "opus-4.6",
     };
-    try writeAgentJson(stream.writer(), 3, 1, 2, 0, .working, "", u);
+    try writeAgentJson(stream.writer(), 3, 1, "", 2, 0, .working, "", u);
     try std.testing.expectEqualStrings(
-        "{\"pane_id\":3,\"tab_id\":1,\"session\":2,\"pid\":0,\"state\":\"working\",\"message\":\"\"," ++
+        "{\"pane_id\":3,\"tab_id\":1,\"tab_name\":\"\",\"session\":2,\"pid\":0,\"state\":\"working\",\"message\":\"\"," ++
             "\"usage\":{\"input_tokens\":1234,\"output_tokens\":5678,\"context_used\":82000," ++
             "\"context_max\":200000,\"cost_usd\":0.4213,\"cost_is_estimate\":false,\"model\":\"opus-4.6\"}}",
         stream.getWritten(),
@@ -448,7 +451,7 @@ test "writeAgentRowFromJson matches writeAgentRow (same format for watch)" {
     try writeAgentRow(as.writer(), 3, 1, 2, 0, .working, "hi", usage, false);
     var json: [512]u8 = undefined;
     var js = std.io.fixedBufferStream(&json);
-    try writeAgentJson(js.writer(), 3, 1, 2, 0, .working, "hi", usage);
+    try writeAgentJson(js.writer(), 3, 1, "", 2, 0, .working, "hi", usage);
     try writeAgentRowFromJson(bs.writer(), std.testing.allocator, js.getWritten(), false);
     try std.testing.expectEqualStrings(as.getWritten(), bs.getWritten());
 }

--- a/src/ipc/client_agent.zig
+++ b/src/ipc/client_agent.zig
@@ -579,3 +579,53 @@ pub fn runForMcp(a: std.mem.Allocator, parsed: IpcRequest) ![]const u8 {
     return resultJson(a, r);
 }
 
+// ---------------------------------------------------------------------------
+// Dashboard helpers. Resolve the pane's transport (daemon if present, else the
+// attached window) and act on it directly — read the visible screen, submit a
+// reply, or send a raw key. Reuse the same focus-free primitives as `agent
+// send`, so the dashboard never switches the user's window. Synchronous (one
+// round-trip); call them only on user action, not per frame.
+// ---------------------------------------------------------------------------
+
+fn paneCtx(a: std.mem.Allocator, pane_id: u32, sock_buf: *[256]u8) ?Ctx {
+    return resolveCtx(a, .{ .command = .agent_send, .pane_id = pane_id }, sock_buf) catch null;
+}
+
+/// Visible screen text of the pane (plain rows), or null if unreachable.
+pub fn paneScreen(a: std.mem.Allocator, pane_id: u32) ?[]const u8 {
+    var sock_buf: [256]u8 = undefined;
+    const ctx = paneCtx(a, pane_id, &sock_buf) orelse return null;
+    return captureSince(a, ctx, pane_id, "").text;
+}
+
+/// Submit a freeform reply: bracketed-paste body + Enter (same as `agent send`
+/// without --wait, so multi-line text and `{`/`}` stay literal).
+pub fn paneReply(a: std.mem.Allocator, pane_id: u32, text: []const u8) void {
+    var sock_buf: [256]u8 = undefined;
+    const ctx = paneCtx(a, pane_id, &sock_buf) orelse return;
+    var paste: [8192]u8 = undefined;
+    var ps = std.io.fixedBufferStream(&paste);
+    ps.writer().writeAll("\x1b[200~") catch {};
+    ps.writer().writeAll(text[0..@min(text.len, paste.len - 12)]) catch {};
+    ps.writer().writeAll("\x1b[201~") catch {};
+    submit(ctx, pane_id, ps.getWritten());
+    submit(ctx, pane_id, "\r");
+}
+
+/// Send raw key bytes to the pane (e.g. an option digit). No paste/Enter.
+pub fn paneKey(a: std.mem.Allocator, pane_id: u32, bytes: []const u8) void {
+    var sock_buf: [256]u8 = undefined;
+    const ctx = paneCtx(a, pane_id, &sock_buf) orelse return;
+    submit(ctx, pane_id, bytes);
+}
+
+/// The agent's last assistant message from its transcript (same source as `agent
+/// read`), or null when the agent reports no transcript (caller falls back to a
+/// screen scrape). Only Claude/Codex report transcripts.
+pub fn paneLastMessage(a: std.mem.Allocator, pane_id: u32) ?[]const u8 {
+    const path = agent_read.resolveTranscriptPath(a, .{ .command = .agent_send, .pane_id = pane_id }) orelse return null;
+    const msgs = agent_read.messagesAtPath(a, path) orelse return null;
+    if (msgs.len == 0) return null;
+    return msgs[msgs.len - 1];
+}
+

--- a/src/ipc/dashboard/input.zig
+++ b/src/ipc/dashboard/input.zig
@@ -18,6 +18,7 @@ pub const Key = enum {
     zoom, // z — zoom selected pane
     close, // x — close selected pane (confirm)
     detail, // Tab — toggle detail panel
+    interact, // i — reply / answer the selected agent inline
     none,
 };
 
@@ -38,6 +39,7 @@ pub const Decoder = struct {
             '/' => .search,
             'z' => .zoom,
             'x' => .close,
+            'i' => .interact,
             0x09 => .detail, // Tab
             '\r', '\n' => .enter,
             'j' => .down,
@@ -95,8 +97,8 @@ fn collect(bytes: []const u8, out: []Key) usize {
 
 test "decodes letters and control keys" {
     var out: [16]Key = undefined;
-    const n = collect("jkqG g\r\x03?rsfz x/\t", &out);
-    const want = [_]Key{ .down, .up, .quit, .bottom, .top, .enter, .quit, .help, .refresh, .sort, .filter, .zoom, .close, .search, .detail };
+    const n = collect("jkqG g\r\x03?rsfz xi/\t", &out);
+    const want = [_]Key{ .down, .up, .quit, .bottom, .top, .enter, .quit, .help, .refresh, .sort, .filter, .zoom, .close, .interact, .search, .detail };
     try testing.expectEqual(want.len, n);
     for (want, 0..) |k, i| try testing.expectEqual(k, out[i]);
 }

--- a/src/ipc/dashboard/model.zig
+++ b/src/ipc/dashboard/model.zig
@@ -96,12 +96,17 @@ pub const Row = struct {
     cost_is_estimate: bool = false,
     model_buf: [40]u8 = undefined,
     model_len: u8 = 0,
+    tab_buf: [48]u8 = undefined,
+    tab_len: u8 = 0,
     msg_buf: [120]u8 = undefined,
     msg_len: u8 = 0,
     state_since_ms: i64 = 0, // when the row entered its current state (for elapsed)
 
     pub fn model(self: *const Row) []const u8 {
         return self.model_buf[0..self.model_len];
+    }
+    pub fn tabName(self: *const Row) []const u8 {
+        return self.tab_buf[0..self.tab_len];
     }
     pub fn message(self: *const Row) []const u8 {
         return self.msg_buf[0..self.msg_len];
@@ -123,6 +128,7 @@ const RawUsage = struct {
 const RawRecord = struct {
     pane_id: u32 = 0,
     tab_id: u32 = 0,
+    tab_name: []const u8 = "",
     session: u32 = 0,
     pid: u32 = 0,
     state: []const u8 = "none",
@@ -218,6 +224,7 @@ pub const Model = struct {
         r.session = parsed.session;
         r.pane_id = parsed.pane_id;
         r.tab_id = parsed.tab_id;
+        r.tab_len = copyBuf(&r.tab_buf, parsed.tab_name);
         r.pid = parsed.pid;
         r.state = st;
         r.msg_len = copyBuf(&r.msg_buf, parsed.message);
@@ -363,6 +370,9 @@ pub const Model = struct {
 };
 
 fn less(a: Row, b: Row, mode: SortMode) bool {
+    // Always group by session first; the mode orders rows within a session. This
+    // keeps the view session-contiguous so the dashboard can render group headers.
+    if (a.session != b.session) return a.session < b.session;
     switch (mode) {
         .state => {
             if (a.state.rank() != b.state.rank()) return a.state.rank() < b.state.rank();
@@ -385,7 +395,6 @@ fn less(a: Row, b: Row, mode: SortMode) bool {
         },
         .session => {},
     }
-    if (a.session != b.session) return a.session < b.session;
     return a.pane_id < b.pane_id;
 }
 
@@ -395,7 +404,7 @@ fn less(a: Row, b: Row, mode: SortMode) bool {
 
 const testing = std.testing;
 
-test "applyLine upserts, sticky-merges usage, sorts by state then cost" {
+test "applyLine upserts, sticky-merges usage; groups by session then state/cost" {
     const a = testing.allocator;
     var m = Model{};
     m.applyLine(a, "{\"session\":1,\"pane_id\":3,\"state\":\"working\",\"usage\":{\"input_tokens\":100,\"cost_usd\":0.10}}", 0);
@@ -403,8 +412,10 @@ test "applyLine upserts, sticky-merges usage, sorts by state then cost" {
     m.applyLine(a, "{\"session\":2,\"pane_id\":5,\"state\":\"working\",\"usage\":{\"input_tokens\":50,\"cost_usd\":0.50}}", 0);
     try testing.expectEqual(@as(usize, 3), m.count);
     try testing.expectEqual(@as(usize, 3), m.view_count);
-    try testing.expectEqual(State.input, m.rows[0].state);
-    try testing.expectEqual(@as(u32, 5), m.rows[1].pane_id); // 0.50 before 0.10
+    // Session 1 rows first (grouped); within it input ranks before working.
+    try testing.expectEqual(@as(u32, 8), m.rows[0].pane_id); // s1, input
+    try testing.expectEqual(@as(u32, 3), m.rows[1].pane_id); // s1, working
+    try testing.expectEqual(@as(u32, 5), m.rows[2].pane_id); // s2
     try testing.expectApproxEqAbs(@as(f64, 0.60), m.total_cost, 1e-9);
 
     m.applyLine(a, "{\"session\":2,\"pane_id\":5,\"state\":\"idle\"}", 0);

--- a/src/ipc/dashboard/prompt.zig
+++ b/src/ipc/dashboard/prompt.zig
@@ -1,0 +1,231 @@
+//! Parse an agent's on-screen prompt into a structured choice — pure, TTY-free,
+//! unit-testable. Input is the pane's visible screen text (plain grid rows, no
+//! ANSI) as returned by `get_text`. Agents that pause for input (Claude/Codex
+//! permission and menu prompts) draw a numbered option list; we find the bottom
+//! contiguous `N. label` block and the question line above it. Agents that don't
+//! (opencode/pi freeform) yield null, and the dashboard falls back to a reply box.
+//!
+//! Also defines `Interact`, the dashboard's transient input state, here (not in
+//! run.zig) so render.zig can read it without importing run.zig.
+const std = @import("std");
+
+pub const max_options = 9;
+
+pub const Option = struct {
+    num: u8 = 0,
+    buf: [96]u8 = undefined,
+    len: u8 = 0,
+
+    pub fn label(self: *const Option) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+pub const Prompt = struct {
+    q_buf: [160]u8 = undefined,
+    q_len: u8 = 0,
+    options: [max_options]Option = undefined,
+    n: u8 = 0,
+
+    pub fn question(self: *const Prompt) []const u8 {
+        return self.q_buf[0..self.q_len];
+    }
+
+    /// Parse `screen` (visible rows, newline-separated, plain text). Returns a
+    /// Prompt when a numbered option block (≥2 options starting at 1, consecutive)
+    /// sits at the bottom of the screen, else null.
+    pub fn parse(screen: []const u8) ?Prompt {
+        // Collect non-blank trimmed lines (drop trailing blanks).
+        var lines: [256][]const u8 = undefined;
+        var nlines: usize = 0;
+        var it = std.mem.splitScalar(u8, screen, '\n');
+        while (it.next()) |raw| {
+            if (nlines >= lines.len) break;
+            lines[nlines] = raw;
+            nlines += 1;
+        }
+        // Trim trailing lines that hold no option/text (blank or box-only).
+        while (nlines > 0 and strip(lines[nlines - 1]).len == 0) nlines -= 1;
+        if (nlines == 0) return null;
+
+        // Walk up from the bottom collecting consecutive option lines.
+        var p = Prompt{};
+        var tmp: [max_options]Option = undefined;
+        var got: usize = 0;
+        var i: usize = nlines;
+        var block_top: usize = nlines;
+        while (i > 0) {
+            i -= 1;
+            if (asOption(strip(lines[i]))) |opt| {
+                if (got < max_options) {
+                    tmp[got] = opt;
+                    got += 1;
+                    block_top = i;
+                    continue;
+                }
+            }
+            // First non-option after we've started the block ends it.
+            if (got > 0) break;
+        }
+        if (got < 2) return null;
+
+        // tmp is bottom-up; reverse into options[] and validate 1,2,3… order.
+        p.n = @intCast(got);
+        var k: usize = 0;
+        while (k < got) : (k += 1) {
+            const src = tmp[got - 1 - k];
+            if (src.num != k + 1) return null; // not a clean 1..N menu → reject
+            p.options[k] = src;
+        }
+
+        // Question: nearest non-blank text line above the block that isn't itself
+        // an option. Strip box noise; empty is fine (some prompts have none).
+        var q: []const u8 = "";
+        var j: usize = block_top;
+        while (j > 0) {
+            j -= 1;
+            const s = strip(lines[j]);
+            if (s.len == 0) continue;
+            if (asOption(s) != null) continue;
+            q = s;
+            break;
+        }
+        p.q_len = copy(&p.q_buf, q);
+        return p;
+    }
+};
+
+/// Dashboard interaction state. `.reply` types a freeform message; `.options`
+/// shows the parsed picker. The expanded panel under the row also shows `msg`
+/// (the agent's last message, scrollable). Owned by run.zig, read by render.zig.
+pub const Interact = struct {
+    mode: enum { none, reply, options } = .none,
+    pane_id: u32 = 0,
+    reply_buf: [512]u8 = undefined,
+    reply_len: usize = 0,
+    prompt: Prompt = .{},
+    sel: u8 = 0,
+    msg_buf: [4096]u8 = undefined,
+    msg_len: usize = 0,
+    msg_scroll: usize = 0, // first wrapped line shown in the message area
+
+    pub fn reply(self: *const Interact) []const u8 {
+        return self.reply_buf[0..self.reply_len];
+    }
+    pub fn msg(self: *const Interact) []const u8 {
+        return self.msg_buf[0..self.msg_len];
+    }
+    pub fn setMsg(self: *Interact, s: []const u8) void {
+        self.msg_len = @min(s.len, self.msg_buf.len);
+        @memcpy(self.msg_buf[0..self.msg_len], s[0..self.msg_len]);
+    }
+    pub fn reset(self: *Interact) void {
+        self.* = .{};
+    }
+};
+
+// --- helpers ---------------------------------------------------------------
+
+const caret_box = [_][]const u8{ "│", "┃", "║", "❯", "▶", "›", "*", ">", "|" };
+
+/// Strip leading whitespace and box/caret glyphs (repeatedly), then trailing
+/// whitespace and box verticals.
+fn strip(line: []const u8) []const u8 {
+    var s = std.mem.trim(u8, line, " \t\r");
+    outer: while (s.len > 0) {
+        for (caret_box) |g| {
+            if (std.mem.startsWith(u8, s, g)) {
+                s = std.mem.trimLeft(u8, s[g.len..], " \t");
+                continue :outer;
+            }
+        }
+        break;
+    }
+    // Trailing box verticals (right border of a panel) + spaces.
+    while (s.len > 0) {
+        var trimmed = false;
+        s = std.mem.trimRight(u8, s, " \t\r");
+        for (caret_box) |g| {
+            if (std.mem.endsWith(u8, s, g)) {
+                s = s[0 .. s.len - g.len];
+                trimmed = true;
+            }
+        }
+        if (!trimmed) break;
+    }
+    return s;
+}
+
+/// `N. label` / `N) label` / `N: label` / `N label`, N in 1..9. Returns the
+/// option or null. `s` is assumed already stripped of leading box/caret.
+fn asOption(s: []const u8) ?Option {
+    if (s.len < 2) return null;
+    if (s[0] < '1' or s[0] > '9') return null;
+    const sep = s[1];
+    if (sep != '.' and sep != ')' and sep != ':' and sep != ' ') return null;
+    const label = std.mem.trim(u8, s[2..], " \t");
+    if (label.len == 0) return null;
+    var o = Option{ .num = s[0] - '0' };
+    o.len = copy(&o.buf, label);
+    return o;
+}
+
+fn copy(buf: []u8, s: []const u8) u8 {
+    const n = @min(s.len, buf.len);
+    @memcpy(buf[0..n], s[0..n]);
+    return @intCast(n);
+}
+
+// --- tests -----------------------------------------------------------------
+
+const testing = std.testing;
+
+test "parses a Claude-style permission box" {
+    const screen =
+        \\╭─────────────────────────────────────╮
+        \\│ Bash command                        │
+        \\│ rm -rf build                        │
+        \\│ Do you want to proceed?             │
+        \\│ ❯ 1. Yes                            │
+        \\│   2. Yes, and don't ask again       │
+        \\│   3. No, and tell Claude what to do │
+        \\╰─────────────────────────────────────╯
+    ;
+    const p = Prompt.parse(screen) orelse return error.NoPrompt;
+    try testing.expectEqual(@as(u8, 3), p.n);
+    try testing.expectEqualStrings("Yes", p.options[0].label());
+    try testing.expectEqual(@as(u8, 2), p.options[1].num);
+    try testing.expectEqualStrings("No, and tell Claude what to do", p.options[2].label());
+    try testing.expectEqualStrings("Do you want to proceed?", p.question());
+}
+
+test "parses a bare numbered menu (no box)" {
+    const screen =
+        \\Select an option:
+        \\1) Continue
+        \\2) Cancel
+        \\
+    ;
+    const p = Prompt.parse(screen) orelse return error.NoPrompt;
+    try testing.expectEqual(@as(u8, 2), p.n);
+    try testing.expectEqualStrings("Continue", p.options[0].label());
+    try testing.expectEqualStrings("Select an option:", p.question());
+}
+
+test "no numbered block → null (freeform)" {
+    try testing.expect(Prompt.parse("Tell me what to build next.\n> ") == null);
+    try testing.expect(Prompt.parse("") == null);
+    try testing.expect(Prompt.parse("step 1. done\nstep 3. later") == null); // not 1..N consecutive
+}
+
+test "ignores prose above; only bottom block counts" {
+    const screen =
+        \\I considered 3 approaches earlier.
+        \\Now choose:
+        \\1. Approach A
+        \\2. Approach B
+    ;
+    const p = Prompt.parse(screen) orelse return error.NoPrompt;
+    try testing.expectEqual(@as(u8, 2), p.n);
+    try testing.expectEqualStrings("Now choose:", p.question());
+}

--- a/src/ipc/dashboard/render.zig
+++ b/src/ipc/dashboard/render.zig
@@ -5,6 +5,7 @@
 const std = @import("std");
 const model = @import("model.zig");
 const fmt = @import("format.zig");
+const prompt = @import("prompt.zig");
 const ui_cell = @import("attyx").overlay_ui_cell;
 
 const Model = model.Model;
@@ -17,6 +18,7 @@ const gutter = "  ";
 const gw: u16 = 2;
 const dot_w: u16 = 2;
 const session_w: u16 = 10;
+const tab_w: u16 = 14;
 const pane_w: u16 = 5;
 const model_w: u16 = 16;
 const state_w: u16 = 8;
@@ -25,9 +27,9 @@ const in_w: u16 = 8;
 const out_w: u16 = 8;
 const ctx_w: u16 = 14;
 const cost_w: u16 = 10;
-const n_cols = 10;
-const col_widths = [n_cols]u16{ dot_w, session_w, pane_w, model_w, state_w, elapsed_w, in_w, out_w, ctx_w, cost_w };
-const col_right = [n_cols]bool{ false, false, false, false, false, true, true, true, true, true };
+const n_cols = 11;
+const col_widths = [n_cols]u16{ dot_w, session_w, tab_w, pane_w, model_w, state_w, elapsed_w, in_w, out_w, ctx_w, cost_w };
+const col_right = [n_cols]bool{ false, false, false, false, false, false, true, true, true, true, true };
 const dot = "\xe2\x97\x8f"; // ●
 const marker_sel = "\xe2\x96\xb6 "; // ▶ + space
 const marker_none = "  ";
@@ -86,6 +88,7 @@ pub const Ctx = struct {
     connected: bool = true,
     detail: bool = false,
     confirm_close: bool = false,
+    interact: ?*const prompt.Interact = null,
 };
 
 fn stateColor(s: State) []const u8 {
@@ -162,11 +165,12 @@ fn rowLine(a: std.mem.Allocator, r: *const Row, ctx: Ctx, color: bool) ![]const 
     var colors = no_colors;
     if (color) {
         colors[0] = stateColor(r.state); // dot
-        colors[4] = stateColor(r.state); // state
+        colors[5] = stateColor(r.state); // state
     }
     return buildLine(a, .{
         dot,
         session,
+        if (r.tab_len > 0) r.tabName() else "\xe2\x80\x94",
         std.fmt.bufPrint(&pb, "{d}", .{r.pane_id}) catch "?",
         if (r.model_len > 0) r.model() else "\xe2\x80\x94",
         stateLabel(r.state),
@@ -179,7 +183,7 @@ fn rowLine(a: std.mem.Allocator, r: *const Row, ctx: Ctx, color: bool) ![]const 
 }
 
 fn headerLine(a: std.mem.Allocator) ![]const u8 {
-    return buildLine(a, .{ " ", "SESSION", "PANE", "MODEL", "STATE", "ELAPSED", "IN", "OUT", "CTX", "COST" }, no_colors);
+    return buildLine(a, .{ " ", "SESSION", "TAB", "PANE", "MODEL", "STATE", "ELAPSED", "IN", "OUT", "CTX", "COST" }, no_colors);
 }
 
 fn totalsLine(a: std.mem.Allocator, m: *const Model) ![]const u8 {
@@ -187,7 +191,7 @@ fn totalsLine(a: std.mem.Allocator, m: *const Model) ![]const u8 {
     var ob: [16]u8 = undefined;
     var cb: [24]u8 = undefined;
     const cost = std.fmt.bufPrint(&cb, "{s}${d:.2}", .{ if (m.any_estimate) "~" else "", m.total_cost }) catch "$?";
-    return buildLine(a, .{ " ", "TOTAL", "", "", "", "", fmt.tokens(&ib, m.total_input), fmt.tokens(&ob, m.total_output), "", cost }, no_colors);
+    return buildLine(a, .{ " ", "TOTAL", "", "", "", "", "", fmt.tokens(&ib, m.total_input), fmt.tokens(&ob, m.total_output), "", cost }, no_colors);
 }
 
 /// Plain-text table to `writer` (for `--once` / non-TTY). No ANSI.
@@ -205,9 +209,42 @@ pub fn snapshot(writer: anytype, a: std.mem.Allocator, m: *const Model, ctx: Ctx
     try writer.print("  {s}\n", .{try totalsLine(a, m)});
 }
 
+const interact_msg_rows: u16 = 5; // message scroll-area height inside the panel
+
+/// Rows the inline interaction panel occupies: a label, the message area, a hint,
+/// plus the input row (reply) or question+buttons rows (options).
+fn interactRows(it: *const prompt.Interact) u16 {
+    return interact_msg_rows + 2 + (if (it.mode == .options) @as(u16, 2) else 1);
+}
+
+/// The session column's display name: the cached name, else `s<id>`.
+fn sessionName(ctx: Ctx, id: u32, buf: []u8) []const u8 {
+    if (ctx.names) |nm| {
+        if (nm.get(id)) |n| return n;
+    }
+    return std.fmt.bufPrint(buf, "s{d}", .{id}) catch "s?";
+}
+
+/// Distinct sessions in the view. Rows are session-contiguous under the session
+/// sort, so a change-count is exact — used to reserve group-header rows.
+fn distinctSessions(m: *const Model) u16 {
+    var n: u16 = 0;
+    var prev: u32 = 0;
+    var have = false;
+    var i: usize = 0;
+    while (i < m.visibleCount()) : (i += 1) {
+        const s = m.rowAt(i).session;
+        if (!have or s != prev) {
+            n += 1;
+            prev = s;
+            have = true;
+        }
+    }
+    return n;
+}
+
 /// Full-screen ANSI frame into `buf` (for the interactive TUI).
 pub fn frame(buf: *std.ArrayList(u8), a: std.mem.Allocator, m: *const Model, rows: u16, cols: u16, ctx: Ctx) !void {
-    _ = cols;
     const w = buf.writer(a);
     try w.writeAll("\x1b[2J\x1b[H");
     var line: u16 = 1;
@@ -223,17 +260,39 @@ pub fn frame(buf: *std.ArrayList(u8), a: std.mem.Allocator, m: *const Model, row
     try w.print("{s}  {s}{s}\x1b[K", .{ dim, try headerLine(a), reset });
     line += 1;
 
-    // Reserve rows: 2 header + totals + help (+ up to 5 detail lines).
-    const detail_rows: u16 = if (ctx.detail and m.selectedRow() != null) 5 else 0;
-    const reserved: u16 = 4 + detail_rows;
+    // The inline interaction panel (expanded under the selected row) and the
+    // detail panel are mutually exclusive — both expand the selection.
+    const it: ?*const prompt.Interact = blk: {
+        const p = ctx.interact orelse break :blk null;
+        if (p.mode != .none and m.selectedRow() != null) break :blk p;
+        break :blk null;
+    };
+    const panel_rows: u16 = if (it) |x| interactRows(x) else 0;
+    const detail_rows: u16 = if (it == null and ctx.detail and m.selectedRow() != null) 5 else 0;
+    // Agents are always grouped by session (the view is session-contiguous), so
+    // we emit a header whenever the session changes. Headers reserve rows.
+    const group = m.visibleCount() > 0;
+    const header_rows: u16 = distinctSessions(m);
+    const reserved: u16 = 4 + detail_rows + panel_rows + header_rows;
     const body_rows = if (rows > reserved + 1) rows - reserved else 1;
     if (m.visibleCount() == 0) {
         try moveTo(w, line);
         try w.print("{s}  no agents \xe2\x80\x94 launch claude/codex/opencode/pi in any pane{s}\x1b[K", .{ dim, reset });
     } else {
         var i: usize = 0;
-        while (i < m.visibleCount() and i < body_rows) : (i += 1) {
+        var shown: u16 = 0;
+        var prev_sess: u32 = 0;
+        var have_prev = false;
+        var sb: [24]u8 = undefined;
+        while (i < m.visibleCount() and shown < body_rows) : (i += 1) {
             const r = m.rowAt(i);
+            if (group and (!have_prev or r.session != prev_sess)) {
+                try moveTo(w, line);
+                try w.print("{s}  {s}{s}\x1b[K", .{ dim, sessionName(ctx, r.session, &sb), reset });
+                line += 1;
+                prev_sess = r.session;
+                have_prev = true;
+            }
             try moveTo(w, line);
             if (i == m.selected) {
                 // Subtle background highlight; per-cell colors use fg-only resets
@@ -243,6 +302,11 @@ pub fn frame(buf: *std.ArrayList(u8), a: std.mem.Allocator, m: *const Model, row
                 try w.print("{s}{s}{s}\x1b[K", .{ marker_none, try rowLine(a, r, ctx, true), reset });
             }
             line += 1;
+            shown += 1;
+            if (it != null and i == m.selected) {
+                try drawInteract(w, line, cols, it.?);
+                line += panel_rows;
+            }
         }
     }
 
@@ -254,6 +318,105 @@ pub fn frame(buf: *std.ArrayList(u8), a: std.mem.Allocator, m: *const Model, row
         try moveTo(w, rows);
         try helpLine(w, m, ctx);
     }
+}
+
+/// The expanded interaction panel under the selected row: a scrollable view of
+/// the agent's last message, then either a reply input line or the parsed option
+/// picker. `line0` is the first panel row; it consumes `interactRows(it)` rows.
+fn drawInteract(w: anytype, line0: u16, cols: u16, it: *const prompt.Interact) !void {
+    var line = line0;
+    try moveTo(w, line);
+    try w.print("{s}  \xe2\x95\xb0 pane {d} \xc2\xb7 last message{s}\x1b[K", .{ dim, it.pane_id, reset });
+    line += 1;
+
+    // Message area: wrap, then show a scrolled window.
+    const inner_w: usize = if (cols > 8) cols - 8 else 24;
+    var wrapped: [512][]const u8 = undefined;
+    const nlines = wrapText(it.msg(), inner_w, &wrapped);
+    const start = clampScroll(it.msg_scroll, nlines, interact_msg_rows);
+    var k: u16 = 0;
+    while (k < interact_msg_rows) : (k += 1) {
+        try moveTo(w, line);
+        const idx = start + k;
+        if (idx < nlines) {
+            try w.print("{s}  \xe2\x94\x82 {s}{s}\x1b[K", .{ dim, reset, wrapped[idx] });
+        } else if (k == 0 and nlines == 0) {
+            try w.print("{s}  \xe2\x94\x82 (no recent message){s}\x1b[K", .{ dim, reset });
+        } else {
+            try w.print("{s}  \xe2\x94\x82{s}\x1b[K", .{ dim, reset });
+        }
+        line += 1;
+    }
+
+    switch (it.mode) {
+        .none => {},
+        .reply => {
+            try moveTo(w, line);
+            try w.print("{s}  reply \xe2\x96\xb8 {s}{s}\xe2\x96\x88\x1b[K", .{ c_input, reset, it.reply() });
+            line += 1;
+        },
+        .options => {
+            try moveTo(w, line);
+            try w.print("{s}  {s}{s}\x1b[K", .{ dim, it.prompt.question(), reset });
+            line += 1;
+            try moveTo(w, line);
+            try w.writeAll("  ");
+            var i: usize = 0;
+            while (i < it.prompt.n) : (i += 1) {
+                const o = &it.prompt.options[i];
+                if (i == it.sel) {
+                    try w.print("{s}{s} {d} {s} {s} ", .{ sel_bg, bold, o.num, o.label(), reset });
+                } else {
+                    try w.print("{s} {d} {s} {s} ", .{ dim, o.num, o.label(), reset });
+                }
+            }
+            try w.writeAll("\x1b[K");
+            line += 1;
+        },
+    }
+
+    try moveTo(w, line);
+    const hint = if (it.mode == .options)
+        "j/k or 1-9 \xc2\xb7 \xe2\x8f\x8e send \xc2\xb7 ^U/^D scroll \xc2\xb7 esc"
+    else
+        "\xe2\x8f\x8e send \xc2\xb7 ^U/^D scroll \xc2\xb7 esc cancel";
+    try w.print("{s}  {s}{s}\x1b[K", .{ dim, hint, reset });
+}
+
+/// Wrap `text` (newline-separated) to `width` byte-columns, filling `out` with
+/// slices into `text`. Breaks on UTF-8 boundaries (no mid-codepoint cuts).
+/// Approximate for wide chars — fine for a preview. Returns the line count.
+fn wrapText(text: []const u8, width: usize, out: [][]const u8) usize {
+    var n: usize = 0;
+    var segs = std.mem.splitScalar(u8, text, '\n');
+    while (segs.next()) |seg| {
+        if (n >= out.len) break;
+        if (seg.len == 0) {
+            out[n] = "";
+            n += 1;
+            continue;
+        }
+        var s = seg;
+        while (s.len > 0 and n < out.len) {
+            if (s.len <= width) {
+                out[n] = s;
+                n += 1;
+                break;
+            }
+            var brk = width;
+            while (brk > 0 and (s[brk] & 0xC0) == 0x80) brk -= 1;
+            if (brk == 0) brk = width;
+            out[n] = s[0..brk];
+            n += 1;
+            s = s[brk..];
+        }
+    }
+    return n;
+}
+
+fn clampScroll(scroll: usize, total: usize, rows_avail: u16) usize {
+    if (total <= rows_avail) return 0;
+    return @min(scroll, total - rows_avail);
 }
 
 fn detailPanel(w: anytype, a: std.mem.Allocator, r: *const Row, at: u16, ctx: Ctx) !void {
@@ -298,7 +461,7 @@ fn helpLine(w: anytype, m: *const Model, ctx: Ctx) !void {
         try w.print("{s}  {s}disconnected{s}{s} \xc2\xb7 reconnecting \xc2\xb7 q quit{s}\x1b[K", .{ dim, c_input, reset, dim, reset });
         return;
     }
-    try w.print("{s}  \xe2\x86\x91\xe2\x86\x93 sel  \xe2\x8f\x8e focus  z zoom  x close  s sort:{s}  f filter:{s}  / search  \xe2\x87\xa5 detail  q quit{s}\x1b[K", .{ dim, m.sort_mode.label(), m.filter_mode.label(), reset });
+    try w.print("{s}  \xe2\x86\x91\xe2\x86\x93 sel  \xe2\x8f\x8e focus  i reply  z zoom  x close  s sort:{s}  f filter:{s}  / search  \xe2\x87\xa5 detail  q quit{s}\x1b[K", .{ dim, m.sort_mode.label(), m.filter_mode.label(), reset });
 }
 
 fn moveTo(w: anytype, row: u16) !void {
@@ -333,4 +496,64 @@ test "name cache resolves the session column" {
     var buf = std.ArrayList(u8){};
     try frame(&buf, a, &m, 24, 100, .{ .names = &names });
     try testing.expect(std.mem.indexOf(u8, buf.items, "build") != null);
+}
+
+test "tab_name from the record shows in the TAB column" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var m = Model{};
+    m.applyLine(a, "{\"session\":1,\"pane_id\":2,\"tab_name\":\"api-server\",\"state\":\"working\"}", 0);
+    var buf = std.ArrayList(u8){};
+    try frame(&buf, a, &m, 24, 120, .{});
+    try testing.expect(std.mem.indexOf(u8, buf.items, "TAB") != null); // header
+    try testing.expect(std.mem.indexOf(u8, buf.items, "api-server") != null);
+}
+
+test "inline interact panel renders message, question and options" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var m = Model{};
+    m.applyLine(a, "{\"session\":1,\"pane_id\":3,\"state\":\"input\"}", 0);
+    var it = prompt.Interact{ .pane_id = 3, .mode = .options };
+    it.setMsg("finished the refactor");
+    it.prompt = prompt.Prompt.parse("Proceed?\n1. Yes\n2. No").?;
+    var buf = std.ArrayList(u8){};
+    try frame(&buf, a, &m, 24, 100, .{ .interact = &it });
+    try testing.expect(std.mem.indexOf(u8, buf.items, "finished the refactor") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "Proceed?") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "Yes") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "last message") != null);
+}
+
+test "agents are grouped under per-session headers (any sort)" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var m = Model{};
+    m.applyLine(a, "{\"session\":1,\"pane_id\":1,\"state\":\"working\"}", 0);
+    m.applyLine(a, "{\"session\":2,\"pane_id\":2,\"state\":\"working\"}", 0);
+    var names = NameCache{};
+    names.set(1, "web");
+    names.set(2, "api");
+    m.sort_mode = .state; // grouping is independent of the sort mode now
+    m.refresh(0);
+    var buf = std.ArrayList(u8){};
+    try frame(&buf, a, &m, 24, 100, .{ .names = &names });
+    // A header line is a dimmed bare session name (distinct from the row's cell).
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\x1b[2m  web\x1b[0m") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "\x1b[2m  api\x1b[0m") != null);
+}
+
+test "wrapText breaks long lines and respects newlines" {
+    var out: [16][]const u8 = undefined;
+    // "hello" (1) + "worldworldworld" (15 chars / 6 = 3 chunks) = 4 lines.
+    const n = wrapText("hello\nworldworldworld", 6, &out);
+    try testing.expectEqual(@as(usize, 4), n);
+    try testing.expectEqualStrings("hello", out[0]);
+    try testing.expectEqualStrings("worldw", out[1]);
+    try testing.expectEqualStrings("rld", out[3]);
+    try testing.expectEqual(@as(usize, 0), clampScroll(10, 3, 5)); // fits → no scroll
+    try testing.expectEqual(@as(usize, 2), clampScroll(10, 7, 5)); // clamp to last page
 }

--- a/src/ipc/dashboard/run.zig
+++ b/src/ipc/dashboard/run.zig
@@ -10,6 +10,8 @@ const term_mod = @import("term.zig");
 const model_mod = @import("model.zig");
 const render = @import("render.zig");
 const input = @import("input.zig");
+const prompt = @import("prompt.zig");
+const client_agent = @import("../client_agent.zig");
 const client = @import("../client.zig");
 const io = @import("../protocol.zig"); // writeAll/readExact/closeFd + header
 const ipc_proto = @import("../protocol.zig");
@@ -228,6 +230,106 @@ pub fn run(gpa: std.mem.Allocator, opts: Options) void {
 
 const Mode = enum { normal, search, confirm };
 
+/// Enter inline interaction for the selected agent. If it's waiting for input and
+/// its visible screen parses as a numbered prompt, open the option picker;
+/// otherwise open a freeform reply box (works for any agent, any state).
+fn startInteract(gpa: std.mem.Allocator, it: *prompt.Interact, r: *const model_mod.Row) void {
+    it.reset();
+    it.pane_id = r.pane_id;
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const screen = client_agent.paneScreen(a, r.pane_id);
+    // Message area: the agent's last transcript message, else the screen tail.
+    if (client_agent.paneLastMessage(a, r.pane_id)) |msg| {
+        it.setMsg(msg);
+    } else if (screen) |s| {
+        it.setMsg(if (s.len > 3072) s[s.len - 3072 ..] else s);
+    }
+    // Option/permission picker when the agent is waiting and its screen parses
+    // as a numbered prompt; otherwise a freeform reply box.
+    if (r.state == .input) {
+        if (screen) |s| {
+            if (prompt.Prompt.parse(s)) |p| {
+                it.prompt = p;
+                it.mode = .options;
+                return;
+            }
+        }
+    }
+    it.mode = .reply;
+}
+
+const scroll_step = 3;
+
+/// One keystroke while interacting. Reply mode edits/sends freeform text; options
+/// mode navigates (j/k), selects by digit, sends the highlighted one on Enter.
+/// Esc / Ctrl-C cancels.
+fn handleInteractByte(gpa: std.mem.Allocator, it: *prompt.Interact, b: u8) void {
+    switch (it.mode) {
+        .none => {},
+        .reply => switch (b) {
+            0x1b, 0x03 => it.reset(),
+            0x15 => it.msg_scroll -|= scroll_step, // ^U scroll message up
+            0x04 => it.msg_scroll += scroll_step, // ^D scroll message down
+            '\r', '\n' => {
+                sendReply(gpa, it);
+                it.reset();
+            },
+            0x7f, 0x08 => if (it.reply_len > 0) {
+                it.reply_len -= 1;
+            },
+            else => if (b >= 0x20 and b < 0x7f and it.reply_len < it.reply_buf.len) {
+                it.reply_buf[it.reply_len] = b;
+                it.reply_len += 1;
+            },
+        },
+        .options => switch (b) {
+            0x1b, 0x03, 'q' => it.reset(),
+            0x15 => it.msg_scroll -|= scroll_step, // ^U scroll message up
+            0x04 => it.msg_scroll += scroll_step, // ^D scroll message down
+            'j' => if (it.sel + 1 < it.prompt.n) {
+                it.sel += 1;
+            },
+            'k' => if (it.sel > 0) {
+                it.sel -= 1;
+            },
+            '\r', '\n' => {
+                if (it.sel < it.prompt.n) sendOption(gpa, it.pane_id, it.prompt.options[it.sel].num);
+                it.reset();
+            },
+            '1'...'9' => {
+                const d = b - '0';
+                for (it.prompt.options[0..it.prompt.n]) |o| {
+                    if (o.num == d) {
+                        sendOption(gpa, it.pane_id, d);
+                        it.reset();
+                        break;
+                    }
+                }
+            },
+            else => {},
+        },
+    }
+}
+
+fn sendReply(gpa: std.mem.Allocator, it: *prompt.Interact) void {
+    if (it.reply_len == 0) return;
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    client_agent.paneReply(arena.allocator(), it.pane_id, it.reply());
+}
+
+/// Send the option's number key. ponytail: digit-only — Claude/Codex permission
+/// and menu prompts select immediately on the number; if some TUI needs Enter to
+/// confirm a highlighted choice, send "\r" after as a follow-up.
+fn sendOption(gpa: std.mem.Allocator, pane_id: u32, num: u8) void {
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    const key = [_]u8{'0' + num};
+    client_agent.paneKey(arena.allocator(), pane_id, &key);
+}
+
 fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model, names: *render.NameCache) !void {
     var t = try term_mod.Term.init();
     g_term = &t;
@@ -241,6 +343,7 @@ fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model, 
     var dirty = true;
     var connected = true;
     var mode: Mode = .normal;
+    var interact = prompt.Interact{};
     var detail = false;
     var next_retry: i64 = 0;
     var backoff: i64 = 500;
@@ -262,6 +365,7 @@ fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model, 
                 .connected = connected,
                 .detail = detail,
                 .confirm_close = mode == .confirm,
+                .interact = &interact,
             }) catch {};
             t.write(buf.items);
             dirty = false;
@@ -317,6 +421,11 @@ fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model, 
             const n = posix.read(posix.STDIN_FILENO, &ib) catch 0;
             if (n == 0) break;
             for (ib[0..n]) |b| {
+                if (interact.mode != .none) {
+                    handleInteractByte(gpa, &interact, b);
+                    dirty = true;
+                    continue;
+                }
                 switch (mode) {
                     .search => {
                         switch (b) {
@@ -371,6 +480,12 @@ fn runInteractive(gpa: std.mem.Allocator, stream: *Stream, m: *model_mod.Model, 
                         .detail => {
                             detail = !detail;
                             dirty = true;
+                        },
+                        .interact => {
+                            if (m.selectedRow()) |r| {
+                                startInteract(gpa, &interact, r);
+                                dirty = true;
+                            }
                         },
                         .zoom => {
                             if (m.selectedRow()) |r| switchAndPane(r.session, r.pane_id, .pane_zoom_targeted);

--- a/src/ipc/handler_query.zig
+++ b/src/ipc/handler_query.zig
@@ -152,6 +152,7 @@ pub fn buildAgentList(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
         // A tab's stable handle is its focused pane's IPC id — the same `pane:N`
         // value `attyx list` prints on each tab line.
         const tab_id = layout.focusedPane().ipc_id;
+        const tab_name = layout.effectiveTitle();
         var leaves: [split_layout_mod.max_panes]split_layout_mod.LeafEntry = undefined;
         const lc = layout.collectLeaves(&leaves);
         for (leaves[0..lc]) |leaf| {
@@ -163,7 +164,7 @@ pub fn buildAgentList(cmd: *queue.IpcCommand, ctx: *PtyThreadCtx) void {
             const pid = agents.panePid(leaf.pane.pty.master);
             if (as_json) {
                 if (!first) w.writeAll(",") catch break;
-                agents.writeAgentJson(w, leaf.pane.ipc_id, tab_id, session_id, pid, status, msg, usage) catch break;
+                agents.writeAgentJson(w, leaf.pane.ipc_id, tab_id, tab_name, session_id, pid, status, msg, usage) catch break;
             } else {
                 agents.writeAgentRow(w, leaf.pane.ipc_id, tab_id, session_id, pid, status, msg, usage, false) catch break;
             }

--- a/src/ipc/watch.zig
+++ b/src/ipc/watch.zig
@@ -87,7 +87,8 @@ pub fn broadcastAgent(ctx: *PtyThreadCtx, pane: *Pane, tab_id: u32) void {
     if (watcher_count == 0) return;
 
     var frame_buf: [frame_cap]u8 = undefined;
-    const frame = buildFrame(&frame_buf, sessionId(ctx), pane, tab_id) orelse return;
+    const tab_name = tabName(ctx, pane.ipc_id);
+    const frame = buildFrame(&frame_buf, sessionId(ctx), pane, tab_id, tab_name) orelse return;
 
     var i: usize = 0;
     while (i < watcher_count) {
@@ -120,15 +121,24 @@ fn sessionId(ctx: *PtyThreadCtx) u32 {
     return 0;
 }
 
+/// The tab title for the tab containing `pane_id` (explicit name, else the
+/// auto-derived hint, else ""), so watch frames carry the same label the tab bar
+/// shows. Empty when the pane isn't found.
+fn tabName(ctx: *PtyThreadCtx, pane_id: u32) []const u8 {
+    const found = ctx.tab_mgr.findPaneWithLayout(pane_id) orelse return "";
+    return found.layout.effectiveTitle();
+}
+
 /// Build a framed (.success) NDJSON line for one agent. Returns null if the
 /// JSON object overflowed the buffer (never expected for our field set).
-fn buildFrame(buf: []u8, session: u32, pane: *Pane, tab_id: u32) ?[]const u8 {
+fn buildFrame(buf: []u8, session: u32, pane: *Pane, tab_id: u32, tab_name: []const u8) ?[]const u8 {
     var json_buf: [frame_cap - protocol.header_size]u8 = undefined;
     var stream = std.io.fixedBufferStream(&json_buf);
     agents.writeAgentJson(
         stream.writer(),
         pane.ipc_id,
         tab_id,
+        tab_name,
         session,
         agents.panePid(pane.pty.master),
         pane.engine.state.agent_status,
@@ -153,7 +163,8 @@ fn writeSnapshot(ctx: *PtyThreadCtx, fd: posix.fd_t, pane_filter: u32) bool {
         for (leaves[0..lc]) |leaf| {
             if (leaf.pane.engine.state.agent_status == .none) continue;
             if (pane_filter != 0 and pane_filter != leaf.pane.ipc_id) continue;
-            const frame = buildFrame(&frame_buf, session, leaf.pane, tab_id) orelse continue;
+            const tab_name = layout.effectiveTitle();
+            const frame = buildFrame(&frame_buf, session, leaf.pane, tab_id, tab_name) orelse continue;
             if (!tryWriteFrame(fd, frame)) return false;
         }
     }


### PR DESCRIPTION
Makes `attyx dashboard` interactive and easier to scan at a glance.

## Inline interaction
Press `i` on any agent row and it expands in place into a panel:
- A scrollable view of the agent's last transcript message (`^U`/`^D` to scroll; falls back to the pane's screen tail for agents without a transcript).
- A **reply box** for any agent in any state, or — when the agent is waiting on a numbered prompt — an **option/permission picker** parsed from its on-screen choices (`j`/`k` or the digit to pick, `⏎` to send).

Sending goes straight to the pane via the existing focus-free send path (same as `agent send`), so it never switches your window or steals focus. `Esc` cancels.

## Tab names
New `TAB` column showing the tab each agent runs in, so agents are easy to tell apart. The agent record gains a `tab_name` field, populated by all producers (daemon watch, daemon ctl-list, window watch, window list) through a shared `SplitLayout.effectiveTitle()` fallback chain: explicit tab name → auto hint title → focused pane's title → process name.

## Session grouping
Agents are grouped under a dimmed per-session header. The view sorts session-first so it stays session-contiguous; the sort key (`s`) orders agents within each session.

## Tests
Pure parser, model sort/grouping, render (TAB column, inline panel, grouping, `wrapText`/`clampScroll`), and the updated `writeAgentJson` wire tests. The only failing test in the suite is a pre-existing flaky daemon timing test (`agent_status_test.zig` — `pane_died` buffering), unrelated to this change.