### PR TITLE
Fix popup PATH command resolution

### DIFF
--- a/src/app/pane.zig
+++ b/src/app/pane.zig
@@ -122,6 +122,7 @@ pub const Pane = struct {
     pub const SpawnOpts = struct {
         capture_stdout: bool = false,
         preserve_tmux: bool = false,
+        path_override: ?[*:0]const u8 = null,
         skip_shell_integration: bool = false,
         shell: if (builtin.os.tag == .windows) Pty.ShellType else void = if (builtin.os.tag == .windows) .auto else {},
     };
@@ -146,6 +147,7 @@ pub const Pane = struct {
                 .cwd = cwd,
                 .capture_stdout = opts.capture_stdout,
                 .preserve_tmux = opts.preserve_tmux,
+                .path_override = opts.path_override,
                 .skip_shell_integration = opts.skip_shell_integration,
             };
             if (comptime builtin.os.tag == .windows) {

--- a/src/app/popup.zig
+++ b/src/app/popup.zig
@@ -193,19 +193,17 @@ pub const PopupState = struct {
             const base_path: ?[]const u8 = shell_path orelse if (std.posix.getenv("PATH")) |p| p else null;
             const popup_path = path_env.allocPathWithAttyxBinDir(allocator, base_path);
             defer if (popup_path) |p| allocator.free(p);
+            const popup_path_z: ?[:0]u8 = if (popup_path) |p| try allocator.dupeZ(u8, p) else null;
+            defer if (popup_path_z) |p| allocator.free(p);
 
-            const cmd_z = if (popup_path) |pp| blk: {
-                if (pp.len == 0) break :blk try allocator.dupeZ(u8, cfg.command);
-                const w = std.fmt.allocPrint(allocator, "export PATH='{s}'; {s}", .{ pp, cfg.command }) catch break :blk try allocator.dupeZ(u8, cfg.command);
-                defer allocator.free(w);
-                break :blk try allocator.dupeZ(u8, w);
-            } else try allocator.dupeZ(u8, cfg.command);
+            const cmd_z = try allocator.dupeZ(u8, cfg.command);
             defer allocator.free(cmd_z);
 
             const shell_argv = [_][:0]const u8{ shell_z, c_flag, cmd_z };
             pane.* = Pane.spawnOpts(allocator, dims.rows, dims.cols, &shell_argv, if (cwd_z) |z| z.ptr else null, RingBuffer.default_max_scrollback, .{
                 .capture_stdout = cfg.capture_stdout or cfg.on_return_cmd != null,
                 .preserve_tmux = true,
+                .path_override = if (popup_path_z) |p| p.ptr else null,
                 .skip_shell_integration = true,
             }) catch |err| {
                 allocator.destroy(pane);

--- a/src/app/pty_posix.zig
+++ b/src/app/pty_posix.zig
@@ -58,6 +58,8 @@ pub const Pty = struct {
         /// When true, keep TMUX/TMUX_PANE env vars in the child.
         /// Popup commands need these to interact with tmux.
         preserve_tmux: bool = false,
+        /// When set, replace PATH in the child before exec.
+        path_override: ?[*:0]const u8 = null,
         /// When true, skip ZDOTDIR override and shell integration setup.
         /// Popup one-shot commands don't need integration hooks, and the
         /// ZDOTDIR trick can cause init scripts to rebuild PATH.
@@ -143,6 +145,10 @@ pub const Pty = struct {
             // FORCE_HYPERLINK first, so this opts us in without lying about
             // TERM_PROGRAM. overwrite=0 — respects a value the user set.
             _ = setenv("FORCE_HYPERLINK", "1", 0);
+
+            if (opts.path_override) |path| {
+                _ = setenv("PATH", path, 1);
+            }
 
             // Set startup command for shell integration to execute after init.
             // This ensures the command runs with the user's full PATH loaded.
@@ -318,6 +324,34 @@ pub const Pty = struct {
 };
 
 // ── Tests ──
+
+test "path_override sets PATH without shell quoting" {
+    const allocator = std.testing.allocator;
+    const base_path = "/tmp/lazy'git/bin:/usr/bin:/bin";
+    const expected = path_env.allocPathWithAttyxBinDir(allocator, base_path) orelse return error.TestUnexpectedResult;
+    defer allocator.free(expected);
+    const expected_z = try allocator.dupeZ(u8, expected);
+    defer allocator.free(expected_z);
+
+    const shell: [:0]const u8 = "/bin/sh";
+    const c_flag: [:0]const u8 = "-c";
+    const cmd: [:0]const u8 = "printf '%s' \"$PATH\"";
+    const argv = [_][:0]const u8{ shell, c_flag, cmd };
+
+    var pty = try Pty.spawn(.{
+        .argv = &argv,
+        .capture_stdout = true,
+        .path_override = expected_z.ptr,
+        .skip_shell_integration = true,
+    });
+    defer pty.deinit();
+    pty.waitForExit();
+    try std.testing.expectEqual(@as(?u8, 0), pty.exitCode());
+
+    var buf: [4096]u8 = undefined;
+    const n = try posix.read(pty.stdout_read_fd, &buf);
+    try std.testing.expectEqualStrings(expected, buf[0..n]);
+}
 
 test "childExited returns false for non-child process that is still alive" {
     // Simulates the hot-upgrade scenario: the new daemon process inherits

--- a/src/app/pty_windows.zig
+++ b/src/app/pty_windows.zig
@@ -440,6 +440,7 @@ pub const Pty = struct {
         cwd: ?[*:0]const u8 = null,
         capture_stdout: bool = false,
         preserve_tmux: bool = false,
+        path_override: ?[*:0]const u8 = null,
         skip_shell_integration: bool = false,
         startup_cmd: ?[*:0]const u8 = null,
         shell: ShellType = .auto,


### PR DESCRIPTION
## Summary
- pass popup PATH overrides through the child process environment instead of prefixing the shell command with `export PATH=...`
- keep the raw popup command unchanged so normal shell command lookup keeps working
- add a PTY test covering PATH values that would break shell-quoted injection

## Tests
- `zig build`
- `zig build test` *(fails: existing daemon agent-status timeout in `daemon: agent status re-shipped when a pane becomes newly active`; new test passed before that failure)*