### PR TITLE
Make bash DEBUG trap errexit-safe (set -e)

### DIFF
--- a/src/app/shell_scripts_posix.zig
+++ b/src/app/shell_scripts_posix.zig
@@ -162,7 +162,13 @@ pub const bash_script =
     \\PROMPT_COMMAND="__attyx_first_prompt"
     \\# Install the preexec DEBUG trap only if the user hasn't set one (bash allows
     \\# a single DEBUG trap; clobbering theirs could break their setup).
-    \\[ -z "$(trap -p DEBUG)" ] && trap '__attyx_preexec' DEBUG
+    \\# `|| true` keeps the trap from ever returning non-zero: when this rc is
+    \\# sourced via BASH_ENV in a non-interactive shell with `set -e` (errexit)
+    \\# active, a DEBUG trap that returns non-zero aborts the shell — and
+    \\# __attyx_preexec returns 1 on its common early-out (empty COMP_LINE leaves
+    \\# `[ -n "" ] && return` at status 1), which would kill the caller's script
+    \\# on its first command. Swallowing the status makes the hook errexit-safe.
+    \\[ -z "$(trap -p DEBUG)" ] && trap '__attyx_preexec || true' DEBUG
     \\
 ;
 
@@ -336,7 +342,19 @@ test "xyron lua module drives the agent-status dot for all agents" {
 
 test "zsh registers the preexec hook and bash installs a DEBUG trap" {
     try testing.expect(std.mem.indexOf(u8, zsh_rc_script, "preexec_functions+=(__attyx_preexec)") != null);
-    try testing.expect(std.mem.indexOf(u8, bash_script, "trap '__attyx_preexec' DEBUG") != null);
+    try testing.expect(std.mem.indexOf(u8, bash_script, "trap '__attyx_preexec || true' DEBUG") != null);
+}
+
+// A DEBUG trap that returns non-zero aborts a shell running with `set -e`
+// (errexit). Because this rc is sourced via BASH_ENV by non-interactive
+// shells, a `set -e` script would otherwise die on its first command:
+// __attyx_preexec returns 1 on its common early-out (empty COMP_LINE leaves
+// `[ -n "" ] && return` at status 1). The trap body must swallow the status
+// with `|| true`. Regression guard. See issue #293 (sibling nounset fix).
+test "bash DEBUG trap is errexit-safe" {
+    try testing.expect(std.mem.indexOf(u8, bash_script, "trap '__attyx_preexec || true' DEBUG") != null);
+    // The unguarded form (no `|| true`) must be gone.
+    try testing.expect(std.mem.indexOf(u8, bash_script, "trap '__attyx_preexec' DEBUG") == null);
 }
 
 // The bash script is sourced by non-interactive shells via BASH_ENV, and the


### PR DESCRIPTION
### Problem

The bash shell integration is sourced by non-interactive shells via
`BASH_ENV`. A **DEBUG trap that returns non-zero aborts a shell running
with `set -e`** (errexit). So any `set -e` script that inherits
`BASH_ENV` pointing at this rc dies **on its first command**, exit 1,
with no output — very hard to diagnose (it looks like the script itself
is broken).

`__attyx_preexec` returns 1 on its common early-out: with an empty
`COMP_LINE`, `[ -n "" ] && return` leaves the function status at 1, and
the `case ... *) return` paths inherit that status.

### Repro

```bash
# with BASH_ENV -> attyx bash integration rc
cat > /tmp/t.sh <<'S'
#!/usr/bin/env bash
set -euo pipefail
echo "reached"
S
chmod +x /tmp/t.sh
/tmp/t.sh            # exits 1, prints nothing
env -u BASH_ENV /tmp/t.sh   # prints "reached", exit 0
```

### Fix

Wrap the trap body in `|| true` so the DEBUG trap can never leak a
non-zero status:

```
[ -z "$(trap -p DEBUG)" ] && trap '__attyx_preexec || true' DEBUG
```

This is the **errexit sibling of the nounset fix in #294**. Adds a
regression test (`bash DEBUG trap is errexit-safe`) asserting the
guarded form is present and the bare form is gone, and updates the
existing DEBUG-trap assertion to match.

Verified locally: with the patched rc, a `set -euo pipefail` script
sourced via `BASH_ENV` runs to completion (exit 0) instead of dying on
its first command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)